### PR TITLE
Add catch-all to if/elseif block... if no other provider detected, set the OPENAI_API_KEY by default.

### DIFF
--- a/backend/modules/llm/litellm_caller.py
+++ b/backend/modules/llm/litellm_caller.py
@@ -99,6 +99,8 @@ class LiteLLMCaller:
                 os.environ["GOOGLE_API_KEY"] = api_key
             elif "cerebras" in model_config.model_url:
                 os.environ["CEREBRAS_API_KEY"] = api_key
+            else:
+                os.environ["OPENAI_API_KEY"] = api_key
         
         # Set custom API base for non-standard endpoints
         if hasattr(model_config, 'model_url') and model_config.model_url:


### PR DESCRIPTION
This fixes an issue where if the model_url doesn't contain one of the expected strings, no api_key gets set. Since OPENAI_API_KEY seems to be the most common, use it by default.