### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-chat"
-version = "0.1.2"
+version = "0.1.3"
 description = "Full-stack LLM chat interface with Model Context Protocol (MCP) integration"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version from 0.1.2 to 0.1.3 for release

## Test plan
- [ ] Verify `pyproject.toml` version is 0.1.3
- [ ] Tag v0.1.3 already pushed

Generated with [Claude Code](https://claude.com/claude-code)