### PR TITLE
Add non-interactive CLI and Python API for Atlas chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ config/overrides/mcp-minimal.json
 
 # Scratch folder (local experimentation)
 scratch/
+backend/report.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #TBD - 2026-01-27
+- **Feature**: Add non-interactive CLI (`atlas_chat_cli.py`) and Python API (`atlas_client.py`) for one-shot LLM chat with full MCP tools, RAG, and agent mode support. Enables scripted workflows, E2E testing, and MCP development without the browser UI.
+- **Feature**: Add CLI event publisher for headless operation with streaming and collecting modes.
+- **Architecture**: Add `initialize()` async method and `create_headless_chat_service()` to `AppFactory` for use outside FastAPI context.
+
 ### PR #TBD - 2026-01-26
 - **Fix**: Add `:U` suffix to bind mounts in docker-compose.yml to fix permissions issues on some platforms where logs and config directories were owned by root instead of appuser.
 

--- a/backend/application/chat/agent/act_loop.py
+++ b/backend/application/chat/agent/act_loop.py
@@ -37,6 +37,7 @@ class ActAgentLoop(AgentLoopProtocol):
         self.prompt_provider = prompt_provider
         self.connection = connection
         self.config_manager = config_manager
+        self.skip_approval = False
 
     def _extract_finished_args(self, tool_calls: List[Dict[str, Any]]) -> Optional[str]:
         """Extract final_answer from finished tool call if present."""
@@ -154,6 +155,7 @@ class ActAgentLoop(AgentLoopProtocol):
                     tool_manager=self.tool_manager,
                     update_callback=(self.connection.send_json if self.connection else None),
                     config_manager=self.config_manager,
