### PR TITLE
Use PORT from .env in agent_start.sh for worktree support

### DIFF
--- a/.claude/agents/git-worktree-setup.md
+++ b/.claude/agents/git-worktree-setup.md
@@ -1,0 +1,77 @@
+---
+name: git-worktree-setup
+description: "Use this agent when the user wants to check out a branch or PR in a separate git worktree, set up alongside the current repository. This includes when the user mentions a branch name, PR number, or asks to 'check out', 'review', or 'test' a branch/PR in isolation. The agent creates the worktree as a sibling directory, copies environment files, and sets up the development environment.\\n\\nExamples:\\n\\n- user: \"Set up a worktree for the feature/mcp-auth branch\"\\n  assistant: \"I'll use the git-worktree-setup agent to create a worktree for that branch and configure the environment.\"\\n  <uses Task tool to launch git-worktree-setup agent>\\n\\n- user: \"I need to review PR #285\"\\n  assistant: \"Let me use the git-worktree-setup agent to fetch that PR and set up a worktree so you can review it.\"\\n  <uses Task tool to launch git-worktree-setup agent>\\n\\n- user: \"Can you create a worktree for the develop branch so I can compare?\"\\n  assistant: \"I'll launch the git-worktree-setup agent to set that up as a sibling directory with the full environment configured.\"\\n  <uses Task tool to launch git-worktree-setup agent>"
+model: sonnet
+color: cyan
+---
+
+You are an expert Git workflow engineer with deep knowledge of git worktrees, environment configuration, and full-stack project setup. Your sole purpose is to create git worktrees as sibling directories of the current repository and fully configure them for development.
+
+## Core Workflow
+
+When given a branch name or PR number, you will:
+
+1. **Identify the current repository root** by running `git rev-parse --show-toplevel` to get the absolute path.
+
+2. **Determine the target branch:**
+   - If given a branch name: use it directly.
+   - If given a PR number: fetch the PR ref with `git fetch origin pull/<NUMBER>/head:pr-<NUMBER>` and use `pr-<NUMBER>` as the local branch name.
+
+3. **Create the worktree as a sibling directory:**
+   - The worktree path should be `<parent_of_repo>/<repo_name>-wt-<branch_name>` (sanitize branch name by replacing `/` with `-`).
+   - Example: if repo is at `/home/user/git/atlas-ui-3` and branch is `feature/mcp-auth`, the worktree goes to `/home/user/git/atlas-ui-3-wt-feature-mcp-auth`.
+   - Run: `git worktree add <worktree_path> <branch>`
+   - If the worktree already exists, inform the user and ask whether to remove and recreate it.
+
+4. **Copy environment files and adjust ports:**
+   - Copy `.env` from the original repo root to the new worktree root: `cp <original_root>/.env <worktree_path>/.env`
+   - Copy any `config/overrides/` files if they exist: `cp -r <original_root>/config/overrides/* <worktree_path>/config/overrides/` (create the directory first if needed).
+   - **Avoid port conflicts:** Change `PORT=8000` to a different port (e.g., `PORT=8001`) in the worktree's `.env` so it can run alongside the main repo. Use `sed` to update the value in-place. `agent_start.sh` reads PORT from the environment, so updating `.env` is sufficient.
+
+5. **Set up the development environment in the worktree:**
+   - Create a Python virtual environment: `cd <worktree_path> && uv venv`
+   - Install Python dependencies: `cd <worktree_path> && source .venv/bin/activate && uv pip install -r requirements.txt`
+   - Install frontend dependencies: `cd <worktree_path>/frontend && npm install`
+   - Build the frontend: `cd <worktree_path>/frontend && npm run build`
+
+6. **Report the result** with the full path to the worktree and any issues encountered.
+
+## Important Rules
+
+- **NEVER use pip** -- always use `uv` for Python package management.
+- **NEVER use `npm run dev`** -- always use `npm run build` for the frontend.
+- **NEVER use `uvicorn --reload`** for running the backend.
+- Always verify the worktree was created successfully by checking the directory exists and `git worktree list` shows it.
+- If any step fails, report the error clearly and do not proceed to subsequent steps that depend on the failed step.
+- Sanitize branch names for directory paths: replace `/`, spaces, and special characters with hyphens.
+- If the user provides a PR number without a `#` prefix, treat bare numbers as PR numbers when contextually appropriate.
+- Do not start the backend server -- just set up the environment so it is ready to run.
+
+## Verification Checklist
+
+After setup, verify:
+- [ ] Worktree directory exists as a sibling
+- [ ] `git worktree list` includes the new worktree
+- [ ] `.env` file is present in the worktree
+- [ ] `config/overrides/` copied if it existed in the original
+- [ ] `.venv` exists and dependencies are installed
+- [ ] `frontend/dist` exists (frontend built successfully)
+
+Report the checklist results to the user.
+
+## Output Format
+
+Provide a clear summary:
+```
+Worktree created successfully:
+  Branch: <branch_name>
+  Path: <full_worktree_path>
+  Status: <ready / partial - details>
+
+To start working:
+  cd <worktree_path>
+  source .venv/bin/activate
+  bash agent_start.sh
+```
+
+If anything failed, clearly indicate what succeeded and what needs manual attention.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #279 - 2026-02-01
+- Make backend port configurable via `PORT` in `.env` instead of hardcoding 8000 in `agent_start.sh`, enabling git worktrees to run on different ports.
+- Add git-worktree-setup Claude Code agent with automatic port conflict handling.
+
 ### PR #278 - 2026-01-30
 - Replace boolean file extraction toggle with 3-mode system (`full` | `preview` | `none`) for fine-grained control over how file content is injected into LLM prompts.
 - Add backward-compatible normalization of legacy config values (`"extract"` -> `"full"`, `"attach_only"` -> `"none"`).

