### PR TITLE
fix: support capability tokens in middleware for MCP server file access

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -36,6 +36,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 claims = verify_file_token(token)
                 if claims:
                     # Valid capability token - extract user from token and allow request
+                    # Note: We only validate token authenticity here (authentication).
+                    # The route handler validates that token's file key matches the requested
+                    # file (authorization). This separation of concerns keeps middleware focused
+                    # on authentication while route handlers handle resource-specific authorization.
                     user_email = claims.get('u')
                     if user_email:
                         logger.info(f"Authenticated via capability token for user: {user_email}")


### PR DESCRIPTION
## Summary

Enables MCP servers to authenticate using capability tokens when accessing files through `/api/files/download/` endpoints. 

Previously, the middleware only checked for `X-User-Email` headers, causing MCP server requests to fail in production nginx environments. The middleware would redirect unauthenticated requests to `/auth`, which doesn't exist, resulting in 404 errors.

## Changes

- Check capability tokens in query parameters before validating `X-User-Email` headers
- Return HTTP 401 for unauthenticated API endpoint requests instead of redirecting
- Maintain backward compatibility with browser-based authentication via headers

## Technical Details

**Authentication Flow (Before):**
```
MCP server → GET /api/files/download/...?token=xyz
  → Middleware checks X-User-Email header (missing)
  → Redirects to /auth (302)
  → 404 Not Found
```

**Authentication Flow (After):**
```
MCP server → GET /api/files/download/...?token=xyz
  → Middleware validates capability token
  → Extracts user email from token claims
  → Request proceeds to route handler
```

## Testing

- ✅ All 56 backend tests pass (including existing capability token tests)
- ✅ All 21 frontend tests pass
- ✅ All 3 e2e tests pass
- ✅ Backward compatible with browser-based authentication
- ✅ Maintains existing middleware auth behavior for non-API endpoints

## Impact

Fixes the issue where MCP servers (like pdfbasic) fail to download files in production K8s environments with nginx authentication proxies. Browser-based requests continue to work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)