### PR TITLE
Fix user message line breaks not displaying in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #TBD - 2026-01-23
+- **Fix**: Preserve line breaks in user messages by adding `whitespace-pre-wrap` CSS class. Previously, multi-line user input displayed as a wall of text without line breaks.
+
 ### PR #243 - 2026-01-23
 - **UI Enhancement**: Implement responsive header with mobile hamburger menu for improved usability on small screens and mobile devices. Header controls collapse into a slide-out menu on screens smaller than 1024px, and button text labels are hidden on mobile while maintaining icon visibility.
 

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -1066,10 +1066,10 @@ const renderContent = () => {
               </div>
             )
           default:
-            return <div className="text-gray-200">{message.content}</div>
+            return <div className="text-gray-200 whitespace-pre-wrap">{message.content}</div>
         }
       }
-      return <div className="text-gray-200">{message.content}</div>
+      return <div className="text-gray-200 whitespace-pre-wrap">{message.content}</div>
     }
 
     // Render markdown for assistant messages


### PR DESCRIPTION
## Summary
- Add `whitespace-pre-wrap` CSS class to user message content divs in `Message.jsx`
- Preserves line breaks when users paste or type multi-line text
- Previously, multi-line input displayed as a wall of text without line breaks

## Test plan
- [ ] Paste multi-line text into chat input and send
- [ ] Verify line breaks are preserved in the displayed message
- [ ] Verify assistant messages still render correctly with markdown

Generated with [Claude Code](https://claude.com/claude-code)