### PR TITLE
Suppress startup noise: FastMCP banners, dead RAGClient, verbose MCP logging

### DIFF
--- a/atlas/mcp/api_key_demo/main.py
+++ b/atlas/mcp/api_key_demo/main.py
@@ -169,4 +169,4 @@ if __name__ == "__main__":
     print(f"Valid API key count: {len(API_KEY_USERS)} (use list_valid_keys tool to see them)")
     print("\nTo test, set your API key in Atlas UI or use the FastMCP client.")
 
-    mcp.run(transport="streamable-http", host="0.0.0.0", port=port)
+    mcp.run(transport="streamable-http", host="0.0.0.0", port=port, show_banner=False)

--- a/atlas/mcp/basictable/main.py
+++ b/atlas/mcp/basictable/main.py
@@ -144,4 +144,4 @@ def analyze_spreadsheet(
 
 if __name__ == "__main__":
     print("Starting CSV/XLSX Analyzer MCP server...")
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/calculator/main.py
+++ b/atlas/mcp/calculator/main.py
@@ -146,4 +146,4 @@ def _finalize_meta(meta: Dict[str, Any], start: float) -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/code-executor/main.py
+++ b/atlas/mcp/code-executor/main.py
@@ -33,23 +33,16 @@ VERBOSE = False
 
 # Configure logging to use main app log with prefix
 current_dir = Path(__file__).parent
-print(f"Current dir: {current_dir.absolute()}")
 atlas_dir = current_dir.parent.parent
-print(f"Atlas dir: {atlas_dir.absolute()}")
 project_root = atlas_dir.parent
-print(f"Project root: {project_root.absolute()}")
 logs_dir = project_root / 'logs'
-print(f"Logs dir: {logs_dir.absolute()}")
+logs_dir.mkdir(parents=True, exist_ok=True)
 main_log_path = logs_dir / 'app.jsonl'
-print(f"Log path: {main_log_path.absolute()}")
-print(f"Log path exists: {main_log_path.exists()}")
-print(f"Logs dir exists: {logs_dir.exists()}")
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - CODE_EXECUTOR - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(main_log_path),
-        logging.StreamHandler()
+        logging.FileHandler(main_log_path)
     ]
 )
 logger = logging.getLogger(__name__)
