### PR TITLE
Fix hardcoded /workspaces paths causing startup failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,7 +157,7 @@ FEATURE_FILE_CONTENT_EXTRACTION_ENABLED=false
 #############################################
 # MCP_TOKEN_ENCRYPTION_KEY=your-random-string-at-least-32-chars
 # Directory to store encrypted tokens (default: config/secure/)
-# MCP_TOKEN_STORAGE_DIR=/var/lib/atlas/tokens
+# MCP_TOKEN_STORAGE_DIR=config/secure
 
 #############################################
 # Configuration File Names
@@ -211,7 +211,8 @@ REQUIRE_TOOL_APPROVAL_BY_DEFAULT=false
 # Set to true to require approval for every tool call
 FORCE_TOOL_APPROVAL_GLOBALLY=false
 
-APP_LOG_DIR=/workspaces/atlas-ui-3/logs
+# APP_LOG_DIR defaults to <project_root>/logs when unset
+# APP_LOG_DIR=/path/to/logs
 
 CAPABILITY_TOKEN_SECRET=blablah
 

--- a/backend/mcp/code-executor/main.py
+++ b/backend/mcp/code-executor/main.py
@@ -55,8 +55,9 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # File loading constants and helpers
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 RUNTIME_UPLOADS = os.environ.get(
-    "CHATUI_RUNTIME_UPLOADS", "/workspaces/atlas-ui-3-11/runtime/uploads"
+    "CHATUI_RUNTIME_UPLOADS", os.path.join(_PROJECT_ROOT, "runtime", "uploads")
 )
 
 def _is_http_url(s: str) -> bool:

--- a/backend/mcp/csv_reporter/main.py
+++ b/backend/mcp/csv_reporter/main.py
@@ -33,8 +33,9 @@ from fastmcp import FastMCP
 mcp = FastMCP("CSV_Reporter")
 
 
+_PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 RUNTIME_UPLOADS = os.environ.get(
-    "CHATUI_RUNTIME_UPLOADS", "/workspaces/atlas-ui-3-11/runtime/uploads"
+    "CHATUI_RUNTIME_UPLOADS", os.path.join(_PROJECT_ROOT, "runtime", "uploads")
 )
 
 


### PR DESCRIPTION
## Summary
- Commented out `APP_LOG_DIR` in `.env.example` so it falls back to the auto-detected `<project_root>/logs` path instead of hardcoding `/workspaces/atlas-ui-3/logs`
- Changed `MCP_TOKEN_STORAGE_DIR` example from `/var/lib/atlas/tokens` to relative `config/secure`
- Replaced hardcoded `/workspaces/atlas-ui-3-11/runtime/uploads` fallback in `backend/mcp/csv_reporter/main.py` and `backend/mcp/code-executor/main.py` with a path computed relative to `__file__`

## Test plan
- [ ] Run `bash agent_start.sh` and verify no `FileNotFoundError` for `/workspaces/...` paths
- [ ] Verify backend starts and logs are written to `<project_root>/logs/`
- [ ] Run `./test/run_tests.sh backend` and confirm no regressions

Generated with [Claude Code](https://claude.com/claude-code)