### PR TITLE
Add Groq gpt-oss-120b model to llmconfig

### DIFF
--- a/atlas/config/llmconfig.yml
+++ b/atlas/config/llmconfig.yml
@@ -17,3 +17,8 @@ models:
     model_name: "gpt-4.1-nano"
     api_key: "${OPENAI_API_KEY}"
     compliance_level: "External"
+  groq-gpt-oss-120b:
+    model_url: "https://api.groq.com/openai/v1"
+    model_name: "openai/gpt-oss-120b"
+    api_key: "${GROQ_API_KEY}"
+    compliance_level: "External"


### PR DESCRIPTION
## Summary
- Added `groq-gpt-oss-120b` model entry to `atlas/config/llmconfig.yml` pointing at `https://api.groq.com/openai/v1`
- Uses existing `GROQ_API_KEY` env var (already in `.env.example`)

## Test plan
- [ ] Verify `groq-gpt-oss-120b` appears in model list via `/api/config`
- [ ] Verify model works with a valid `GROQ_API_KEY`

Generated with [Claude Code](https://claude.com/claude-code)