### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,15 +22,15 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -54,7 +54,7 @@ jobs:
         run: twine check dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-distributions
           path: dist/
@@ -69,7 +69,7 @@ jobs:
       url: https://test.pypi.org/p/atlas-chat
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -90,7 +90,7 @@ jobs:
       url: https://pypi.org/p/atlas-chat
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -109,7 +109,7 @@ jobs:
       contents: write
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #333 - 2026-02-11
+- **CI**: Update GitHub Actions versions in pypi-publish.yml: checkout v4->v6, setup-python v5->v6, setup-node v4->v6, upload-artifact v4->v6, download-artifact v4->v7. Combines Dependabot PRs #328-#332.
+
 ### PR #318 - 2026-02-10
 - **Feature**: Per-user LLM API keys. Models can be configured with `api_key_source: "user"` in `llmconfig.yml` so users bring their own API keys, stored encrypted via the existing MCP token storage infrastructure.
 - **API**: New REST endpoints at `/api/llm/auth/` for uploading, checking, and removing per-user LLM API keys.


### PR DESCRIPTION
## Summary
- Update actions/checkout from v4 to v6
- Update actions/setup-python from v5 to v6
- Update actions/setup-node from v4 to v6
- Update actions/upload-artifact from v4 to v6
- Update actions/download-artifact from v4 to v7

This PR combines the following Dependabot PRs:
- #328 (actions/upload-artifact v4->v6)
- #329 (actions/setup-python v5->v6)
- #330 (actions/download-artifact v4->v7)
- #331 (actions/checkout v4->v6)
- #332 (actions/setup-node v4->v6)

## Test plan
- [x] All backend tests pass (787 tests)
- [x] All frontend tests pass (221 tests)
- [x] All E2E tests pass (5 tests)

Generated with [Claude Code](https://claude.com/claude-code)