### PR TITLE
Fix RAG+tools conflict: don't bypass tools on is_completion

### DIFF
--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -640,18 +640,14 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
 
                 if rag_response.is_completion:
                     logger.info(
-                        "[LLM+RAG+Tools] RAG returned chat completion - returning directly without LLM processing"
+                        "[LLM+RAG+Tools] RAG returned completion - injecting as context (tools still available)"
                     )
-                    final_response = self._build_rag_completion_response(rag_response, display_source)
-                    logger.info(
-                        "[LLM+RAG+Tools] Returning RAG completion directly: response_length=%d",
-                        len(final_response),
-                    )
-                    return LLMResponse(content=final_response)
-
-                rag_content = rag_response.content
+                    rag_content = self._build_rag_completion_response(rag_response, display_source)
+                    context_label = f"Pre-synthesized answer from {display_source}"
+                else:
+                    rag_content = rag_response.content
+                    context_label = f"Retrieved context from {display_source}"
                 rag_metadata = rag_response.metadata
-                context_label = f"Retrieved context from {display_source}"
             else:
                 # Multiple sources: combine all as raw context
                 rag_content, rag_metadata = self._combine_rag_contexts(source_responses)

--- a/atlas/modules/llm/litellm_streaming.py
+++ b/atlas/modules/llm/litellm_streaming.py
@@ -292,12 +292,11 @@ class LiteLLMStreamingMixin:
         if len(data_sources) == 1:
             display_source, rag_response = source_responses[0]
             if rag_response.is_completion:
-                yield LLMResponse(
-                    content=self._build_rag_completion_response(rag_response, display_source),
-                )
-                return
-            rag_content = rag_response.content
-            context_label = f"Retrieved context from {display_source}"
+                rag_content = self._build_rag_completion_response(rag_response, display_source)
+                context_label = f"Pre-synthesized answer from {display_source}"
+            else:
+                rag_content = rag_response.content
+                context_label = f"Retrieved context from {display_source}"
         else:
             rag_content, _ = self._combine_rag_contexts(source_responses)
             context_label = f"Retrieved context from {len(source_responses)} RAG sources"


### PR DESCRIPTION
## Summary
- When both RAG and tools were active and a RAG source returned `is_completion=True`, the backend returned the RAG response directly, completely bypassing the LLM call with tools. Tools were silently ignored.
- Now the RAG completion content is injected as context ("Pre-synthesized answer from...") and the LLM is still called with tools available, so both features work together.

## Test plan
- [ ] `bash run_test_shortcut.sh` -- all tests pass (907 backend, 281 frontend, 8 e2e)
- [ ] Enable RAG + tools simultaneously, send a message, verify tools can execute
- [ ] Enable RAG only (no tools), verify `is_completion` responses still work as before in the RAG-only paths

Fixes #378