+                    skip_approval=self.skip_approval,
                 )
 
                 messages.append({

--- a/backend/application/chat/agent/factory.py
+++ b/backend/application/chat/agent/factory.py
@@ -47,6 +47,7 @@ class AgentLoopFactory:
         self.prompt_provider = prompt_provider
         self.connection = connection
         self.config_manager = config_manager
+        self.skip_approval = False
 
         # Registry of available strategies
         self._strategy_registry = {
@@ -98,6 +99,8 @@ class AgentLoopFactory:
             connection=self.connection,
             config_manager=self.config_manager,
         )
+
+        loop_instance.skip_approval = self.skip_approval
 
         # Cache for future use
         self._loop_cache[strategy_normalized] = loop_instance

--- a/backend/application/chat/agent/react_loop.py
+++ b/backend/application/chat/agent/react_loop.py
@@ -38,6 +38,7 @@ class ReActAgentLoop(AgentLoopProtocol):
         self.prompt_provider = prompt_provider
         self.connection = connection
         self.config_manager = config_manager
+        self.skip_approval = False
 
     # ---- Internal helpers (mirroring service implementation) ----
     def _latest_user_question(self, msgs: List[Dict[str, Any]]) -> str:
@@ -247,6 +248,7 @@ class ReActAgentLoop(AgentLoopProtocol):
                         tool_manager=self.tool_manager,
                         update_callback=(self.connection.send_json if self.connection else None),
                         config_manager=self.config_manager,
+                        skip_approval=self.skip_approval,
                     )
                     tool_results.append(result)
                     messages.append({

--- a/backend/application/chat/agent/think_act_loop.py
+++ b/backend/application/chat/agent/think_act_loop.py
@@ -33,6 +33,7 @@ class ThinkActAgentLoop(AgentLoopProtocol):
         self.prompt_provider = prompt_provider
         self.connection = connection
         self.config_manager = config_manager
+        self.skip_approval = False
 
     async def run(
         self,
@@ -143,6 +144,7 @@ class ThinkActAgentLoop(AgentLoopProtocol):
                         tool_manager=self.tool_manager,
                         update_callback=(self.connection.send_json if self.connection else None),
                         config_manager=self.config_manager,
+                        skip_approval=self.skip_approval,
                     )
                     messages.append({"role": "tool", "content": result.content, "tool_call_id": result.tool_call_id})
                     # Notify service to ingest artifacts

--- a/backend/application/chat/modes/tools.py
+++ b/backend/application/chat/modes/tools.py
@@ -52,6 +52,7 @@ class ToolsModeRunner:
         self.prompt_provider = prompt_provider
         self.artifact_processor = artifact_processor
         self.config_manager = config_manager
+        self.skip_approval = False
 
         # Verify event_publisher has send_json for elicitation support
         if hasattr(event_publisher, 'send_json'):
@@ -139,6 +140,7 @@ class ToolsModeRunner:
             prompt_provider=self.prompt_provider,
             update_callback=effective_callback,
             config_manager=self.config_manager,
+            skip_approval=self.skip_approval,
         )
 
         # Process artifacts if handler provided

--- a/backend/application/chat/utilities/tool_executor.py
+++ b/backend/application/chat/utilities/tool_executor.py
@@ -32,11 +32,12 @@ async def execute_tools_workflow(
     llm_caller,
     prompt_provider,
     update_callback: Optional[UpdateCallback] = None,
-    config_manager=None
+    config_manager=None,
+    skip_approval: bool = False,
 ) -> tuple[str, List[ToolResult]]:
     """
     Execute the complete tools workflow: calls -> results -> synthesis.
-    
+
     Pure function that coordinates tool execution without maintaining state.
     """
     logger.debug("Entering execute_tools_workflow")
@@ -55,7 +56,8 @@ async def execute_tools_workflow(
             session_context=session_context,
             tool_manager=tool_manager,
             update_callback=update_callback,
-            config_manager=config_manager
+            config_manager=config_manager,
+            skip_approval=skip_approval,
         )
         tool_results.append(result)
 
@@ -168,7 +170,8 @@ async def execute_single_tool(
     session_context: Dict[str, Any],
     tool_manager,
     update_callback: Optional[UpdateCallback] = None,
-    config_manager=None
+    config_manager=None,
+    skip_approval: bool = False,
 ) -> ToolResult:
     """
     Execute a single tool with argument preparation and error handling.
@@ -192,7 +195,9 @@ async def execute_single_tool(
         needs_approval = False
         allow_edit = True
         admin_required = False
-        if config_manager:
+        if skip_approval:
+            needs_approval = False
+        elif config_manager:
             needs_approval, allow_edit, admin_required = requires_approval(tool_call.function.name, config_manager)
         else:
             # No config manager means user-level approval by default

--- a/backend/application/chat/utilities/tool_executor.py
+++ b/backend/application/chat/utilities/tool_executor.py
@@ -19,6 +19,37 @@ from modules.mcp_tools.token_storage import AuthenticationRequiredException
 
 logger = logging.getLogger(__name__)
 
+
+def _try_repair_json(raw: str) -> Optional[Dict[str, Any]]:
+    """Attempt to repair truncated JSON from LLM tool arguments.
+
+    Common cases: missing opening/closing braces, trailing quote.
+    Returns parsed dict on success, None on failure.
+    """
+    s = raw.strip()
+    # Add missing braces
+    if not s.startswith("{"):
+        s = "{" + s
+    if not s.endswith("}"):
+        s = s + "}"
+    try:
+        result = json.loads(s)
+        if isinstance(result, dict):
+            return result
+    except Exception:
+        pass
+    # Try closing an open string value: e.g. {"expression": "355/113
+    if s.count('"') % 2 != 0:
+        s = s.rstrip("}") + '"}'
+        try:
+            result = json.loads(s)
+            if isinstance(result, dict):
+                return result
+        except Exception:
+            pass
+    return None
+
+
 # Type hint for update callback
 UpdateCallback = Callable[[Dict[str, Any]], Awaitable[None]]
 
@@ -454,11 +485,20 @@ def prepare_tool_arguments(tool_call, session_context: Dict[str, Any], tool_mana
                 if not isinstance(parsed_args, dict):
                     parsed_args = {"_value": parsed_args}
             except Exception:
-                logger.warning(
-                    "Failed to parse tool arguments as JSON for %s, using empty dict. Raw: %r",
-                    getattr(tool_call.function, "name", "<unknown>"), raw_args
-                )
-                parsed_args = {}
+                # Attempt to repair truncated JSON (e.g., missing braces)
+                repaired = _try_repair_json(raw_args)
+                if repaired is not None:
+                    logger.info(
+                        "Repaired truncated tool arguments for %s",
+                        getattr(tool_call.function, "name", "<unknown>"),
+                    )
+                    parsed_args = repaired
+                else:
+                    logger.warning(
+                        "Failed to parse tool arguments as JSON for %s, using empty dict. Raw: %r",
+                        getattr(tool_call.function, "name", "<unknown>"), raw_args
+                    )
+                    parsed_args = {}
 
     # Inject username and file URL mappings with schema awareness
     return inject_context_into_args(parsed_args, session_context, tool_call.function.name, tool_manager)

--- a/backend/atlas_chat_cli.py
+++ b/backend/atlas_chat_cli.py
@@ -15,7 +15,6 @@ import logging
 import os
 import sys
 from pathlib import Path
-from uuid import UUID
 
 # Suppress LiteLLM verbose stdout noise BEFORE any transitive import of litellm.
 # litellm._logging reads LITELLM_LOG at import time and defaults to DEBUG.
@@ -51,7 +50,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--tools", default=None, help="Comma-separated list of tool names to enable.")
     parser.add_argument("-o", "--output", default=None, help="Write final response to file path.")
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output structured JSON.")
-    parser.add_argument("--session-id", default=None, help="Reuse an existing session UUID.")
+
     parser.add_argument("--max-steps", type=int, default=10, help="Max agent iterations (default: 10).")
     parser.add_argument("--user-email", default=None, help="Override user identity.")
     parser.add_argument("-q", "--quiet", action="store_true", help="Suppress tool/status output, only final response.")
@@ -99,8 +98,6 @@ async def run(args: argparse.Namespace) -> int:
     if args.tools:
         selected_tools = [t.strip() for t in args.tools.split(",") if t.strip()]
 
-    session_id = UUID(args.session_id) if args.session_id else None
-
     # In JSON or output-file mode, collect rather than stream
     streaming = not args.json_output and args.output is None
 
@@ -112,7 +109,7 @@ async def run(args: argparse.Namespace) -> int:
             agent_mode=args.agent,
             selected_tools=selected_tools,
             user_email=args.user_email,
-            session_id=session_id,
+            session_id=None,
             max_steps=args.max_steps,
             streaming=streaming,
             quiet=args.quiet,

--- a/backend/atlas_chat_cli.py
+++ b/backend/atlas_chat_cli.py
@@ -1,0 +1,144 @@
+"""
+Non-interactive CLI for Atlas chat.
+
+Usage:
+    python atlas_chat_cli.py "Summarize the latest docs" --model gpt-4o
+    python atlas_chat_cli.py "Use the search tool" --agent --tools server_tool1
+    python atlas_chat_cli.py "Generate a report" --agent --output ./report.md
+    echo "prompt" | python atlas_chat_cli.py - --model gpt-4o
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from uuid import UUID
+
+# Suppress LiteLLM verbose stdout noise BEFORE any transitive import of litellm.
+# litellm._logging reads LITELLM_LOG at import time and defaults to DEBUG.
+if "LITELLM_LOG" not in os.environ:
+    os.environ["LITELLM_LOG"] = "ERROR"
+
+from dotenv import load_dotenv
+
+# Load env (won't overwrite LITELLM_LOG we just set)
+load_dotenv(dotenv_path=str(Path(__file__).resolve().parents[1] / ".env"))
+
+# Now safe to import atlas code (which transitively imports litellm)
+from atlas_client import AtlasClient  # noqa: E402
+
+# Belt-and-suspenders: also quiet the Python loggers litellm creates
+for _name in ("LiteLLM", "LiteLLM Proxy", "LiteLLM Router", "litellm", "httpx"):
+    logging.getLogger(_name).setLevel(logging.WARNING)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="atlas-chat",
+        description="Non-interactive CLI for Atlas LLM chat with MCP tools and RAG.",
+    )
+    parser.add_argument(
+        "prompt",
+        nargs="?",
+        default=None,
+        help="Chat prompt text, or '-' to read from stdin.",
+    )
+    parser.add_argument("--model", default=None, help="LLM model name (uses config default if omitted).")
+    parser.add_argument("--agent", action="store_true", help="Enable agent mode for multi-step tool use.")
+    parser.add_argument("--tools", default=None, help="Comma-separated list of tool names to enable.")
+    parser.add_argument("-o", "--output", default=None, help="Write final response to file path.")
+    parser.add_argument("--json", dest="json_output", action="store_true", help="Output structured JSON.")
+    parser.add_argument("--session-id", default=None, help="Reuse an existing session UUID.")
+    parser.add_argument("--max-steps", type=int, default=10, help="Max agent iterations (default: 10).")
+    parser.add_argument("--user-email", default=None, help="Override user identity.")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Suppress tool/status output, only final response.")
+    parser.add_argument("--list-tools", action="store_true", help="Print available tools and exit.")
+    return parser
+
+
+async def list_tools() -> int:
+    """Discover and print all available tools in CLI-usable format."""
+    client = AtlasClient()
+    try:
+        await client.initialize()
+        mcp_manager = client._factory.get_mcp_manager()
+        tool_index = getattr(mcp_manager, "_tool_index", {})
+        if not tool_index:
+            print("No tools discovered.", file=sys.stderr)
+            return 1
+        # Group by server
+        servers: dict[str, list[str]] = {}
+        for full_name, info in sorted(tool_index.items()):
+            server = info["server"]
+            servers.setdefault(server, []).append(full_name)
+        for server, tools in servers.items():
+            print(f"{server}:")
+            for name in tools:
+                print(f"  {name}")
+        return 0
+    finally:
+        await client.cleanup()
+
+
+async def run(args: argparse.Namespace) -> int:
+    if args.list_tools:
+        return await list_tools()
+
+    # Resolve prompt
+    prompt = args.prompt
+    if prompt == "-" or (prompt is None and not sys.stdin.isatty()):
+        prompt = sys.stdin.read().strip()
+    if not prompt:
+        print("Error: no prompt provided.", file=sys.stderr)
+        return 2
+
+    selected_tools = None
+    if args.tools:
+        selected_tools = [t.strip() for t in args.tools.split(",") if t.strip()]
+
+    session_id = UUID(args.session_id) if args.session_id else None
+
+    # In JSON or output-file mode, collect rather than stream
+    streaming = not args.json_output and args.output is None
+
+    client = AtlasClient()
+    try:
+        result = await client.chat(
+            prompt=prompt,
+            model=args.model,
+            agent_mode=args.agent,
+            selected_tools=selected_tools,
+            user_email=args.user_email,
+            session_id=session_id,
+            max_steps=args.max_steps,
+            streaming=streaming,
+            quiet=args.quiet,
+        )
+
+        if args.json_output:
+            print(json.dumps(result.to_dict(), indent=2))
+        elif args.output:
+            Path(args.output).write_text(result.message, encoding="utf-8")
+            print(f"Output written to {args.output}", file=sys.stderr)
+        # If streaming, output was already printed live
+
+        return 0
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        logging.getLogger(__name__).debug("CLI error details", exc_info=True)
+        return 1
+    finally:
+        await client.cleanup()
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/atlas_chat_cli.py
+++ b/backend/atlas_chat_cli.py
@@ -46,7 +46,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Chat prompt text, or '-' to read from stdin.",
     )
     parser.add_argument("--model", default=None, help="LLM model name (uses config default if omitted).")
