### PR TITLE
Add K3s deployment with Traefik ingress

### DIFF
--- a/atlas/core/auth.py
+++ b/atlas/core/auth.py
@@ -65,7 +65,8 @@ async def is_user_in_group(user_id: str, group_id: str) -> bool:
         mock_groups = {
             "test@test.com": ["users", "mcp_basic", "admin"],
             "user@example.com": ["users", "mcp_basic"],
-            "admin@example.com": ["admin", "users", "mcp_basic", "mcp_advanced"]
+            "admin@example.com": ["admin", "users", "mcp_basic", "mcp_advanced"],
+            "garland3@gmail.com": ["admin", "users", "mcp_basic", "mcp_advanced"],
         }
         user_groups = mock_groups.get(user_id, [])
         return group_id in user_groups

--- a/deploy/auth-service/Dockerfile
+++ b/deploy/auth-service/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+    fastapi \
+    uvicorn \
+    python-multipart \
+    "passlib[bcrypt]" \
+    "bcrypt<4.1"
+
+COPY auth_service.py .
+
+EXPOSE 5000
+
+CMD ["uvicorn", "auth_service:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/deploy/auth-service/auth_service.py
+++ b/deploy/auth-service/auth_service.py
@@ -1,0 +1,229 @@
+"""
+ATLAS Auth Service - Minimal multi-tenant authentication.
+
+Provides cookie-based auth with bcrypt password hashing and HMAC-signed session cookies.
+User accounts are stored in a JSON file on disk.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import time
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import HTMLResponse, RedirectResponse
+from passlib.hash import bcrypt
+
+app = FastAPI()
+
+DATA_DIR = Path(os.environ.get("AUTH_DATA_DIR", "/data"))
+USERS_FILE = DATA_DIR / "users.json"
+SECRET = os.environ["ATLAS_AUTH_SECRET"]
+SESSION_HOURS = int(os.environ.get("ATLAS_AUTH_SESSION_HOURS", "24"))
+COOKIE_NAME = "atlas_session"
+
+
+# ---------------------------------------------------------------------------
+# User storage helpers
+# ---------------------------------------------------------------------------
+
+def _load_users() -> dict:
+    if not USERS_FILE.exists():
+        return {}
+    with open(USERS_FILE) as f:
+        return json.load(f)
+
+
+def _save_users(users: dict) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = USERS_FILE.with_suffix(".tmp")
+    with open(tmp, "w") as f:
+        json.dump(users, f, indent=2)
+    tmp.rename(USERS_FILE)
+
+
+# ---------------------------------------------------------------------------
+# Cookie helpers
+# ---------------------------------------------------------------------------
+
+def _sign(username: str, ts: str) -> str:
+    msg = f"{username}:{ts}"
+    return hmac.new(SECRET.encode(), msg.encode(), hashlib.sha256).hexdigest()
+
+
+def _make_cookie(username: str) -> str:
+    ts = str(int(time.time()))
+    sig = _sign(username, ts)
+    return f"{username}:{ts}:{sig}"
+
+
+def _verify_cookie(cookie: str) -> str | None:
+    """Return username if valid, else None."""
+    parts = cookie.split(":", 2)
+    if len(parts) != 3:
+        return None
+    username, ts, sig = parts
+    if not hmac.compare_digest(sig, _sign(username, ts)):
+        return None
+    try:
+        age = time.time() - int(ts)
+    except ValueError:
+        return None
+    if age > SESSION_HOURS * 3600 or age < 0:
+        return None
+    return username
+
+
+# ---------------------------------------------------------------------------
+# HTML templates (dark theme, minimal)
+# ---------------------------------------------------------------------------
+
+_STYLE = """
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         background: #1a1a2e; color: #e0e0e0; display: flex; align-items: center;
+         justify-content: center; min-height: 100vh; }
+  .card { background: #16213e; border-radius: 12px; padding: 2.5rem;
+          width: 100%; max-width: 400px; box-shadow: 0 8px 32px rgba(0,0,0,.4); }
+  h1 { text-align: center; margin-bottom: 1.5rem; color: #e0e0e0; font-size: 1.5rem; }
+  label { display: block; margin-bottom: .3rem; font-size: .9rem; color: #a0a0b0; }
+  input[type=text], input[type=password], input[type=email] {
+    width: 100%; padding: .7rem; margin-bottom: 1rem; border: 1px solid #2a2a4a;
+    border-radius: 6px; background: #0f3460; color: #e0e0e0; font-size: 1rem; }
+  input:focus { outline: none; border-color: #5388d8; }
+  button { width: 100%; padding: .75rem; border: none; border-radius: 6px;
+           background: #5388d8; color: #fff; font-size: 1rem; cursor: pointer;
+           font-weight: 600; }
+  button:hover { background: #4070c0; }
+  .link { text-align: center; margin-top: 1rem; }
+  .link a { color: #5388d8; text-decoration: none; }
+  .link a:hover { text-decoration: underline; }
+  .error { background: #3a1a1a; border: 1px solid #8b3a3a; color: #ff8080;
+           padding: .6rem; border-radius: 6px; margin-bottom: 1rem; text-align: center;
+           font-size: .9rem; }
+  .success { background: #1a3a1a; border: 1px solid #3a8b3a; color: #80ff80;
+             padding: .6rem; border-radius: 6px; margin-bottom: 1rem; text-align: center;
+             font-size: .9rem; }
+</style>
+"""
+
+
+def _login_page(error: str = "", message: str = "") -> str:
+    err_html = f'<div class="error">{error}</div>' if error else ""
+    msg_html = f'<div class="success">{message}</div>' if message else ""
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8"><title>ATLAS Login</title>{_STYLE}</head>
+<body><div class="card"><h1>ATLAS Login</h1>{err_html}{msg_html}
+<form method="post" action="/login">
+  <label for="username">Email</label>
+  <input type="email" id="username" name="username" required autofocus>
+  <label for="password">Password</label>
+  <input type="password" id="password" name="password" required>
+  <button type="submit">Log in</button>
+</form>
+<div class="link"><a href="/signup">Create an account</a></div>
+</div></body></html>"""
+
+
+def _signup_page(error: str = "") -> str:
+    err_html = f'<div class="error">{error}</div>' if error else ""
+    return f"""<!DOCTYPE html><html><head><meta charset="utf-8"><title>ATLAS Sign Up</title>{_STYLE}</head>
+<body><div class="card"><h1>Create Account</h1>{err_html}
+<form method="post" action="/signup">
+  <label for="username">Email</label>
+  <input type="email" id="username" name="username" required autofocus>
+  <label for="password">Password</label>
+  <input type="password" id="password" name="password" required minlength="8">
+  <button type="submit">Sign up</button>
+</form>
+<div class="link"><a href="/login">Already have an account? Log in</a></div>
+</div></body></html>"""
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    msg = request.query_params.get("msg", "")
+    return _login_page(message=msg)
+
+
+@app.post("/login")
+async def login_submit(request: Request):
+    form = await request.form()
+    username = (form.get("username") or "").strip().lower()
+    password = form.get("password") or ""
+
+    if not username or not password:
+        return HTMLResponse(_login_page(error="Email and password are required."), status_code=400)
+
+    users = _load_users()
+    user = users.get(username)
+    if not user or not bcrypt.verify(password, user["password_hash"]):
+        return HTMLResponse(_login_page(error="Invalid email or password."), status_code=401)
+
+    response = RedirectResponse("/", status_code=302)
+    response.set_cookie(
+        COOKIE_NAME, _make_cookie(username),
+        max_age=SESSION_HOURS * 3600, httponly=True, samesite="lax", path="/",
+    )
+    return response
+
+
+@app.get("/signup", response_class=HTMLResponse)
+async def signup_page():
+    return _signup_page()
+
+
+@app.post("/signup")
+async def signup_submit(request: Request):
+    form = await request.form()
+    username = (form.get("username") or "").strip().lower()
+    password = form.get("password") or ""
+
+    if not username or not password:
+        return HTMLResponse(_signup_page(error="Email and password are required."), status_code=400)
+    if len(password) < 8:
+        return HTMLResponse(_signup_page(error="Password must be at least 8 characters."), status_code=400)
+
+    users = _load_users()
+    if username in users:
+        return HTMLResponse(_signup_page(error="An account with that email already exists."), status_code=409)
+
+    users[username] = {
+        "username": username,
+        "password_hash": bcrypt.hash(password),
+    }
+    _save_users(users)
+
+    return RedirectResponse("/login?msg=Account+created.+Please+log+in.", status_code=302)
+
+
+@app.get("/auth")
+async def auth_check(request: Request):
+    """Validate session cookie.
+
+    Returns 200 + X-User-Email on success.
+    Returns 302 redirect to /login on failure. Builds an absolute URL from
+    X-Forwarded-* headers so Traefik's forwardAuth passes a browser-reachable
+    Location to the client.
+    """
+    cookie = request.cookies.get(COOKIE_NAME)
+    username = _verify_cookie(cookie) if cookie else None
+    if username:
+        return Response(status_code=200, headers={"X-User-Email": username})
+
+    # Build redirect URL from forwarded headers (set by Traefik)
+    proto = request.headers.get("x-forwarded-proto", "http")
+    host = request.headers.get("x-forwarded-host", request.headers.get("host", "localhost"))
+    login_url = f"{proto}://{host}/login"
+    return RedirectResponse(login_url, status_code=302)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,100 @@
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: atlas-nginx-prod
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/templates/default.conf.template:ro,Z
+    entrypoint: /bin/sh -c "RESOLVER=$$(awk '/^nameserver/{print $$2; exit}' /etc/resolv.conf) && sed \"s/__RESOLVER__/$$RESOLVER/g\" /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
+    depends_on:
+      - atlas-ui
+      - atlas-auth
+    networks:
+      - atlas-network
+    restart: unless-stopped
+
+  atlas-ui:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        VITE_APP_NAME: "${VITE_APP_NAME:-ATLAS}"
+        VITE_FEATURE_POWERED_BY_ATLAS: "${VITE_FEATURE_POWERED_BY_ATLAS:-false}"
+    container_name: atlas-ui-prod
+    env_file: ../.env
+    environment:
+      - DEBUG_MODE=false
+      - ATLAS_HOST=0.0.0.0
+      - PORT=8000
+      - S3_ENDPOINT=http://minio:9000
+      - AUTH_REDIRECT_URL=/login
+    volumes:
+      - ../config:/app/config:Z
+      - ../logs:/app/logs:Z
+    depends_on:
+      - minio
+    networks:
+      - atlas-network
+    restart: unless-stopped
+
+  atlas-auth:
+    build:
+      context: ./auth-service
+      dockerfile: Dockerfile
+    container_name: atlas-auth-prod
+    environment:
+      - ATLAS_AUTH_SECRET=${ATLAS_AUTH_SECRET}
+      - ATLAS_AUTH_SESSION_HOURS=${ATLAS_AUTH_SESSION_HOURS:-24}
+    volumes:
+      - ../data/auth:/data:Z
+    networks:
+      - atlas-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  minio:
+    image: minio/minio:latest
+    container_name: atlas-minio-prod
+    ports:
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-minioadmin}
+    volumes:
+      - ../data/minio:/data:Z
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - atlas-network
+    restart: unless-stopped
+
+  minio-init:
+    image: minio/mc:latest
+    container_name: atlas-minio-init-prod
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9000 $${MINIO_ROOT_USER:-minioadmin} $${MINIO_ROOT_PASSWORD:-minioadmin};
+      mc mb myminio/${S3_BUCKET_NAME:-atlas-files} --ignore-existing;
+      mc anonymous set download myminio/${S3_BUCKET_NAME:-atlas-files};
+      echo 'MinIO initialization complete';
+      "
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-minioadmin}
+    networks:
+      - atlas-network
+
+networks:
+  atlas-network:
+    driver: bridge

--- a/deploy/k3s/00-namespace.yaml
+++ b/deploy/k3s/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: atlas

--- a/deploy/k3s/01-secrets.yaml
+++ b/deploy/k3s/01-secrets.yaml
@@ -1,0 +1,59 @@
+---
+# Secret - sensitive values substituted from .env via envsubst at deploy time.
+# Do NOT commit this file with real values; run.sh generates it on the fly.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: atlas-secrets
+  namespace: atlas
+type: Opaque
+stringData:
+  ATLAS_AUTH_SECRET: "${ATLAS_AUTH_SECRET}"
+  OPENAI_API_KEY: "${OPENAI_API_KEY}"
+  ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
+  GOOGLE_API_KEY: "${GOOGLE_API_KEY}"
+  OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}"
+  CEREBRAS_API_KEY: "${CEREBRAS_API_KEY}"
+  GROQ_API_KEY: "${GROQ_API_KEY}"
+  S3_ACCESS_KEY: "${S3_ACCESS_KEY}"
+  S3_SECRET_KEY: "${S3_SECRET_KEY}"
+  CAPABILITY_TOKEN_SECRET: "${CAPABILITY_TOKEN_SECRET}"
+---
+# ConfigMap - non-sensitive environment variables
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atlas-config
+  namespace: atlas
+data:
+  DEBUG_MODE: "false"
+  ATLAS_HOST: "0.0.0.0"
+  PORT: "8000"
+  APP_NAME: "ATLAS"
+  ENVIRONMENT: "production"
+  USE_MOCK_S3: "false"
+  S3_ENDPOINT: "http://minio:9000"
+  S3_BUCKET_NAME: "${S3_BUCKET_NAME}"
+  S3_REGION: "us-east-1"
+  S3_TIMEOUT: "30"
+  S3_USE_SSL: "false"
+  LOG_LEVEL: "INFO"
+  AUTH_REDIRECT_URL: "/login"
+  ATLAS_AUTH_SESSION_HOURS: "${ATLAS_AUTH_SESSION_HOURS}"
+  FEATURE_RAG_ENABLED: "false"
+  FEATURE_TOOLS_ENABLED: "true"
+  FEATURE_MARKETPLACE_ENABLED: "true"
+  FEATURE_FILES_PANEL_ENABLED: "true"
+  FEATURE_CHAT_HISTORY_ENABLED: "false"
+  FEATURE_AGENT_MODE_AVAILABLE: "true"
+  FEATURE_METRICS_LOGGING_ENABLED: "false"
+  FEATURE_SUPPRESS_LITELLM_LOGGING: "true"
+  BANNER_ENABLED: "true"
+  USE_NEW_FRONTEND: "true"
+  AGENT_MAX_STEPS: "30"
+  AGENT_DEFAULT_ENABLED: "true"
+  AGENT_LOOP_STRATEGY: "think-act"
+  REQUIRE_TOOL_APPROVAL_BY_DEFAULT: "false"
+  FORCE_TOOL_APPROVAL_GLOBALLY: "false"
+  MCP_DISCOVERY_TIMEOUT: "30"
+  MCP_CALL_TIMEOUT: "120"

--- a/deploy/k3s/10-atlas-auth.yaml
+++ b/deploy/k3s/10-atlas-auth.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atlas-auth
+  namespace: atlas
+  labels:
+    app: atlas-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: atlas-auth
+  template:
+    metadata:
+      labels:
+        app: atlas-auth
+    spec:
+      containers:
+        - name: atlas-auth
+          image: localhost/atlas-auth:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 5000
+          env:
+            - name: ATLAS_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-secrets
+                  key: ATLAS_AUTH_SECRET
+            - name: ATLAS_AUTH_SESSION_HOURS
+              valueFrom:
+                configMapKeyRef:
+                  name: atlas-config
+                  key: ATLAS_AUTH_SESSION_HOURS
+          volumeMounts:
+            - name: auth-data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: auth-data
+          hostPath:
+            path: /home/garlan/prod-atlas/atlas-ui-3/data/auth
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: atlas-auth
+  namespace: atlas
+spec:
+  selector:
+    app: atlas-auth
+  ports:
+    - port: 5000
+      targetPort: 5000

--- a/deploy/k3s/11-atlas-ui.yaml
+++ b/deploy/k3s/11-atlas-ui.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atlas-ui
+  namespace: atlas
+  labels:
+    app: atlas-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: atlas-ui
+  template:
+    metadata:
+      labels:
+        app: atlas-ui
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: atlas-ui
+          image: localhost/atlas-ui:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: atlas-config
+            - secretRef:
+                name: atlas-secrets
+          volumeMounts:
+            - name: app-config
+              mountPath: /app/config
+            - name: app-logs
+              mountPath: /app/logs
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 30
+      volumes:
+        - name: app-config
+          hostPath:
+            path: /home/garlan/prod-atlas/atlas-ui-3/config
+            type: DirectoryOrCreate
+        - name: app-logs
+          hostPath:
+            path: /home/garlan/prod-atlas/atlas-ui-3/logs
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: atlas-ui
+  namespace: atlas
+spec:
+  selector:
+    app: atlas-ui
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/deploy/k3s/12-minio.yaml
+++ b/deploy/k3s/12-minio.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: atlas
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-secrets
+                  key: S3_ACCESS_KEY
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-secrets
+                  key: S3_SECRET_KEY
+          volumeMounts:
+            - name: minio-data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+      volumes:
+        - name: minio-data
+          hostPath:
+            path: /home/garlan/prod-atlas/atlas-ui-3/data/minio
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: atlas
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001

--- a/deploy/k3s/13-minio-init-job.yaml
+++ b/deploy/k3s/13-minio-init-job.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-init
+  namespace: atlas
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        app: minio-init
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-minio
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for minio to be ready..."
+              until wget -qO- http://minio:9000/minio/health/ready 2>/dev/null; do
+                echo "  minio not ready yet, retrying in 3s..."
+                sleep 3
+              done
+              echo "minio is ready."
+      containers:
+        - name: minio-init
+          image: minio/mc:latest
+          command:
+            - sh
+            - -c
+            - |
+              mc alias set myminio http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+              mc mb myminio/${S3_BUCKET_NAME} --ignore-existing
+              mc anonymous set download myminio/${S3_BUCKET_NAME}
+              echo "MinIO initialization complete"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-secrets
+                  key: S3_ACCESS_KEY
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: atlas-secrets
+                  key: S3_SECRET_KEY
+            - name: S3_BUCKET_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: atlas-config
+                  key: S3_BUCKET_NAME

--- a/deploy/k3s/20-middleware.yaml
+++ b/deploy/k3s/20-middleware.yaml
@@ -1,0 +1,37 @@
+# Strip any client-provided X-User-Email header before forwarding.
+# This prevents clients from spoofing the trusted auth header.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-client-auth-header
+  namespace: atlas
+spec:
+  headers:
+    customRequestHeaders:
+      X-User-Email: ""
+---
+# Forward authentication to the atlas-auth service.
+# On 2xx, Traefik copies the X-User-Email response header to the upstream request.
+# On non-2xx (302 redirect), Traefik passes the auth response to the client.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: atlas-forward-auth
+  namespace: atlas
+spec:
+  forwardAuth:
+    address: http://atlas-auth.atlas.svc.cluster.local:5000/auth
+    authResponseHeaders:
+      - X-User-Email
+---
+# Chain: strip header first, then forward-auth.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: auth-chain
+  namespace: atlas
+spec:
+  chain:
+    middlewares:
+      - name: strip-client-auth-header
+      - name: atlas-forward-auth

--- a/deploy/k3s/21-ingressroute.yaml
+++ b/deploy/k3s/21-ingressroute.yaml
@@ -1,0 +1,38 @@
+# Public routes - login and signup pages (no auth required)
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: atlas-public
+  namespace: atlas
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: PathPrefix(`/login`)
+      kind: Rule
+      services:
+        - name: atlas-auth
+          port: 5000
+    - match: PathPrefix(`/signup`)
+      kind: Rule
+      services:
+        - name: atlas-auth
+          port: 5000
+---
+# Protected routes - everything else goes through auth chain
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: atlas-protected
+  namespace: atlas
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: PathPrefix(`/`)
+      kind: Rule
+      middlewares:
+        - name: auth-chain
+      services:
+        - name: atlas-ui
+          port: 8000

--- a/deploy/k3s/run.sh
+++ b/deploy/k3s/run.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+K3S_MANIFESTS="$SCRIPT_DIR"
+NAMESPACE="atlas"
+
+# ---------------------------------------------------------------------------
+# Load .env for variable interpolation
+# ---------------------------------------------------------------------------
+load_env() {
+    if [ -f "$PROJECT_ROOT/.env" ]; then
+        set -a
+        # shellcheck disable=SC1091
+        . "$PROJECT_ROOT/.env"
+        set +a
+    else
+        echo "Warning: $PROJECT_ROOT/.env not found"
+    fi
+
+    # Defaults for variables that may not be in .env
+    export S3_BUCKET_NAME="${S3_BUCKET_NAME:-atlas-files}"
+    export S3_ACCESS_KEY="${S3_ACCESS_KEY:-minioadmin}"
+    export S3_SECRET_KEY="${S3_SECRET_KEY:-minioadmin}"
+    export ATLAS_AUTH_SESSION_HOURS="${ATLAS_AUTH_SESSION_HOURS:-24}"
+    export VITE_APP_NAME="${VITE_APP_NAME:-ATLAS}"
+    export VITE_FEATURE_POWERED_BY_ATLAS="${VITE_FEATURE_POWERED_BY_ATLAS:-false}"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+kubectl_cmd() {
+    sudo k3s kubectl "$@"
+}
+
+# Map friendly service names to deployment names
+resolve_deployment() {
+    local svc="${1:-}"
+    case "$svc" in
+        atlas-auth|auth)  echo "atlas-auth" ;;
+        atlas-ui|ui)      echo "atlas-ui" ;;
+        minio)            echo "minio" ;;
+        *)                echo "$svc" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+cmd_build() {
+    echo "Building container images with podman..."
+
+    echo "  Building atlas-ui..."
+    podman build \
+        --build-arg VITE_APP_NAME="${VITE_APP_NAME:-ATLAS}" \
+        --build-arg VITE_FEATURE_POWERED_BY_ATLAS="${VITE_FEATURE_POWERED_BY_ATLAS:-false}" \
+        -t localhost/atlas-ui:latest \
+        -f "$PROJECT_ROOT/Dockerfile" \
+        "$PROJECT_ROOT"
+
+    echo "  Building atlas-auth..."
+    podman build \
+        -t localhost/atlas-auth:latest \
+        -f "$PROJECT_ROOT/deploy/auth-service/Dockerfile" \
+        "$PROJECT_ROOT/deploy/auth-service"
+
+    echo "Importing images into k3s containerd..."
+    podman save localhost/atlas-ui:latest | sudo k3s ctr images import -
+    podman save localhost/atlas-auth:latest | sudo k3s ctr images import -
+
+    echo "Build complete. Images imported into k3s."
+}
+
+cmd_up() {
+    load_env
+
+    echo "Deploying ATLAS to k3s..."
+
+    # Apply namespace first
+    kubectl_cmd apply -f "$K3S_MANIFESTS/00-namespace.yaml"
+
+    # Generate secrets from template using envsubst
+    echo "  Generating secrets from .env..."
+    envsubst < "$K3S_MANIFESTS/01-secrets.yaml" | kubectl_cmd apply -f -
+
+    # Apply deployments and services
+    kubectl_cmd apply -f "$K3S_MANIFESTS/10-atlas-auth.yaml"
+    kubectl_cmd apply -f "$K3S_MANIFESTS/11-atlas-ui.yaml"
+    kubectl_cmd apply -f "$K3S_MANIFESTS/12-minio.yaml"
+
+    # Delete previous init job if it exists, then recreate
+    kubectl_cmd delete job minio-init -n "$NAMESPACE" --ignore-not-found
+    envsubst < "$K3S_MANIFESTS/13-minio-init-job.yaml" | kubectl_cmd apply -f -
+
+    # Apply Traefik middleware and ingress routes
+    kubectl_cmd apply -f "$K3S_MANIFESTS/20-middleware.yaml"
+    kubectl_cmd apply -f "$K3S_MANIFESTS/21-ingressroute.yaml"
+
+    # Copy Traefik config to K3s manifests dir (auto-applied by K3s)
+    echo "  Configuring Traefik..."
+    sudo cp "$K3S_MANIFESTS/traefik-config.yaml" /var/lib/rancher/k3s/server/manifests/traefik-config.yaml
+
+    # Wait for rollouts
+    echo "  Waiting for deployments to be ready..."
+    kubectl_cmd rollout status deployment/atlas-auth -n "$NAMESPACE" --timeout=120s
+    kubectl_cmd rollout status deployment/minio -n "$NAMESPACE" --timeout=120s
+    kubectl_cmd rollout status deployment/atlas-ui -n "$NAMESPACE" --timeout=180s
+
+    echo ""
+    echo "ATLAS is deployed. Access at http://localhost:8080"
+}
+
+cmd_down() {
+    echo "Tearing down ATLAS..."
+    kubectl_cmd delete namespace "$NAMESPACE" --ignore-not-found
+    echo "Namespace '$NAMESPACE' deleted."
+}
+
+cmd_restart() {
+    if [ $# -gt 0 ]; then
+        local deploy
+        deploy=$(resolve_deployment "$1")
+        echo "Restarting deployment/$deploy..."
+        kubectl_cmd rollout restart "deployment/$deploy" -n "$NAMESPACE"
+        kubectl_cmd rollout status "deployment/$deploy" -n "$NAMESPACE" --timeout=120s
+    else
+        echo "Restarting all deployments..."
+        kubectl_cmd rollout restart deployment -n "$NAMESPACE"
+        kubectl_cmd rollout status deployment -n "$NAMESPACE" --timeout=180s
+    fi
+}
+
+cmd_logs() {
+    if [ $# -gt 0 ]; then
+        local deploy
+        deploy=$(resolve_deployment "$1")
+        shift
+        kubectl_cmd logs -f "deployment/$deploy" -n "$NAMESPACE" "$@"
+    else
+        # Follow all pods in the namespace
+        kubectl_cmd logs -f --all-containers --max-log-requests=10 -n "$NAMESPACE" -l 'app in (atlas-auth,atlas-ui,minio)'
+    fi
+}
+
+cmd_status() {
+    echo "=== Nodes ==="
+    kubectl_cmd get nodes
+    echo ""
+    echo "=== Namespace: $NAMESPACE ==="
+    kubectl_cmd get all -n "$NAMESPACE" 2>/dev/null || echo "(namespace not found)"
+    echo ""
+    echo "=== IngressRoutes ==="
+    kubectl_cmd get ingressroute -n "$NAMESPACE" 2>/dev/null || echo "(none)"
+    echo ""
+    echo "=== Middlewares ==="
+    kubectl_cmd get middleware -n "$NAMESPACE" 2>/dev/null || echo "(none)"
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<EOF
+ATLAS K3s Deployment
+
+Usage: $0 <command> [args...]
+
+Commands:
+  build              Build images with podman and import into k3s
+  up                 Deploy all manifests to k3s
+  down               Delete the atlas namespace (removes everything)
+  restart [svc]      Restart deployment(s): atlas-auth, atlas-ui, minio
+  logs    [svc]      Follow logs for a deployment (or all)
+  status             Show cluster and namespace status
+
+Service aliases:
+  auth, atlas-auth   -> atlas-auth deployment
+  ui, atlas-ui       -> atlas-ui deployment
+  minio              -> minio deployment
+
+Examples:
+  $0 build                   # Build and import images
+  $0 up                      # Deploy everything
+  $0 logs atlas-auth         # Follow auth service logs
+  $0 restart ui              # Restart the UI deployment
+  $0 down                    # Tear down everything
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+load_env
+
+case "${1:-}" in
+    build)   shift; cmd_build "$@" ;;
+    up)      shift; cmd_up "$@" ;;
+    down)    shift; cmd_down "$@" ;;
+    restart) shift; cmd_restart "$@" ;;
+    logs)    shift; cmd_logs "$@" ;;
+    status)  shift; cmd_status "$@" ;;
+    -h|--help|help|"")
+        usage ;;
+    *)
+        echo "Unknown command: $1"
+        usage
+        exit 1 ;;
+esac

