### PR TITLE
Fix agent_start.sh to respect ATLAS_HOST env var

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -248,6 +248,7 @@ Set `APP_AGENT_LOOP_STRATEGY` to `react | think-act | act`.
 4. **Frontend not loading**: Verify `npm run build` completed
 5. **Missing tools**: Check MCP transport/URL and server logs
 6. **Empty lists**: Check auth groups and compliance filtering
+7. **Host binding ignored**: `agent_start.sh` and the Dockerfile both use `ATLAS_HOST` env var for host binding; `main.py` also reads it directly -- keep all three in sync when changing network configuration
 
 ## Critical Restrictions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #324 - 2026-02-08
+- **Fix**: `agent_start.sh` now respects the `ATLAS_HOST` environment variable instead of hardcoding host values. Previously, backend-only mode (`-b`) always bound to `0.0.0.0` and full startup always bound to `127.0.0.1`, ignoring the `.env` setting.
+
 ### PR #306 - 2026-02-08
 - **Feature**: Add spinner animation and elapsed time counter to tool call status badges during active `calling`/`in_progress` states, with a timeout warning after 30 seconds.
 - **Feature**: Make the global "Thinking..." indicator context-aware: shows "Processing tool results..." after tool completion and "Running tool..." during tool execution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,7 @@ Set `APP_AGENT_LOOP_STRATEGY` to `react | think-act | act`; ChatService uses `ap
 5. **Container build SSL errors**: Use local development instead
 6. **Missing tools**: Check MCP transport/URL and server logs
 7. **Empty lists**: Check auth groups and compliance filtering
+8. **Host binding ignored**: `agent_start.sh` and the Dockerfile both use `ATLAS_HOST` env var for host binding; `main.py` also reads it directly -- keep all three in sync when changing network configuration
 
 ## PR Validation Scripts (Required)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -287,6 +287,7 @@ Set `APP_AGENT_LOOP_STRATEGY` to `react | think-act | act`.
 5. **Container build SSL errors**: Use local development instead
 6. **Missing tools**: Check MCP transport/URL and server logs
 7. **Empty lists**: Check auth groups and compliance filtering
+8. **Host binding ignored**: `agent_start.sh` and the Dockerfile both use `ATLAS_HOST` env var for host binding; `main.py` also reads it directly -- keep all three in sync when changing network configuration
 
 ## Critical Restrictions
 

--- a/agent_start.sh
+++ b/agent_start.sh
@@ -249,7 +249,7 @@ main() {
         cleanup_processes
         cleanup_logs
         start_mcp_mock
-        start_backend "${PORT:-8000}" "0.0.0.0"
+        start_backend "${PORT:-8000}" "${ATLAS_HOST:-127.0.0.1}"
         echo "Backend server started."
         echo "Press Ctrl+C to stop all services."
         # Keep script running to prevent cleanup
@@ -262,7 +262,7 @@ main() {
     cleanup_logs
     build_frontend
     start_mcp_mock
-    start_backend "${PORT:-8000}" "127.0.0.1"
+    start_backend "${PORT:-8000}" "${ATLAS_HOST:-127.0.0.1}"
     
     # Display MCP info if started
     if [ "$START_MCP_MOCK" = true ]; then


### PR DESCRIPTION
## Summary
- `agent_start.sh` was ignoring the `ATLAS_HOST` environment variable, hardcoding `0.0.0.0` in backend-only mode (`-b`) and `127.0.0.1` in full startup mode
- Both modes now read `${ATLAS_HOST:-127.0.0.1}` from the environment, consistent with `main.py` and the Dockerfile
- The `-b` flag previously always bound to all interfaces (`0.0.0.0`), which was a security concern since the documented default is localhost-only

## Test plan
- [ ] Set `ATLAS_HOST=0.0.0.0` in `.env`, run `bash agent_start.sh -b`, verify uvicorn binds to `0.0.0.0`
- [ ] Comment out `ATLAS_HOST` in `.env`, run `bash agent_start.sh -b`, verify uvicorn binds to `127.0.0.1` (default)
- [ ] Set `ATLAS_HOST=0.0.0.0` in `.env`, run `bash agent_start.sh`, verify uvicorn binds to `0.0.0.0`
- [ ] Comment out `ATLAS_HOST` in `.env`, run `bash agent_start.sh`, verify uvicorn binds to `127.0.0.1` (default)

Generated with [Claude Code](https://claude.com/claude-code)