-    parser.add_argument("--agent", action="store_true", help="Enable agent mode for multi-step tool use.")
     parser.add_argument("--tools", default=None, help="Comma-separated list of tool names to enable.")
     parser.add_argument("--json", dest="json_output", action="store_true", help="Output structured JSON.")
     parser.add_argument("--user-email", default=None, help="Override user identity.")
@@ -102,7 +101,7 @@ async def run(args: argparse.Namespace) -> int:
         result = await client.chat(
             prompt=prompt,
             model=args.model,
-            agent_mode=args.agent,
+            agent_mode=False,
             selected_tools=selected_tools,
             user_email=args.user_email,
             session_id=None,

--- a/backend/atlas_client.py
+++ b/backend/atlas_client.py
@@ -1,0 +1,161 @@
+"""Python client API for Atlas chat -- headless, non-interactive usage."""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+from uuid import UUID, uuid4
+
+from infrastructure.events.cli_event_publisher import CLIEventPublisher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChatResult:
+    """Structured result from a chat call."""
+
+    message: str
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    files: Dict[str, Any] = field(default_factory=dict)
+    canvas_content: Optional[str] = None
+    session_id: Optional[UUID] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "message": self.message,
+            "tool_calls": self.tool_calls,
+            "files": self.files,
+            "canvas_content": self.canvas_content,
+            "session_id": str(self.session_id) if self.session_id else None,
+        }
+
+
+class AtlasClient:
+    """
+    Headless Python client for Atlas chat.
+
+    Wraps AppFactory + ChatService for programmatic one-shot or
+    multi-turn LLM conversations with MCP tools, RAG, and agent mode.
+    """
+
+    def __init__(self) -> None:
+        self._factory = None
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Initialize the backend (MCP discovery, etc.)."""
+        if self._initialized:
+            return
+
+        from infrastructure.app_factory import AppFactory
+
+        self._factory = AppFactory()
+
+        mcp_manager = self._factory.get_mcp_manager()
+        try:
+            await mcp_manager.initialize_clients()
+            await mcp_manager.discover_tools()
+            await mcp_manager.discover_prompts()
+        except Exception:
+            logger.warning("MCP initialization failed; continuing without tools")
+
+        # LiteLLMCaller sets litellm.set_verbose = debug_mode, which causes
+        # litellm to print() debug info to stdout. Force it off for CLI use.
+        import litellm as _litellm
+        _litellm.set_verbose = False
+        _litellm.suppress_debug_info = True
+
+        self._initialized = True
+
+    async def chat(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        agent_mode: bool = False,
+        selected_tools: Optional[List[str]] = None,
+        user_email: Optional[str] = None,
+        session_id: Optional[UUID] = None,
+        max_steps: int = 10,
+        temperature: float = 0.7,
+        streaming: bool = False,
+        quiet: bool = False,
+    ) -> ChatResult:
+        """
+        Send a chat message and return the result.
+
+        Args:
+            prompt: User message text.
+            model: LLM model name. Uses config default if not specified.
+            agent_mode: Enable agent loop for multi-step tool use.
+            selected_tools: List of tool names to enable.
+            user_email: User identity for auth-filtered tools/RAG.
+            session_id: Reuse an existing session for multi-turn.
+            max_steps: Max agent iterations.
+            temperature: LLM temperature.
+            streaming: If True, stream tokens to stdout as they arrive.
+            quiet: Suppress status output on stderr (only affects streaming mode).
+
+        Returns:
+            ChatResult with assistant message, tool calls, files, etc.
+        """
+        await self.initialize()
+
+        if session_id is None:
+            session_id = uuid4()
+
+        if model is None:
+            models = self._factory.get_config_manager().llm_config.models
+            if models:
+                # models is a dict of {display_name: ModelConfig}
+                first_key = next(iter(models))
+                model = first_key
+            else:
+                model = "gpt-4o"
+
+        if user_email is None:
+            cfg = self._factory.get_config_manager()
+            user_email = cfg.app_settings.test_user or "cli@atlas.local"
+
+        event_publisher = CLIEventPublisher(streaming=streaming, quiet=quiet)
+        chat_service = self._factory.create_chat_service(connection=None)
+        # Replace the default event publisher with our CLI one
+        chat_service.event_publisher = event_publisher
+        # Re-initialize mode runners with the new publisher
+        chat_service.plain_mode.event_publisher = event_publisher
+        chat_service.rag_mode.event_publisher = event_publisher
+        chat_service.tools_mode.event_publisher = event_publisher
+        chat_service.tools_mode.skip_approval = True
+        chat_service.agent_mode.event_publisher = event_publisher
+        chat_service.agent_mode.agent_loop_factory.skip_approval = True
+
+        await chat_service.handle_chat_message(
+            session_id=session_id,
+            content=prompt,
+            model=model,
+            selected_tools=selected_tools,
+            agent_mode=agent_mode,
+            agent_max_steps=max_steps,
+            user_email=user_email,
+            temperature=temperature,
+        )
+
+        collected = event_publisher.get_result()
+        return ChatResult(
+            message=collected.message,
+            tool_calls=collected.tool_calls,
+            files=collected.files,
+            canvas_content=collected.canvas_content,
+            session_id=session_id,
+        )
+
+    def chat_sync(self, prompt: str, **kwargs) -> ChatResult:
+        """Synchronous wrapper around chat()."""
+        return asyncio.run(self.chat(prompt, **kwargs))
+
+    async def cleanup(self) -> None:
+        """Cleanup MCP connections."""
+        if self._factory:
+            mcp = self._factory.get_mcp_manager()
+            await mcp.cleanup()

--- a/backend/infrastructure/app_factory.py
+++ b/backend/infrastructure/app_factory.py
@@ -65,6 +65,16 @@ class AppFactory:
 
         logger.info("AppFactory initialized")
 
+    async def initialize(self) -> None:
+        """Initialize async resources (MCP clients, tool discovery) for headless use."""
+        try:
+            await self.mcp_tools.initialize_clients()
+            await self.mcp_tools.discover_tools()
+            await self.mcp_tools.discover_prompts()
+            logger.info("AppFactory async initialization complete")
+        except Exception as e:
+            logger.warning("MCP initialization failed; continuing without tools: %s", e)
+
     def create_chat_service(
         self, connection: Optional[ChatConnectionProtocol] = None
     ) -> ChatService:
@@ -75,6 +85,20 @@ class AppFactory:
             config_manager=self.config_manager,
             file_manager=self.file_manager,
             session_repository=self.session_repository,
+        )
+
+    def create_headless_chat_service(
+        self, event_publisher=None
+    ) -> ChatService:
+        """Create a ChatService for headless/CLI use with a custom event publisher."""
+        return ChatService(
+            llm=self.llm_caller,
+            tool_manager=self.mcp_tools,
+            connection=None,
+            config_manager=self.config_manager,
+            file_manager=self.file_manager,
+            session_repository=self.session_repository,
+            event_publisher=event_publisher,
         )
 
     # Accessors

--- a/backend/infrastructure/events/cli_event_publisher.py
+++ b/backend/infrastructure/events/cli_event_publisher.py
@@ -1,0 +1,140 @@
+"""CLI event publisher for headless/non-interactive use."""
+
+import logging
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CLICollectedResult:
+    """Structured result from a collected CLI chat session."""
+
+    message: str = ""
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    files: Dict[str, Any] = field(default_factory=dict)
+    canvas_content: Optional[str] = None
+    raw_events: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class CLIEventPublisher:
+    """
+    Event publisher for CLI / headless usage.
+
+    Two modes:
+    - streaming: prints token text to stdout, tool/status info to stderr
+    - collecting: buffers all events, returns structured result
+    """
+
+    def __init__(self, streaming: bool = True, quiet: bool = False):
+        self.streaming = streaming
+        self.quiet = quiet
+        self._collected = CLICollectedResult()
+
+    def get_result(self) -> CLICollectedResult:
+        """Return the collected result (useful in collecting mode)."""
+        return self._collected
+
+    async def publish_chat_response(
+        self,
+        message: str,
+        has_pending_tools: bool = False,
+    ) -> None:
+        self._collected.message += message
+        if self.streaming:
+            sys.stdout.write(message)
+            sys.stdout.flush()
+
+    async def publish_response_complete(self) -> None:
+        if self.streaming:
+            # Ensure final newline
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+
+    async def publish_agent_update(
+        self,
+        update_type: str,
+        **kwargs: Any,
+    ) -> None:
+        event = {"type": "agent_update", "update_type": update_type, **kwargs}
+        self._collected.raw_events.append(event)
+        if self.streaming and not self.quiet:
+            _print_status(f"[agent] {update_type}")
+
+    async def publish_tool_start(
+        self,
+        tool_name: str,
+        **kwargs: Any,
+    ) -> None:
+        self._collected.tool_calls.append({"tool": tool_name, "status": "started"})
+        if self.streaming and not self.quiet:
+            _print_status(f"[tool] {tool_name} ...")
+
+    async def publish_tool_complete(
+        self,
+        tool_name: str,
+        result: Any,
+        **kwargs: Any,
+    ) -> None:
+        # Update last matching tool call
+        for tc in reversed(self._collected.tool_calls):
+            if tc["tool"] == tool_name and tc["status"] == "started":
+                tc["status"] = "complete"
+                tc["result"] = result
+                break
+        if self.streaming and not self.quiet:
+            _print_status(f"[tool] {tool_name} done")
+
+    async def publish_files_update(
+        self,
+        files: Dict[str, Any],
+    ) -> None:
+        self._collected.files.update(files)
+        if self.streaming and not self.quiet:
+            _print_status(f"[files] {len(files)} file(s)")
+
+    async def publish_canvas_content(
+        self,
+        content: str,
+        content_type: str = "text/html",
+        **kwargs: Any,
+    ) -> None:
+        self._collected.canvas_content = content
+
+    async def send_json(self, data: Dict[str, Any]) -> None:
+        self._collected.raw_events.append(data)
+        if self.streaming and not self.quiet:
+            msg_type = data.get("type", "")
+            if msg_type == "tool_start":
+                tool_name = data.get("tool_name", "unknown")
+                args = data.get("arguments", {})
+                _print_status(f"[tool] {tool_name} called with: {args}")
+            elif msg_type == "tool_complete":
+                tool_name = data.get("tool_name", "unknown")
+                success = data.get("success", False)
+                result = data.get("result", "")
+                status = "ok" if success else "error"
+                _print_status(f"[tool] {tool_name} {status}: {result}")
+
+    async def publish_elicitation_request(
+        self,
+        elicitation_id: str,
+        tool_call_id: str,
+        tool_name: str,
+        message: str,
+        response_schema: Dict[str, Any],
+    ) -> None:
+        # CLI cannot handle interactive elicitation; log and skip
+        logger.warning(
+            "Elicitation requested by tool %s but CLI mode cannot respond interactively",
+            tool_name,
+        )
+        if self.streaming and not self.quiet:
+            _print_status(f"[elicitation] {tool_name}: {message} (skipped, non-interactive)")
+
+
+def _print_status(text: str) -> None:
+    """Print status/tool info to stderr so stdout stays clean for LLM output."""
+    print(text, file=sys.stderr, flush=True)

--- a/backend/tests/test_atlas_client.py
+++ b/backend/tests/test_atlas_client.py
@@ -1,0 +1,134 @@
+"""Tests for AtlasClient and CLI arg parsing."""
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from infrastructure.events.cli_event_publisher import CLIEventPublisher
+
+
+# ---------------------------------------------------------------------------
+# CLIEventPublisher unit tests
+# ---------------------------------------------------------------------------
+
+class TestCLIEventPublisher:
+    """Tests for CLIEventPublisher in collecting mode."""
+
+    @pytest.fixture
+    def publisher(self):
+        return CLIEventPublisher(streaming=False)
+
+    @pytest.mark.asyncio
+    async def test_publish_chat_response_accumulates(self, publisher):
+        await publisher.publish_chat_response("Hello ")
+        await publisher.publish_chat_response("world")
+        result = publisher.get_result()
+        assert result.message == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_publish_tool_start_and_complete(self, publisher):
+        await publisher.publish_tool_start("my_tool")
+        assert len(publisher.get_result().tool_calls) == 1
+        assert publisher.get_result().tool_calls[0]["status"] == "started"
+
+        await publisher.publish_tool_complete("my_tool", result="ok")
+        assert publisher.get_result().tool_calls[0]["status"] == "complete"
+        assert publisher.get_result().tool_calls[0]["result"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_publish_files_update(self, publisher):
+        await publisher.publish_files_update({"report.pdf": {"key": "s3/report.pdf"}})
+        assert "report.pdf" in publisher.get_result().files
+
+    @pytest.mark.asyncio
+    async def test_publish_canvas_content(self, publisher):
+        await publisher.publish_canvas_content("<h1>Hi</h1>")
+        assert publisher.get_result().canvas_content == "<h1>Hi</h1>"
+
+    @pytest.mark.asyncio
+    async def test_send_json_records_event(self, publisher):
+        await publisher.send_json({"type": "custom", "data": 1})
+        assert len(publisher.get_result().raw_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_writes_to_stdout(self, capsys):
+        pub = CLIEventPublisher(streaming=True)
+        await pub.publish_chat_response("token1")
+        captured = capsys.readouterr()
+        assert "token1" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_quiet_suppresses_status(self, capsys):
+        pub = CLIEventPublisher(streaming=True, quiet=True)
+        await pub.publish_tool_start("some_tool")
+        captured = capsys.readouterr()
+        # quiet mode: no stderr output for tool status
+        assert "some_tool" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# CLI arg parsing tests
+# ---------------------------------------------------------------------------
+
+class TestCLIArgParsing:
+    """Tests for atlas_chat_cli argument parsing."""
+
+    def test_basic_prompt(self):
+        from atlas_chat_cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["Hello world"])
+        assert args.prompt == "Hello world"
+        assert args.json_output is False
+
+    def test_tools_flag(self):
+        from atlas_chat_cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "Do stuff", "--tools", "toolA,toolB"
+        ])
+        assert args.tools == "toolA,toolB"
+
+    def test_json_output_flag(self):
+        from atlas_chat_cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["prompt", "--json"])
+        assert args.json_output is True
+
+    def test_list_tools_flag(self):
+        from atlas_chat_cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["--list-tools"])
+        assert args.list_tools is True
+
+
+# ---------------------------------------------------------------------------
+# ChatResult serialization tests
+# ---------------------------------------------------------------------------
+
+class TestChatResult:
+    def test_to_dict(self):
+        from atlas_client import ChatResult
+
+        sid = uuid4()
+        result = ChatResult(
+            message="Hi",
+            tool_calls=[{"tool": "x", "status": "complete"}],
+            files={"a.txt": {}},
+            canvas_content="<p>c</p>",
+            session_id=sid,
+        )
+        d = result.to_dict()
+        assert d["message"] == "Hi"
+        assert d["session_id"] == str(sid)
+        assert len(d["tool_calls"]) == 1
+
+    def test_to_dict_json_serializable(self):
+        from atlas_client import ChatResult
+
+        result = ChatResult(message="ok")
+        json.dumps(result.to_dict())  # should not raise

--- a/backend/tests/test_atlas_client.py
+++ b/backend/tests/test_atlas_client.py
@@ -98,6 +98,13 @@ class TestCLIArgParsing:
         args = parser.parse_args(["prompt", "--json"])
         assert args.json_output is True
 
+    def test_output_file_flag(self):
+        from atlas_chat_cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["prompt", "-o", "/tmp/out.txt"])
+        assert args.output == "/tmp/out.txt"
+
     def test_list_tools_flag(self):
         from atlas_chat_cli import build_parser
 

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -41,6 +41,9 @@ python atlas_chat_cli.py "Calculate 2^10 then execute print('hello') in Python" 
 # Read prompt from stdin
 echo "Explain quantum computing" | python atlas_chat_cli.py -
 
+# Write output to file
+python atlas_chat_cli.py "Generate a report" -o ./report.md
+
 # JSON output (structured result with tool_calls, files, etc.)
 python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate --json
 
@@ -55,6 +58,7 @@ python atlas_chat_cli.py --list-tools
 | `prompt` | Positional prompt text, or `-` for stdin |
 | `--model` | LLM model name (default from config) |
 | `--tools` | Comma-separated fully-qualified tool names (`serverName_toolName`) |
+| `-o, --output` | Write response to file path |
 | `--json` | Output structured JSON |
 | `--user-email` | Override user identity |
 | `--list-tools` | Print available tools and exit |

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -32,23 +32,17 @@ cd backend
 python atlas_chat_cli.py "Summarize the latest docs" --model gpt-4o
 
 # With tools
-python atlas_chat_cli.py "What is 355/113?" --tools calculator_evaluate
+python atlas_chat_cli.py "What is 355/113 +sin0.23)*897^1.23. use the tool" --tools calculator_evaluate
 
 # Multiple tools
 python atlas_chat_cli.py "Calculate 2^10 then execute print('hello') in Python" \
   --tools calculator_evaluate,code-executor_execute_code
-
-# Write output to file
-python atlas_chat_cli.py "Generate a report" -o ./report.md
 
 # Read prompt from stdin
 echo "Explain quantum computing" | python atlas_chat_cli.py -
 
 # JSON output (structured result with tool_calls, files, etc.)
 python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate --json
-
-# Quiet mode (suppress tool/status output on stderr, only final response on stdout)
-python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate -q
 
 # List available tools (prints in the format used by --tools)
 python atlas_chat_cli.py --list-tools
@@ -61,11 +55,8 @@ python atlas_chat_cli.py --list-tools
 | `prompt` | Positional prompt text, or `-` for stdin |
 | `--model` | LLM model name (default from config) |
 | `--tools` | Comma-separated fully-qualified tool names (`serverName_toolName`) |
-| `-o, --output` | Write response to file path |
 | `--json` | Output structured JSON |
-| `--max-steps` | Max agent iterations (default: 10) |
 | `--user-email` | Override user identity |
-| `-q, --quiet` | Suppress tool/status output |
 | `--list-tools` | Print available tools and exit |
 
 ### Exit Codes

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -142,6 +142,10 @@ The CLI uses the same configuration as the web app:
 
 To see which tools are available, check the server keys in your `mcp.json` and the `@mcp.tool` decorated functions in each server's `main.py`.
 
+### Tool Approval
+
+In the web UI, tools may require user approval before execution (configured via `require_approval` in `mcp.json`). The CLI automatically approves all tool calls since there is no interactive approval UI. This applies to both tools mode and agent mode.
+
 ## Use Cases
 
 - **E2E testing**: Script chat interactions for automated testing

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -1,0 +1,146 @@
+# Atlas CLI and Python API
+
+Last updated: 2026-01-27 20:30
+
+## Overview
+
+Atlas provides a non-interactive CLI and Python API for one-shot LLM chat with full MCP tools and RAG support -- no browser or WebSocket needed.
+
+## Tool Naming Convention
+
+Tool names are fully qualified as `{serverName}_{toolName}`, where `serverName` is the key in `mcp.json` and `toolName` is the function name registered in the MCP server.
+
+Default servers from `config/defaults/mcp.json` and their tools:
+
+| Server | Tool name(s) | Description |
+|--------|-------------|-------------|
+| `calculator` | `calculator_evaluate` | Evaluate math expressions |
+| `pdfbasic` | `pdfbasic_*` | PDF text extraction and analysis |
+| `code-executor` | `code-executor_*` | Sandboxed code execution |
+| `ui-demo` | `ui-demo_*` | UI customization demo |
+| `prompts` | (prompts only, no tools) | System prompt overrides |
+| `env-demo` | `env-demo_*` | Environment variable demo |
+
+The special pseudo-tool `canvas_canvas` is always available regardless of selection.
+
+## CLI Usage
+
+```bash
+cd backend
+
+# Basic prompt
+python atlas_chat_cli.py "Summarize the latest docs" --model gpt-4o
+
+# With tools
+python atlas_chat_cli.py "What is 355/113?" --tools calculator_evaluate
+
+# Multiple tools
+python atlas_chat_cli.py "Calculate 2^10 then execute print('hello') in Python" \
+  --tools calculator_evaluate,code-executor_execute_code
+
+# Write output to file
+python atlas_chat_cli.py "Generate a report" -o ./report.md
+
+# Read prompt from stdin
+echo "Explain quantum computing" | python atlas_chat_cli.py -
+
+# JSON output (structured result with tool_calls, files, etc.)
+python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate --json
+
+# Quiet mode (suppress tool/status output on stderr, only final response on stdout)
+python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate -q
+
+# Reuse a session for multi-turn conversation
+python atlas_chat_cli.py "Remember: my name is Alice" --session-id 550e8400-e29b-41d4-a716-446655440000
+python atlas_chat_cli.py "What is my name?" --session-id 550e8400-e29b-41d4-a716-446655440000
+```
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `prompt` | Positional prompt text, or `-` for stdin |
+| `--model` | LLM model name (default from config) |
+| `--tools` | Comma-separated fully-qualified tool names (`serverName_toolName`) |
+| `-o, --output` | Write response to file path |
+| `--json` | Output structured JSON |
+| `--session-id` | Reuse session UUID for multi-turn |
+| `--max-steps` | Max agent iterations (default: 10) |
+| `--user-email` | Override user identity |
+| `-q, --quiet` | Suppress tool/status output |
+
+### Exit Codes
+
+- `0` - Success
+- `1` - Runtime error
+- `2` - Bad arguments (no prompt provided)
+
+## Python API
+
+```python
+import asyncio
+from atlas_client import AtlasClient
+
+async def main():
+    client = AtlasClient()
+    result = await client.chat(
+        prompt="What is 355 divided by 113?",
+        model="gpt-4o",
+        selected_tools=["calculator_evaluate"],
+    )
+    print(result.message)
+    print(result.tool_calls)
+    await client.cleanup()
+
+asyncio.run(main())
+```
+
+### Using multiple tools
+
+```python
+result = await client.chat(
+    prompt="Calculate 2^10 then run print('hello') in Python",
+    selected_tools=["calculator_evaluate", "code-executor_execute_code"],
+)
+```
+
+### Sync usage
+
+```python
+from atlas_client import AtlasClient
+
+client = AtlasClient()
+result = client.chat_sync(
+    "What is 2+2?",
+    model="gpt-4o",
+    selected_tools=["calculator_evaluate"],
+)
+print(result.message)
+```
+
+### ChatResult fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | `str` | Assistant's text response |
+| `tool_calls` | `list[dict]` | Tool invocations with name, status, result |
+| `files` | `dict` | Session files produced by tools |
+| `canvas_content` | `str or None` | HTML/markdown canvas content |
+| `session_id` | `UUID` | Session ID for multi-turn reuse |
+
+## Configuration
+
+The CLI uses the same configuration as the web app:
+- `.env` for environment variables
+- `config/defaults/` and `config/overrides/` for LLM, MCP, and RAG config
+- MCP tool discovery runs automatically on first use
+- Tool servers are defined in `config/defaults/mcp.json` (or `config/overrides/mcp.json`)
+
+To see which tools are available, check the server keys in your `mcp.json` and the `@mcp.tool` decorated functions in each server's `main.py`.
+
+## Use Cases
+
+- **E2E testing**: Script chat interactions for automated testing
+- **MCP development**: Test tool servers without starting the full UI
+- **Scripted workflows**: Chain LLM calls in shell scripts or Python
+- **CI/CD**: Validate LLM + tool integrations in pipelines

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -52,10 +52,6 @@ python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate -q
 
 # List available tools (prints in the format used by --tools)
 python atlas_chat_cli.py --list-tools
-
-# Reuse a session for multi-turn conversation
-python atlas_chat_cli.py "Remember: my name is Alice" --session-id 550e8400-e29b-41d4-a716-446655440000
-python atlas_chat_cli.py "What is my name?" --session-id 550e8400-e29b-41d4-a716-446655440000
 ```
 
 ### CLI Flags
@@ -67,7 +63,6 @@ python atlas_chat_cli.py "What is my name?" --session-id 550e8400-e29b-41d4-a716
 | `--tools` | Comma-separated fully-qualified tool names (`serverName_toolName`) |
 | `-o, --output` | Write response to file path |
 | `--json` | Output structured JSON |
-| `--session-id` | Reuse session UUID for multi-turn |
 | `--max-steps` | Max agent iterations (default: 10) |
 | `--user-email` | Override user identity |
 | `-q, --quiet` | Suppress tool/status output |
@@ -130,7 +125,6 @@ print(result.message)
 | `tool_calls` | `list[dict]` | Tool invocations with name, status, result |
 | `files` | `dict` | Session files produced by tools |
 | `canvas_content` | `str or None` | HTML/markdown canvas content |
-| `session_id` | `UUID` | Session ID for multi-turn reuse |
 
 ## Configuration
 

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -50,6 +50,9 @@ python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate --json
 # Quiet mode (suppress tool/status output on stderr, only final response on stdout)
 python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate -q
 
+# List available tools (prints in the format used by --tools)
+python atlas_chat_cli.py --list-tools
+
 # Reuse a session for multi-turn conversation
 python atlas_chat_cli.py "Remember: my name is Alice" --session-id 550e8400-e29b-41d4-a716-446655440000
 python atlas_chat_cli.py "What is my name?" --session-id 550e8400-e29b-41d4-a716-446655440000
@@ -68,6 +71,7 @@ python atlas_chat_cli.py "What is my name?" --session-id 550e8400-e29b-41d4-a716
 | `--max-steps` | Max agent iterations (default: 10) |
 | `--user-email` | Override user identity |
 | `-q, --quiet` | Suppress tool/status output |
+| `--list-tools` | Print available tools and exit |
 
 ### Exit Codes
 

--- a/docs/developer/cli-usage-2026-01-27.md
+++ b/docs/developer/cli-usage-2026-01-27.md
@@ -129,7 +129,7 @@ To see which tools are available, check the server keys in your `mcp.json` and t
 
 ### Tool Approval
 
-In the web UI, tools may require user approval before execution (configured via `require_approval` in `mcp.json`). The CLI automatically approves all tool calls since there is no interactive approval UI. This applies to both tools mode and agent mode.
+In the web UI, tools may require user approval before execution (configured via `require_approval` in `mcp.json`). The CLI automatically approves all tool calls since there is no interactive approval UI. This applies to all tool calls.
 
 ## Use Cases
 

--- a/test/test_cli_e2e.sh
+++ b/test/test_cli_e2e.sh
@@ -91,15 +91,6 @@ for k in (\"message\", \"tool_calls\", \"files\", \"session_id\"):
     run_test "Read prompt from stdin" \
         bash -c "echo 'Say hi' | (cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py - --json 2>/dev/null) | $PYTHON -c 'import sys,json; d=json.load(sys.stdin); assert len(d[\"message\"])>0'"
 
-    # 8. Session reuse returns same session_id
-    SESSION_ID="550e8400-e29b-41d4-a716-446655440000"
-    run_test "Session reuse with --session-id" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hi' --session-id $SESSION_ID --json 2>/dev/null | $PYTHON -c '
-import sys, json
-d = json.load(sys.stdin)
-assert d[\"session_id\"] == \"$SESSION_ID\", f\"wrong session_id: {d[\"session_id\"]}\"
-'"
-
     echo ""
 fi
 
@@ -134,8 +125,6 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "offline" ]; then
     run_test "--help lists --output flag" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--output'"
 
-    run_test "--help lists --session-id flag" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--session-id'"
 
     run_test "--help lists --max-steps flag" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--max-steps'"

--- a/test/test_cli_e2e.sh
+++ b/test/test_cli_e2e.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# End-to-end test for atlas_chat_cli.py
+#
+# Tests are split into two groups:
+#   - Offline tests: no LLM API key needed (arg parsing, help, error codes)
+#   - Online tests: require a valid LLM API key and working backend config
+#
+# Usage:
+#   bash test/test_cli_e2e.sh            # run all tests
+#   bash test/test_cli_e2e.sh offline    # run only offline tests
+#   bash test/test_cli_e2e.sh online     # run only online tests
+#
+# NOT included in run_tests.sh -- run manually.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BACKEND_DIR="$PROJECT_ROOT/backend"
+
+# Use the project venv python by default
+if [ -x "$PROJECT_ROOT/.venv/bin/python" ]; then
+    PYTHON="${PYTHON:-$PROJECT_ROOT/.venv/bin/python}"
+else
+    PYTHON="${PYTHON:-python}"
+fi
+
+MODE="${1:-all}"
+PASS=0
+FAIL=0
+TMPDIR=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+TEST_TIMEOUT="${TEST_TIMEOUT:-30}"
+
+run_test() {
+    local name="$1"
+    shift
+    echo -n "  $name ... "
+    if timeout "$TEST_TIMEOUT" "$@" ; then
+        echo "PASS"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL"
+        FAIL=$((FAIL + 1))
+        echo ""
+        echo "ABORTED: test '$name' failed"
+        exit 1
+    fi
+}
+
+echo "================================================================"
+echo "Atlas CLI End-to-End Tests (mode: $MODE)"
+echo "================================================================"
+echo "Using python: $PYTHON"
+echo ""
+
+# ======================================================================
+# ONLINE TESTS -- require a working LLM API key and MCP servers
+# ======================================================================
+if [ "$MODE" = "all" ] || [ "$MODE" = "online" ]; then
+    echo "--- Online tests (require LLM API key) ---"
+    echo ""
+
+    # 3. Basic prompt returns JSON with message
+    run_test "Basic prompt returns JSON with message" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hello in one word' --json 2>/dev/null | $PYTHON -c 'import sys,json; d=json.load(sys.stdin); assert len(d[\"message\"])>0, \"empty message\"'"
+
+    # 4. JSON output has all required keys
+    run_test "JSON output has required keys" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hi' --json 2>/dev/null | $PYTHON -c '
+import sys, json
+d = json.load(sys.stdin)
+for k in (\"message\", \"tool_calls\", \"files\", \"session_id\"):
+    assert k in d, f\"missing key: {k}\"
+'"
+
+    # 5. Output to file
+    run_test "Output written to file with -o" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hello' -o '$TMPDIR/out.txt' 2>/dev/null && [ -s '$TMPDIR/out.txt' ]"
+
+    # 7. Stdin prompt
+    run_test "Read prompt from stdin" \
+        bash -c "echo 'Say hi' | (cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py - --json 2>/dev/null) | $PYTHON -c 'import sys,json; d=json.load(sys.stdin); assert len(d[\"message\"])>0'"
+
+    # 8. Session reuse returns same session_id
+    SESSION_ID="550e8400-e29b-41d4-a716-446655440000"
+    run_test "Session reuse with --session-id" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hi' --session-id $SESSION_ID --json 2>/dev/null | $PYTHON -c '
+import sys, json
+d = json.load(sys.stdin)
+assert d[\"session_id\"] == \"$SESSION_ID\", f\"wrong session_id: {d[\"session_id\"]}\"
+'"
+
+    echo ""
+fi
+
+# ======================================================================
+# OFFLINE TESTS -- no LLM API key or running backend required
+# ======================================================================
+if [ "$MODE" = "all" ] || [ "$MODE" = "offline" ]; then
+    echo "--- Offline tests ---"
+    echo ""
+
+    # 0. --help exits cleanly and shows usage
+    run_test "--help prints usage and exits 0" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q 'usage:'"
+
+    # 1. No prompt gives exit code 2
+    run_test "No prompt returns exit code 2" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 2>/dev/null; [ \$? -eq 2 ]"
+
+    # 2. --help shows all expected flags
+    run_test "--help lists --model flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--model'"
+
+    run_test "--help lists --agent flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--agent'"
+
+    run_test "--help lists --tools flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--tools'"
+
+    run_test "--help lists --json flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--json'"
+
+    run_test "--help lists --output flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--output'"
+
+    run_test "--help lists --session-id flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--session-id'"
+
+    run_test "--help lists --max-steps flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--max-steps'"
+
+    run_test "--help lists --user-email flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--user-email'"
+
+    run_test "--help lists --quiet flag" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--quiet'"
+
+    echo ""
+fi
+
+echo "================================================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================================================"
+
+[ "$FAIL" -eq 0 ]

--- a/test/test_cli_e2e.sh
+++ b/test/test_cli_e2e.sh
@@ -109,8 +109,6 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "offline" ]; then
     run_test "--help lists --model flag" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--model'"
 
-    run_test "--help lists --agent flag" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--agent'"
 
     run_test "--help lists --tools flag" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--tools'"

--- a/test/test_cli_e2e.sh
+++ b/test/test_cli_e2e.sh
@@ -83,11 +83,7 @@ for k in (\"message\", \"tool_calls\", \"files\", \"session_id\"):
     assert k in d, f\"missing key: {k}\"
 '"
 
-    # 5. Output to file
-    run_test "Output written to file with -o" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hello' -o '$TMPDIR/out.txt' 2>/dev/null && [ -s '$TMPDIR/out.txt' ]"
-
-    # 7. Stdin prompt
+    # 5. Stdin prompt
     run_test "Read prompt from stdin" \
         bash -c "echo 'Say hi' | (cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py - --json 2>/dev/null) | $PYTHON -c 'import sys,json; d=json.load(sys.stdin); assert len(d[\"message\"])>0'"
 
@@ -122,18 +118,8 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "offline" ]; then
     run_test "--help lists --json flag" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--json'"
 
-    run_test "--help lists --output flag" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--output'"
-
-
-    run_test "--help lists --max-steps flag" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--max-steps'"
-
     run_test "--help lists --user-email flag" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--user-email'"
-
-    run_test "--help lists --quiet flag" \
-        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --help 2>/dev/null | grep -q -- '--quiet'"
 
     echo ""
 fi

--- a/test/test_cli_e2e.sh
+++ b/test/test_cli_e2e.sh
@@ -66,6 +66,10 @@ if [ "$MODE" = "all" ] || [ "$MODE" = "online" ]; then
     echo "--- Online tests (require LLM API key) ---"
     echo ""
 
+    # --list-tools prints discovered tools
+    run_test "--list-tools prints available tools" \
+        bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py --list-tools 2>/dev/null | grep -q 'calculator_evaluate'"
+
     # 3. Basic prompt returns JSON with message
     run_test "Basic prompt returns JSON with message" \
         bash -c "cd $BACKEND_DIR && $PYTHON atlas_chat_cli.py 'Say hello in one word' --json 2>/dev/null | $PYTHON -c 'import sys,json; d=json.load(sys.stdin); assert len(d[\"message\"])>0, \"empty message\"'"


### PR DESCRIPTION
## Summary
- Add `atlas_chat_cli.py` CLI and `atlas_client.py` Python API for headless one-shot LLM chat with MCP tools and RAG
- Add `--list-tools` flag to discover available tools in CLI-usable format
- Auto-approve all tool calls in CLI mode (no interactive approval UI)
- Show tool name, args, and results on stderr during execution
- Add JSON repair for truncated LLM tool arguments
- Add e2e test suite (`test/test_cli_e2e.sh`) with fail-fast, per-test timeout, and online/offline test groups
- Add CLI documentation in `docs/developer/cli-usage-2026-01-27.md`

## Test plan
- [ ] `bash test/run_tests.sh backend` -- all backend unit tests pass
- [ ] `bash test/test_cli_e2e.sh` -- all CLI e2e tests pass (online + offline)
- [ ] `python atlas_chat_cli.py --list-tools` -- prints available tools
- [ ] `python atlas_chat_cli.py "What is 2+2?" --tools calculator_evaluate` -- tool executes without approval hang
- [ ] `python atlas_chat_cli.py "Hello" --json` -- returns structured JSON

Generated with [Claude Code](https://claude.com/claude-code)