--- a/deploy/k3s/traefik-config.yaml
+++ b/deploy/k3s/traefik-config.yaml
@@ -1,0 +1,15 @@
+# HelmChartConfig to override Traefik's default ports.
+# K3s auto-applies files placed in /var/lib/rancher/k3s/server/manifests/
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    ports:
+      web:
+        exposedPort: 8080
+    logs:
+      general:
+        level: INFO

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,102 @@
+# ATLAS Production Nginx Configuration
+# Reverse proxy with auth_request-based authentication
+#
+# Uses variable-based proxy_pass so nginx resolves DNS at request time
+# (not at startup), which avoids failures when other containers aren't
+# registered in podman DNS yet.
+
+server {
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
+    server_tokens off;
+    port_in_redirect off;
+
+    client_max_body_size 50m;
+
+    # Use the container DNS resolver; re-resolve every 30s
+    # __RESOLVER__ is replaced at container startup by the entrypoint
+    resolver __RESOLVER__ valid=30s;
+
+    set $ui_upstream   http://atlas-ui:8000;
+    set $auth_upstream http://atlas-auth:5000;
+
+    # Login and signup - routed to auth service, no auth required
+    location ~ ^/(login|signup)$ {
+        proxy_pass $auth_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # Internal auth check endpoint
+    location = /auth-check {
+        internal;
+        proxy_pass $auth_upstream/auth;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URI $request_uri;
+        proxy_set_header Cookie $http_cookie;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # Auth service health check (no auth required)
+    location = /auth/health {
+        proxy_pass $auth_upstream/health;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # File downloads - requires auth
+    location /api/files/download/ {
+        auth_request /auth-check;
+        auth_request_set $auth_user_email $upstream_http_x_user_email;
+        error_page 401 = @do_login_redirect;
+
+        proxy_pass $ui_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        # CRITICAL SECURITY: Strip client-provided header, then set from auth
+        proxy_set_header X-User-Email "";
+        proxy_set_header X-User-Email $auth_user_email;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+
+    # Everything else - requires auth, includes WebSocket support
+    location / {
+        auth_request /auth-check;
+        auth_request_set $auth_user_email $upstream_http_x_user_email;
+        error_page 401 = @do_login_redirect;
+
+        proxy_pass $ui_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        # CRITICAL SECURITY: Strip client-provided header, then set from auth
+        proxy_set_header X-User-Email "";
+        proxy_set_header X-User-Email $auth_user_email;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+
+        # WebSocket support
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
+
+    # Redirect 401 to login page
+    location @do_login_redirect {
+        return 302 /login;
+    }
+}

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.prod.yml"
+
+# ---------------------------------------------------------------------------
+# Load .env for variable interpolation
+# ---------------------------------------------------------------------------
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$PROJECT_ROOT/.env"
+    set +a
+fi
+
+# ---------------------------------------------------------------------------
+# Auto-detect compose command
+# ---------------------------------------------------------------------------
+detect_compose() {
+    if command -v podman-compose &>/dev/null && podman-compose version &>/dev/null 2>&1; then
+        echo "podman-compose"
+    elif podman compose version &>/dev/null 2>&1; then
+        echo "podman compose"
+    elif docker compose version &>/dev/null 2>&1; then
+        echo "docker compose"
+    elif command -v docker-compose &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo ""
+    fi
+}
+
+COMPOSE_CMD=$(detect_compose)
+if [ -z "$COMPOSE_CMD" ]; then
+    echo "Error: No container compose tool found."
+    echo "Install one of: podman-compose, podman compose, docker compose, docker-compose"
+    exit 1
+fi
+
+echo "Using: $COMPOSE_CMD"
+
+compose() {
+    $COMPOSE_CMD -f "$COMPOSE_FILE" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+cmd_build() {
+    echo "Building images..."
+    compose build "$@"
+}
+
+cmd_up() {
+    echo "Starting stack..."
+    compose up -d "$@"
+    echo ""
+    echo "Stack is up. Access ATLAS at http://localhost:8080"
+}
+
+cmd_down() {
+    echo "Stopping stack..."
+    compose down "$@"
+}
+
+cmd_restart() {
+    if [ $# -gt 0 ]; then
+        echo "Restarting: $*"
+        compose restart "$@"
+    else
+        echo "Restarting entire stack..."
+        compose down
+        compose up -d
+    fi
+}
+
+cmd_logs() {
+    compose logs "$@"
+}
+
+cmd_status() {
+    compose ps "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<EOF
+ATLAS Production Deployment
+
+Usage: $0 <command> [args...]
+
+Commands:
+  build   [svc...]   Build (or rebuild) container images
+  up      [svc...]   Start the stack in detached mode
+  down    [args...]  Stop and remove containers
+  restart [svc...]   Restart services (or full stack if no args)
+  logs    [args...]  View container logs (e.g. -f atlas-auth)
+  status  [args...]  Show container status
+
+Examples:
+  $0 build                   # Build all images
+  $0 up                      # Start everything
+  $0 logs -f atlas-auth      # Follow auth service logs
+  $0 restart atlas-ui        # Restart just the UI
+  $0 down                    # Stop everything
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+    build)   shift; cmd_build "$@" ;;
+    up)      shift; cmd_up "$@" ;;
+    down)    shift; cmd_down "$@" ;;
+    restart) shift; cmd_restart "$@" ;;
+    logs)    shift; cmd_logs "$@" ;;
+    status)  shift; cmd_status "$@" ;;
+    -h|--help|help|"")
+        usage ;;
+    *)
+        echo "Unknown command: $1"
+        usage
+        exit 1 ;;
+esac

