### PR TITLE
Add sticky headers for code blocks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,8 @@ Concise rules for getting productive fast in this repo. Prefer these over explor
 
 **LLM Streaming**: Token streaming uses `LiteLLMStreamingMixin` (in `litellm_streaming.py`) mixed into `LiteLLMCaller`; the frontend buffers tokens with `setTimeout(30ms)` -- never use `requestAnimationFrame` for token flushing as it breaks progressive rendering.
 
+**Code Block Rendering**: Code blocks use `.code-block-header` with `position: sticky` and the container uses `max-height: 80vh` with `overflow-y: auto`; the `.copy-button` is flex-positioned inside the header (not absolute).
+
 ## Do This First
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #393 - 2026-03-10
+- **Feature**: Code block headers (language label and copy button) are now sticky, remaining visible at the top of long code blocks when scrolling. Code blocks are also capped at 80vh max-height with internal scrolling to prevent them from dominating the chat view.
+
 ### PR #390 - 2026-03-07
 - **Fix**: Admin panel MCP server status now correctly excludes failed servers from connected list, shows per-server tool/prompt counts, and displays the active `mcp.json` file path so admins know which config file is being read and written.
 - **Fix**: Add/remove server endpoints now properly reload MCP config instead of calling non-existent `reload_servers()` method; removed servers are cleaned up from clients, tools, and prompts caches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Atlas UI 3 is a full-stack LLM chat interface with Model Context Protocol (MCP) 
 
 **LLM Streaming**: Token streaming uses `LiteLLMStreamingMixin` (in `litellm_streaming.py`) mixed into `LiteLLMCaller` to keep files under 400 lines; the frontend buffers tokens with `setTimeout(30ms)` -- never use `requestAnimationFrame` for token flushing as it breaks progressive rendering.
 
+**Code Block Rendering**: Code blocks rendered via `marked` custom renderer in `Message.jsx` use a `.code-block-header` class with `position: sticky` for persistent visibility; the `.copy-button` uses flex positioning (not absolute) inside the header, and the container caps at `max-height: 80vh` with `overflow-y: auto` for internal scrolling.
+
 ## Installation
 
 ### As a Python Package (Recommended for Users)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,6 +24,8 @@ Atlas UI 3 is a full-stack LLM chat interface with Model Context Protocol (MCP) 
 
 **LLM Streaming**: Token streaming uses `LiteLLMStreamingMixin` (in `litellm_streaming.py`) mixed into `LiteLLMCaller`; the frontend buffers tokens with `setTimeout(30ms)` -- never use `requestAnimationFrame` for token flushing as it breaks progressive rendering.
 
+**Code Block Rendering**: Code blocks use `.code-block-header` with `position: sticky` and the container uses `max-height: 80vh` with `overflow-y: auto`; the `.copy-button` is flex-positioned inside the header (not absolute).
+
 ## Do This First
 
 ```bash

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -592,12 +592,18 @@
 
 .code-block-container {
     position: relative;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.code-block-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    border-radius: 0.5rem 0.5rem 0 0;
 }
 
 .copy-button {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
     background: #4b5563; /* gray-600 */
     border: 1px solid #6b7280; /* gray-500 */
     color: #e5e7eb; /* gray-200 */

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -147,10 +147,10 @@ renderer.code = function(code, language) {
   }
   
   return `<div class="code-block-container relative bg-gray-900 rounded-lg my-4 border border-gray-700">
-    <div class="flex items-center justify-between px-4 py-2 bg-gray-800 border-b border-gray-700">
+    <div class="code-block-header flex items-center justify-between px-4 py-2 bg-gray-800 border-b border-gray-700">
       <span class="text-xs text-gray-400 font-medium uppercase tracking-wider">${actualLanguage || 'text'}</span>
-      <button 
-        class="copy-button bg-gray-700 hover:bg-gray-600 border border-gray-600 text-gray-200 px-3 py-1 rounded text-xs transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500" 
+      <button
+        class="copy-button bg-gray-700 hover:bg-gray-600 border border-gray-600 text-gray-200 px-3 py-1 rounded text-xs transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500"
         data-action="copy-code"
         title="Copy code to clipboard"
         type="button"


### PR DESCRIPTION
## Summary
- Code block headers (language label + copy button) now use `position: sticky` so they remain visible when scrolling through long code blocks
- Code blocks are capped at `max-height: 80vh` with internal `overflow-y: auto` scrolling to prevent very long blocks from dominating the chat
- Removed absolute positioning from `.copy-button` in favor of flex layout within the sticky header

Closes #393

## Test plan
- [ ] Open a chat with a long code block (50+ lines) and verify the language label and copy button remain visible while scrolling within the block
- [ ] Verify the copy button still works correctly (copies code, shows green checkmark feedback)
- [ ] Verify short code blocks (< 80vh) render normally without unnecessary scrollbars
- [ ] Verify horizontal scrolling still works for wide code lines
- [ ] Run `cd frontend && npm run lint` -- no new errors
- [ ] Run `cd frontend && npm test` -- all tests pass