### PR TITLE
Fix CodeQL security scan findings

### DIFF
--- a/atlas/application/chat/utilities/error_handler.py
+++ b/atlas/application/chat/utilities/error_handler.py
@@ -348,7 +348,9 @@ async def with_retry(
             logger.warning(f"Operation failed (attempt {attempt + 1}/{max_retries + 1}): {e}")
 
     # If we get here, all retries failed
-    raise last_error
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Operation failed: no retry attempts were made")
 
 
 def sanitize_kwargs_for_logging(kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/atlas/core/prompt_risk.py
+++ b/atlas/core/prompt_risk.py
@@ -74,7 +74,7 @@ def calculate_prompt_injection_risk(message: str, *, mode: str = "general") -> D
 
     # 3) Statistical anomalies
     # Delimiter density (triple quotes, fences, etc.)
-    delimiters = len(re.findall(r"[#*\-_=]{3,}|[\"\"\"''']{3,}", message or ""))
+    delimiters = len(re.findall(r"[#*\-_=]{3,}|[\"']{3,}", message or ""))
     if delimiters >= 3:
         score += 25
         triggers.append("excessive_delimiters")

--- a/atlas/tests/test_init_cli.py
+++ b/atlas/tests/test_init_cli.py
@@ -39,9 +39,9 @@ class TestInitCliStartup:
             [
                 sys.executable,
                 "-c",
-                "import atlas; import sys; "
-                "assert 'atlas.atlas_client' not in sys.modules, "
-                "'atlas.atlas_client was eagerly imported'",
+                ("import atlas; import sys; "
+                 "assert 'atlas.atlas_client' not in sys.modules, "
+                 "'atlas.atlas_client was eagerly imported'"),
             ],
             capture_output=True,
             text=True,
@@ -106,9 +106,9 @@ class TestInitCliStartup:
             [
                 sys.executable,
                 "-c",
-                "import atlas; print(atlas.__version__); print(atlas.VERSION); "
-                "import sys; "
-                "assert 'atlas.atlas_client' not in sys.modules",
+                ("import atlas; print(atlas.__version__); print(atlas.VERSION); "
+                 "import sys; "
+                 "assert 'atlas.atlas_client' not in sys.modules"),
             ],
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary
- Fix illegal raise when `last_error` is `None` in retry logic (`error_handler.py:351`) -- CodeQL `py/illegal-raise`
- Remove duplicate characters in regex character class (`prompt_risk.py:77`) -- CodeQL `py/regex/duplicate-in-character-class`
- Wrap implicit string concatenation in parentheses to clarify intent in test code (`test_init_cli.py`) -- CodeQL `py/implicit-string-concatenation-in-list`
- Dismissed ~300 false positive / container-level CodeQL alerts via `ghsec` tool after individual review

## Test plan
- [x] Backend tests pass (874 passed, 3 pre-existing RAG integration failures unrelated to changes)
- [x] `test_init_cli.py` tests pass (6/6)
- [ ] CodeQL re-scan should auto-resolve alerts #1161 and #1162 after merge

Generated with [Claude Code](https://claude.com/claude-code)