### PR TITLE
Remove dead sync_package_assets.sh from PyPI workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -34,9 +34,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install build twine
 
-      - name: Sync package assets
-        run: scripts/sync_package_assets.sh
-
       - name: Build package
         run: python -m build
 


### PR DESCRIPTION
## Summary
- Remove reference to `scripts/sync_package_assets.sh` from the PyPI publish workflow -- the script no longer exists and was causing the v0.1.1 release to fail

## Test plan
- [ ] Merge and re-trigger the v0.1.1 release workflow

Generated with [Claude Code](https://claude.com/claude-code)