### PR TITLE
Default all users to 'users' group in mock auth mode

### DIFF
--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -45,6 +45,9 @@ async def is_user_in_group(user_id: str, group_id: str) -> bool:
             logger.error(f"Error during external auth check: {e}", exc_info=True)
             return False
     else:
+        # Everybody is in the users group by default
+        if (group_id == "users"):
+            return True
         # Fallback to mock implementation if no external endpoint is configured
         if (app_settings.debug_mode and
                 user_id == app_settings.test_user and

--- a/docs/02_admin_guide.md
+++ b/docs/02_admin_guide.md
@@ -479,6 +479,8 @@ You can configure the application to call an external HTTP endpoint to check for
 
 If `AUTH_GROUP_CHECK_URL` is not set, the application will fall back to the mock implementation in `backend/core/auth.py`.
 
+When using the mock implementation (no external endpoint configured), **all users are treated as part of the `users` group by default**. This ensures that basic, non-privileged features remain available even without an authorization service. Higher-privilege groups such as `admin` still require explicit membership via the mock group table or your real authorization system.
+
 #### Legacy Method: Modifying the Code
 
 For advanced use cases, you can still directly modify the `is_user_in_group` function located in `backend/core/auth.py`. The default implementation is a mock and **must be replaced** if you are not using the HTTP endpoint method.


### PR DESCRIPTION
When no external authorization endpoint is configured, all users are now treated as members of the 'users' group by default. This ensures basic non-privileged features remain available.

Changes:
- Modified `backend/core/auth.py` to return `True` for `group_id == 'users'` in mock mode
- Updated `docs/02_admin_guide.md` to document this default behavior

Supersedes #98