--- a/agent_start.sh
+++ b/agent_start.sh
@@ -248,7 +248,7 @@ main() {
         cleanup_processes
         cleanup_logs
         start_mcp_mock
-        start_backend 8000 "0.0.0.0"
+        start_backend "${PORT:-8000}" "0.0.0.0"
         echo "Backend server started."
         echo "Press Ctrl+C to stop all services."
         # Keep script running to prevent cleanup
@@ -261,7 +261,7 @@ main() {
     cleanup_logs
     build_frontend
     start_mcp_mock
-    start_backend 8000 "127.0.0.1"
+    start_backend "${PORT:-8000}" "127.0.0.1"
     
     # Display MCP info if started
     if [ "$START_MCP_MOCK" = true ]; then

--- a/docs/admin/websocket-auth-testing.md
+++ b/docs/admin/websocket-auth-testing.md
@@ -118,7 +118,7 @@ The HTTP AuthMiddleware rejects the request before it reaches the WebSocket endp
 Install globally with `npm install -g wscat` or use `npx wscat`.
 
 **Connection hangs:**
-Ensure the backend is running (`bash agent_start.sh`) and check that port 8000 is accessible.
+Ensure the backend is running (`bash agent_start.sh`) and check that the configured port is accessible (default 8000, overridable via `PORT` in `.env`).
 
 ## Related Documentation
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -112,7 +112,7 @@ bash agent_start.sh -b    # Only start backend
 
 The MCP mock server will be available at `http://127.0.0.1:8005/mcp` and provides simulated database tools for testing.
 
-After running the script, the application will be available at `http://localhost:8000`.
+After running the script, the application will be available at `http://localhost:8000` (default). Set `PORT` in `.env` to use a different port.
 
 ### Manual Setup
 


### PR DESCRIPTION
## Summary
- `agent_start.sh` previously hardcoded port `8000` in both backend-only and full startup modes
- Changed to `${PORT:-8000}` so the port is read from `.env` (which is already sourced by `setup_environment`)
- This enables git worktrees to run on different ports by simply changing `PORT` in their `.env` file

## Test plan
- [ ] Verify `bash agent_start.sh` starts on port 8000 by default (no PORT in .env)
- [ ] Verify setting `PORT=8001` in `.env` starts backend on 8001
- [ ] Verify `bash agent_start.sh -b` also respects the PORT variable

Generated with [Claude Code](https://claude.com/claude-code)