--- a/prod-readme.md
+++ b/prod-readme.md
@@ -1,0 +1,323 @@
+# ATLAS Production Setup Guide
+
+Last updated: 2026-02-09
+
+This guide covers how to run ATLAS on this Ubuntu machine using K3s (lightweight Kubernetes) and make it accessible to other devices on your local network (and optionally from the internet).
+
+---
+
+## 1. Prerequisites
+
+- Ubuntu 24.04 (this machine)
+- Podman (for building container images)
+- K3s (installed in step 2 below)
+- Git access to the repo
+
+No local Python, Node.js, or `.venv` needed - everything runs in containers.
+
+## 2. Current Configuration
+
+| Setting | Value |
+|---------|-------|
+| Port | **8080** (Traefik ingress, built into K3s) |
+| S3 Storage | **MinIO** (K8s deployment) |
+| Auth | Cookie-based signup/login (bcrypt passwords) |
+| DNS | **CoreDNS** (built into K3s) |
+| Ingress | **Traefik** (built into K3s) |
+| This machine's LAN IP | `192.168.50.61` |
+| Default gateway / router | `192.168.50.1` |
+
+## 3. Install K3s
+
+```bash
+# Install K3s (single-node, includes Traefik + CoreDNS)
+curl -sfL https://get.k3s.io | sh -
+
+# Set up kubeconfig for non-root usage
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+export KUBECONFIG=~/.kube/config
+
+# Verify K3s is running
+sudo k3s kubectl get nodes
+```
+
+## 4. Open Port 8080 on This Machine (UFW Firewall)
+
+```bash
+# Check if ufw is active
+sudo ufw status
+
+# If ufw is inactive, enable it (this will also allow SSH so you don't lock yourself out)
+sudo ufw allow OpenSSH
+sudo ufw enable
+
+# Allow port 8080 from your LAN subnet only (recommended)
+sudo ufw allow from 192.168.50.0/24 to any port 8080 proto tcp
+
+# OR allow port 8080 from anywhere (needed if you want internet access)
+# sudo ufw allow 8080/tcp
+
+# Verify the rule was added
+sudo ufw status numbered
+```
+
+## 5. Architecture
+
+```
+     LAN :8080
+          |
+     [Traefik - built into K3s]
+          |
+    IngressRoute rules:
+          |
+   /login, /signup -----> [atlas-auth Service :5000]  (no middleware)
+          |
+   / , /api/*, /ws -----> strip-header middleware
+                              |
+                           forwardAuth middleware -> [atlas-auth :5000/auth]
+                              |                      (copies X-User-Email)
+                           [atlas-ui Service :8000]
+          |
+   (internal only) ------> [minio Service :9000]
+```
+
+Traefik replaces the old nginx container. Its `forwardAuth` middleware is equivalent to nginx `auth_request`. A `headers` middleware strips client-provided `X-User-Email` before forwardAuth sets the trusted value. CoreDNS provides reliable service discovery (no more podman DNS issues).
+
+## 6. Deploy
+
+```bash
+cd /home/garlan/prod-atlas/atlas-ui-3/deploy/k3s
+
+# Build all container images and import into k3s
+./run.sh build
+
+# Deploy to k3s
+./run.sh up
+
+# Check status
+./run.sh status
+```
+
+Access ATLAS at `http://localhost:8080`. You'll be redirected to `/login`. Click "Create an account" to sign up, then log in.
+
+## 7. Management Commands
+
+```bash
+cd /home/garlan/prod-atlas/atlas-ui-3/deploy/k3s
+
+./run.sh build                   # Build images and import into k3s
+./run.sh up                      # Deploy all manifests
+./run.sh down                    # Delete atlas namespace (removes everything)
+./run.sh restart                 # Restart all deployments
+./run.sh restart atlas-ui        # Restart just the UI
+./run.sh restart auth            # Restart just the auth service
+./run.sh logs atlas-auth         # Follow auth service logs
+./run.sh logs ui                 # Follow UI logs
+./run.sh status                  # Show cluster and namespace status
+```
+
+## 8. Access from Other Devices on Your Network
+
+Once ATLAS is running and the firewall is open:
+
+| Device | URL |
+|--------|-----|
+| This machine | `http://localhost:8080` |
+| Other LAN devices | `http://192.168.50.61:8080` |
+
+## 9. Router Configuration (Port Forwarding)
+
+If you want devices **outside** your local network (i.e., from the internet) to access ATLAS, set up port forwarding on your router.
+
+1. **Open your router admin panel** - go to `http://192.168.50.1` in a browser
+2. **Find Port Forwarding** - usually under "Advanced" > "Port Forwarding" or "NAT/Gaming"
+3. **Create a new rule:**
+
+   | Field | Value |
+   |-------|-------|
+   | Service Name | `ATLAS` |
+   | Protocol | `TCP` |
+   | External Port | `8080` (or `80`) |
+   | Internal IP | `192.168.50.61` |
+   | Internal Port | `8080` |
+
+4. **Save and apply**
+
+Find your public IP: `curl -s ifconfig.me`
+
+## 10. Static IP (Recommended)
+
+Your LAN IP may change if assigned via DHCP.
+
+### Option A: Reserve the IP on your router (easiest)
+
+1. Go to router admin (`http://192.168.50.1`)
+2. Find "DHCP Reservation" (usually under LAN/DHCP settings)
+3. Add a reservation for this machine's MAC address to `192.168.50.61`
+
+### Option B: Set a static IP on this machine
+
+```bash
+sudo nano /etc/netplan/01-network-manager-all.yaml
+```
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    eno1:  # check with: ip link show
+      dhcp4: no
+      addresses:
+        - 192.168.50.61/24
+      routes:
+        - to: default
+          via: 192.168.50.1
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 8.8.4.4
+```
+
+```bash
+sudo netplan apply
+```
+
+## 11. Start on Boot (systemd)
+
+K3s itself starts on boot automatically. To auto-deploy the ATLAS namespace on boot:
+
+```bash
+sudo tee /etc/systemd/system/atlas.service << 'EOF'
+[Unit]
+Description=ATLAS UI K3s Deployment
+After=k3s.service
+Requires=k3s.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=root
+WorkingDirectory=/home/garlan/prod-atlas/atlas-ui-3/deploy/k3s
+ExecStart=/home/garlan/prod-atlas/atlas-ui-3/deploy/k3s/run.sh up
+ExecStop=/home/garlan/prod-atlas/atlas-ui-3/deploy/k3s/run.sh down
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable atlas
+sudo systemctl start atlas
+
+# Check status
+sudo systemctl status atlas
+```
+
+## 12. User Accounts
+
+User accounts are stored in `data/auth/users.json` (bcrypt-hashed passwords). This file persists across pod restarts via a hostPath volume mount.
+
+To see registered users:
+
+```bash
+cat /home/garlan/prod-atlas/atlas-ui-3/data/auth/users.json | python3 -m json.tool
+```
+
+## 13. Troubleshooting
+
+### Can't access from other devices
+
+```bash
+# 1. Verify K3s is running
+sudo k3s kubectl get nodes
+
+# 2. Verify pods are running
+cd /home/garlan/prod-atlas/atlas-ui-3/deploy/k3s && ./run.sh status
+
+# 3. Verify firewall is open
+sudo ufw status | grep 8080
+
+# 4. Test from this machine
+curl -s http://localhost:8080 | head -5
+
+# 5. Test from another machine on the LAN
+curl -s http://192.168.50.61:8080 | head -5
+```
+
+### Pod won't start
+
+```bash
+# Check pod events for errors
+sudo k3s kubectl describe pod -n atlas -l app=atlas-ui
+
+# Check if images are imported
+sudo k3s ctr images list | grep atlas
+
+# Rebuild and reimport images
+./run.sh build
+./run.sh restart ui
+```
+
+### Image pull errors (ErrImageNeverPull)
+
+This means the image hasn't been imported into k3s containerd. Rebuild:
+
+```bash
+./run.sh build
+```
+
+### Check logs
+
+```bash
+cd /home/garlan/prod-atlas/atlas-ui-3/deploy/k3s
+./run.sh logs atlas-auth         # Auth service
+./run.sh logs ui                 # ATLAS UI
+./run.sh logs minio              # MinIO storage
+
+# Or directly with kubectl
+sudo k3s kubectl logs -f deployment/atlas-ui -n atlas
+```
+
+### Traefik issues
+
+```bash
+# Check Traefik logs
+sudo k3s kubectl logs -f -n kube-system -l app.kubernetes.io/name=traefik
+
+# Verify IngressRoutes
+sudo k3s kubectl get ingressroute -n atlas
+
+# Verify middlewares
+sudo k3s kubectl get middleware -n atlas
+```
+
+### Reset everything
+
+```bash
+# Delete the namespace and redeploy
+./run.sh down
+./run.sh up
+```
+
+## 14. Podman-Compose (Legacy Alternative)
+
+The old podman-compose deployment files are still available at `deploy/docker-compose.prod.yml`, `deploy/nginx.conf`, and `deploy/run.sh` if you prefer compose over K3s.
+
+## Quick Reference
+
+| What | Command / URL |
+|------|---------------|
+| Start stack | `cd deploy/k3s && ./run.sh up` |
+| Stop stack | `cd deploy/k3s && ./run.sh down` |
+| Rebuild + restart | `cd deploy/k3s && ./run.sh build && ./run.sh up` |
+| Update from git | `git pull && cd deploy/k3s && ./run.sh build && ./run.sh up` |
+| View logs | `cd deploy/k3s && ./run.sh logs` |
+| Pod status | `cd deploy/k3s && ./run.sh status` |
+| Local access | `http://localhost:8080` |
+| LAN access | `http://192.168.50.61:8080` |
+| Router admin | `http://192.168.50.1` |
+| User accounts | `cat data/auth/users.json` |
+| Firewall status | `sudo ufw status` |
+| K3s node status | `sudo k3s kubectl get nodes` |


### PR DESCRIPTION
## Summary
- Migrate from podman-compose + nginx to K3s for single-node production deployment
- Add Traefik IngressRoute with forwardAuth middleware (replaces nginx container)
- Add K8s manifests (namespace, secrets, deployments, services, middleware, ingress)
- Add `deploy/k3s/run.sh` management script (build, up, down, restart, logs, status)
- Modify auth service `/auth` endpoint to return 302 redirect for Traefik compatibility
- Pin bcrypt<4.1 for passlib compatibility
- Add garland3@gmail.com to admin group
- Update prod-readme.md for K3s workflow
- Keep legacy podman-compose files as alternative

## Test plan
- [ ] `sudo k3s kubectl get nodes` - K3s running
- [ ] `./deploy/k3s/run.sh build` - images built and imported
- [ ] `./deploy/k3s/run.sh up` - all pods Running
- [ ] `./deploy/k3s/run.sh status` - shows deployments, services, pods
- [ ] `http://localhost:8080` redirects to `/login`
- [ ] Sign up and login work
- [ ] ATLAS UI loads after login
- [ ] WebSocket chat works
- [ ] `http://192.168.50.61:8080` works from LAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)