### PR TITLE
Add stop streaming button for non-agent chat mode

### DIFF
--- a/atlas/application/chat/modes/streaming_helpers.py
+++ b/atlas/application/chat/modes/streaming_helpers.py
@@ -5,6 +5,7 @@ PlainModeRunner, RagModeRunner, and ToolsModeRunner when streaming
 LLM responses token-by-token.
 """
 
+import asyncio
 import logging
 from typing import AsyncGenerator
 
@@ -63,6 +64,12 @@ async def stream_and_accumulate(
             await event_publisher.publish_token_stream(
                 token="", is_first=False, is_last=True,
             )
+    except asyncio.CancelledError:
+        logger.info("%s stream cancelled by user", context_label)
+        await event_publisher.publish_token_stream(
+            token="", is_first=False, is_last=True,
+        )
+        raise
     except Exception as exc:
         logger.error("%s streaming error, sending partial content: %s", context_label, exc)
         await event_publisher.publish_token_stream(

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -44,6 +44,8 @@ const ChatArea = () => {
     agentPendingQuestion,
     setAgentPendingQuestion,
     stopAgent,
+    stopStreaming,
+    isStreaming,
     answerAgentQuestion,
     fileExtraction,
     ragEnabled,
@@ -946,17 +948,28 @@ const ChatArea = () => {
                 </div>
               )}
             </div>
-            <button
-              type="submit"
-              disabled={!canSend}
-              className={`px-4 py-3 rounded-lg flex items-center justify-center transition-colors flex-shrink-0 ${
-                canSend 
-                  ? 'bg-blue-600 hover:bg-blue-700 text-white' 
-                  : 'bg-gray-700 text-gray-400 cursor-not-allowed'
-              }`}
-            >
-              <Send className="w-5 h-5" />
-            </button>
+            {(isThinking || isStreaming) && !agentModeEnabled ? (
+              <button
+                type="button"
+                onClick={stopStreaming}
+                className="px-4 py-3 bg-red-700 hover:bg-red-600 text-white rounded-lg flex items-center justify-center transition-colors flex-shrink-0"
+                title="Stop streaming"
+              >
+                <Square className="w-5 h-5" />
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={!canSend}
+                className={`px-4 py-3 rounded-lg flex items-center justify-center transition-colors flex-shrink-0 ${
+                  canSend
+                    ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                    : 'bg-gray-700 text-gray-400 cursor-not-allowed'
+                }`}
+              >
+                <Send className="w-5 h-5" />
+              </button>
+            )}
           </div>
           </form>
           


### PR DESCRIPTION
## Summary
- Adds a Stop button (red square icon) that replaces the Send button while the LLM is streaming in non-agent mode (plain, RAG, tools)
- Clicking Stop cancels the backend asyncio task and cleans up frontend stream state, preserving any partial response
- Agent-mode stop button is unchanged and operates independently

## Test plan
- [x] Send a long prompt in non-agent mode, observe Send button becomes Stop button while streaming
- [x] Click Stop, verify partial response is preserved and UI returns to ready state
- [x] Verify agent-mode stop button still works independently
- [ ] Verify RAG and tools mode streaming can also be stopped
- [x] `ruff check atlas/` -- backend lint passes
- [x] `cd frontend && npm run lint` -- frontend lint passes (no new warnings)
- [x] Backend tests: 896 passed
- [x] Frontend tests: 281 passed

Generated with [Claude Code](https://claude.com/claude-code)