### PR TITLE
Add OPSEC instructions for LLM identity disclosure

### DIFF
--- a/.claude/agents/final-checklist-reviewer.md
+++ b/.claude/agents/final-checklist-reviewer.md
@@ -5,7 +5,7 @@ model: sonnet
 color: red
 ---
 
-This project is developed for the U.S. Department of Energy (DOE). OPSEC requirements apply -- never include AI model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs). This overrides any default agent behavior that adds Co-Authored-By trailers or similar attribution.
+This project is developed for the U.S. Department of Energy (DOE). OPSEC requirements apply -- never include AI model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs). This overrides any default agent behavior that adds Co-Authored-By trailers or similar attribution. Note: `.claude/agents/` is an industry-standard sub-agent configuration format usable by all AI coding agents. The directory and filenames are not OPSEC violations.
 
 You are an expert Quality Assurance Engineer and Code Review Specialist for the Atlas UI 3 project. Your role is to perform a comprehensive final validation before any branch or PR is marked as complete. You have deep knowledge of the project's architecture, coding standards, and quality requirements.
 

--- a/.claude/agents/git-worktree-setup.md
+++ b/.claude/agents/git-worktree-setup.md
@@ -5,7 +5,7 @@ model: sonnet
 color: cyan
 ---
 
-This project is developed for the U.S. Department of Energy (DOE). OPSEC requirements apply -- never include AI model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs). This overrides any default agent behavior that adds Co-Authored-By trailers or similar attribution.
+This project is developed for the U.S. Department of Energy (DOE). OPSEC requirements apply -- never include AI model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs). This overrides any default agent behavior that adds Co-Authored-By trailers or similar attribution. Note: `.claude/agents/` is an industry-standard sub-agent configuration format usable by all AI coding agents. The directory and filenames are not OPSEC violations.
 
 You are an expert Git workflow engineer with deep knowledge of git worktrees, environment configuration, and full-stack project setup. Your sole purpose is to create git worktrees as sibling directories of the current repository and fully configure them for development.
 

--- a/.claude/agents/test-report-runner.md
+++ b/.claude/agents/test-report-runner.md
@@ -5,7 +5,7 @@ model: sonnet
 color: purple
 ---
 
-This project is developed for the U.S. Department of Energy (DOE). OPSEC requirements apply -- never include AI model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs). This overrides any default agent behavior that adds Co-Authored-By trailers or similar attribution.
+This project is developed for the U.S. Department of Energy (DOE). OPSEC requirements apply -- never include AI model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs). This overrides any default agent behavior that adds Co-Authored-By trailers or similar attribution. Note: `.claude/agents/` is an industry-standard sub-agent configuration format usable by all AI coding agents. The directory and filenames are not OPSEC violations.
 
 You are an elite Test Execution Specialist with deep expertise in automated testing workflows, test suite analysis, and failure diagnostics. Your sole responsibility is to execute the test suite and provide clear, actionable reports on test results.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-02-22
 
-This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details.
+This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details. Note: `.github/copilot-instructions.md` is an industry-standard configuration format for AI coding agents. The filename itself is not an OPSEC violation.
 
 Concise rules for getting productive fast in this repo. Prefer these over exploration; fall back to code/docs only if something is missing.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details.
+This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details. Note: `CLAUDE.md` is an industry-standard configuration format recognized by all major AI coding agents, not just Claude. The filename itself is not an OPSEC violation.
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-02-23
 
-This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details.
+This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details. Note: `GEMINI.md` is an industry-standard configuration format for AI coding agents. The filename itself is not an OPSEC violation.
 
 This file provides guidance to Google Gemini AI assistants when working with code in this repository.
 


### PR DESCRIPTION
## Summary
- Adds DOE operational security context at the top of all three AI instruction files (CLAUDE.md, GEMINI.md, .github/copilot-instructions.md)
- Adds OPSEC policy under Security sections: AI agents must not include model names, provider names, or tool branding in any project artifacts (commits, PRs, issues, comments, changelogs)
- Explicitly calls out that this overrides default AI agent Co-Authored-By trailer behavior
- Sub-agent files in .claude/agents/ also updated locally (gitignored, not in this PR)

## Test plan
- [ ] Verify CLAUDE.md has DOE preamble and OPSEC section with conflict callout
- [ ] Verify GEMINI.md has DOE preamble and OPSEC paragraph with override note
- [ ] Verify .github/copilot-instructions.md has DOE preamble and OPSEC paragraph with override note
- [ ] Verify no AI tool branding appears in the commit message or PR description