@@ -525,4 +518,4 @@ def execute_python_code_with_file(
             }
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/corporate_cars/main.py
+++ b/atlas/mcp/corporate_cars/main.py
@@ -434,4 +434,4 @@ def rag_get_synthesized_results(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/csv_reporter/main.py
+++ b/atlas/mcp/csv_reporter/main.py
@@ -542,4 +542,4 @@ def plot_time_series(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/duckduckgo/main.py
+++ b/atlas/mcp/duckduckgo/main.py
@@ -179,4 +179,4 @@ def search_and_fetch(query: str, max_results: Union[str, int] = 3) -> Dict[str, 
 if __name__ == "__main__":
     # To run this server, you need to install the required libraries:
     # pip install fastmcp duckduckgo-search requests beautifulsoup4
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/elicitation_demo/main.py
+++ b/atlas/mcp/elicitation_demo/main.py
@@ -259,4 +259,4 @@ async def approve_deletion(ctx: Context) -> str:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/env-demo/main.py
+++ b/atlas/mcp/env-demo/main.py
@@ -196,4 +196,4 @@ def demonstrate_env_usage(operation: str = "info") -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/file_size_test/main.py
+++ b/atlas/mcp/file_size_test/main.py
@@ -281,4 +281,4 @@ def _format_size(size_bytes: int) -> str:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/filesystem/main.py
+++ b/atlas/mcp/filesystem/main.py
@@ -345,4 +345,4 @@ def file_exists(path: str) -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/image_demo/main.py
+++ b/atlas/mcp/image_demo/main.py
@@ -110,4 +110,4 @@ def generate_multiple_images() -> ToolResult:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/logging_demo/main.py
+++ b/atlas/mcp/logging_demo/main.py
@@ -100,4 +100,4 @@ async def test_logging(operation: str, ctx: Context) -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/many_tools_demo/main.py
+++ b/atlas/mcp/many_tools_demo/main.py
@@ -46,5 +46,5 @@ def {tool_name}(input_data: str = "default") -> str:
 """)
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)
 

--- a/atlas/mcp/order_database/main.py
+++ b/atlas/mcp/order_database/main.py
@@ -366,4 +366,4 @@ def get_signal_data_csv() -> Dict[str, Any]:
         }
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/pdfbasic/main.py
+++ b/atlas/mcp/pdfbasic/main.py
@@ -391,4 +391,4 @@ def generate_report_about_pdf(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/pptx_generator/main.py
+++ b/atlas/mcp/pptx_generator/main.py
@@ -35,35 +35,20 @@ from pptx.util import Inches, Pt
 # Configuration
 VERBOSE = True
 
-# Configure logging first
+# Configure logging (file-only to avoid polluting stdio)
+current_dir = Path(__file__).parent
+atlas_dir = current_dir.parent.parent
+logs_dir = atlas_dir.parent / 'logs'
+logs_dir.mkdir(parents=True, exist_ok=True)
+main_log_path = logs_dir / 'app.jsonl'
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - PPTX_GENERATOR - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.StreamHandler()
+        logging.FileHandler(main_log_path)
     ]
 )
 logger = logging.getLogger(__name__)
-
-# Configure paths and add file handler if available
-current_dir = Path(__file__).parent
-logger.info(f"Current dir: {current_dir.absolute()}")
-atlas_dir = current_dir.parent.parent
-logger.info(f"Atlas dir: {atlas_dir.absolute()}")
-project_root = atlas_dir.parent
-logger.info(f"Project root: {project_root.absolute()}")
-logs_dir = project_root / 'logs'
-logger.info(f"Logs dir: {logs_dir.absolute()}")
-main_log_path = logs_dir / 'app.jsonl'
-logger.info(f"Log path: {main_log_path.absolute()}")
-logger.info(f"Log path exists: {main_log_path.exists()}")
-logger.info(f"Logs dir exists: {logs_dir.exists()}")
-
-# Add file handler if log path exists
-if main_log_path.exists():
-    file_handler = logging.FileHandler(main_log_path)
-    file_handler.setFormatter(logging.Formatter('%(asctime)s - PPTX_GENERATOR - %(name)s - %(levelname)s - %(message)s'))
-    logger.addHandler(file_handler)
 
 mcp = FastMCP("pptx_generator")
 
@@ -853,4 +838,4 @@ def markdown_to_pptx(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/progress_demo/main.py
+++ b/atlas/mcp/progress_demo/main.py
@@ -163,5 +163,5 @@ async def status_updates(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)
 

--- a/atlas/mcp/progress_updates_demo/main.py
+++ b/atlas/mcp/progress_updates_demo/main.py
@@ -494,4 +494,4 @@ async def task_with_artifacts(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/prompts/main.py
+++ b/atlas/mcp/prompts/main.py
@@ -219,4 +219,4 @@ def list_available_prompts() -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/public_demo/main.py
+++ b/atlas/mcp/public_demo/main.py
@@ -186,4 +186,4 @@ def echo(message: str) -> dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/sampling_demo/main.py
+++ b/atlas/mcp/sampling_demo/main.py
@@ -231,4 +231,4 @@ async def translate_and_explain(text: str, target_language: str, ctx: Context) -
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/thinking/main.py
+++ b/atlas/mcp/thinking/main.py
@@ -74,4 +74,4 @@ def thinking(list_of_thoughts: List[str]) -> Dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/tool_planner/main.py
+++ b/atlas/mcp/tool_planner/main.py
@@ -237,4 +237,4 @@ async def plan_with_tools(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/ui-demo/main.py
+++ b/atlas/mcp/ui-demo/main.py
@@ -483,4 +483,4 @@ Overall: {"NEEDS ATTENTION" if p99_lat > 10 or gc_pause > 200 or oom_kills > 0 e
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/mcp/username-override-demo/main.py
+++ b/atlas/mcp/username-override-demo/main.py
@@ -305,4 +305,4 @@ def plan_with_tools(
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(show_banner=False)

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -859,9 +859,12 @@ class MCPToolManager:
                 logger.error(f"Exception during client initialization for {server_name}: {error_msg}", exc_info=True)
                 self._record_server_failure(server_name, error_msg)
             elif result is not None:
+                is_new = server_name not in self.clients
                 self.clients[server_name] = result
                 self._clear_server_failure(server_name)
                 logger.info(f"Successfully initialized client for {server_name}")
+                if is_new:
+                    print(f"  MCP connected: {server_name}")
             else:
                 self._record_server_failure(server_name, "Initialization returned None")
                 logger.warning(f"Failed to initialize client for {server_name}")

--- a/atlas/modules/rag/__init__.py
+++ b/atlas/modules/rag/__init__.py
@@ -9,9 +9,6 @@ This module provides:
 from .atlas_rag_client import AtlasRAGClient, create_atlas_rag_client_from_config
 from .client import DataSource, DocumentMetadata, RAGClient, RAGMetadata, RAGResponse
 
-# Create default instance
-rag_client = RAGClient()
-
 __all__ = [
     "RAGClient",
     "AtlasRAGClient",
@@ -20,5 +17,4 @@ __all__ = [
     "DocumentMetadata",
     "RAGMetadata",
     "RAGResponse",
-    "rag_client",
 ]


### PR DESCRIPTION
## Summary
- Suppress FastMCP ASCII art banners by adding `show_banner=False` to all 26 internal MCP server `mcp.run()` calls (FastMCP 2.14.5 does not support the `FASTMCP_SHOW_SERVER_BANNER` env var)
- Remove dead `rag_client = RAGClient()` instantiation in `atlas/modules/rag/__init__.py` that logged a deprecation warning on every import
- Fix `code-executor` and `pptx_generator`: remove debug `print()`/`logger.info()` calls that dumped path info to stdout/stderr, add `logs_dir.mkdir()` for safe log directory creation, remove `StreamHandler` to keep MCP server logs file-only
- Add clean `print("  MCP connected: {name}")` to stdout on first connection for user-facing feedback (skips duplicates on re-initialization)

## Test plan
- [ ] Run `bash agent_start.sh` and verify no FastMCP banners, no RAGClient deprecation warning, no pptx_generator verbose output
- [ ] Verify each MCP server shows a single "MCP connected: {name}" line on startup
- [ ] Verify no duplicate "MCP connected" lines when servers are re-initialized
- [ ] Run `./test/run_tests.sh backend` -- all tests pass

Generated with [Claude Code](https://claude.com/claude-code)