### PR TITLE
Upgrade fastmcp minimum version to 3.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -288,6 +288,7 @@ Set `APP_AGENT_LOOP_STRATEGY` to `agentic | react | think-act | act`.
 10. **Empty `tool_calls` arrays**: OpenAI and compatible providers reject messages where `tool_calls` is present but empty (`[]`); always call `_sanitize_messages()` in `LiteLLMCaller` before passing messages to `acompletion()`
 11. **Nginx `auth_request` vs HMAC tokens**: Do not apply nginx `auth_request` to endpoints that use application-layer HMAC capability tokens (e.g., `/api/files/download/`); non-browser clients like MCP servers lack session cookies and will get 302 redirects instead of the resource
 12. **Admin MCP reload after add/remove**: The admin add-server/remove-server endpoints must call `reload_config()` + `initialize_clients()` + `discover_tools()` + `discover_prompts()` in sequence; there is no single `reload_servers()` method on `MCPToolManager`. Also, `reload_config()` must clean up removed servers from `clients`, `available_tools`, and `available_prompts` dicts to prevent stale data
+13. **FastMCP 3.x compatibility**: The project requires `fastmcp>=3.0.0`; the codebase already uses the 3.x API (`list_tools()`, `list_prompts()`, `Client` constructor args), so no legacy `get_tools()`/`get_prompts()` calls should be introduced
 
 ## Critical Restrictions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #366 - 2026-03-10
+- **Upgrade**: Bump minimum FastMCP dependency from `>=2.10.0` to `>=3.0.0`. The codebase already used FastMCP 3.x-compatible APIs (`list_tools()`, `list_prompts()`, `Client` constructor), so no application code changes were needed.
+
 ### PR #390 - 2026-03-07
 - **Fix**: Admin panel MCP server status now correctly excludes failed servers from connected list, shows per-server tool/prompt counts, and displays the active `mcp.json` file path so admins know which config file is being read and written.
 - **Fix**: Add/remove server endpoints now properly reload MCP config instead of calling non-existent `reload_servers()` method; removed servers are cleaned up from clients, tools, and prompts caches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,6 +423,7 @@ Set `APP_AGENT_LOOP_STRATEGY` to `agentic | react | think-act | act`; ChatServic
 11. **Empty `tool_calls` arrays**: OpenAI and compatible providers reject messages where `tool_calls` is present but empty (`[]`); always call `_sanitize_messages()` in `LiteLLMCaller` before passing messages to `acompletion()`
 12. **Nginx `auth_request` vs HMAC tokens**: Do not apply nginx `auth_request` to endpoints that use application-layer HMAC capability tokens (e.g., `/api/files/download/`); non-browser clients like MCP servers lack session cookies and will get 302 redirects instead of the resource
 13. **Admin MCP reload after add/remove**: The admin add-server/remove-server endpoints must call `reload_config()` + `initialize_clients()` + `discover_tools()` + `discover_prompts()` in sequence; there is no single `reload_servers()` method on `MCPToolManager`. Also, `reload_config()` must clean up removed servers from `clients`, `available_tools`, and `available_prompts` dicts to prevent stale data
+14. **FastMCP 3.x compatibility**: The project requires `fastmcp>=3.0.0`; the codebase already uses the 3.x API (`list_tools()`, `list_prompts()`, `Client` constructor args), so no legacy `get_tools()`/`get_prompts()` calls should be introduced
 
 ## PR Validation Scripts (Required)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -327,6 +327,7 @@ Set `APP_AGENT_LOOP_STRATEGY` to `agentic | react | think-act | act`.
 11. **Empty `tool_calls` arrays**: OpenAI and compatible providers reject messages where `tool_calls` is present but empty (`[]`); always call `_sanitize_messages()` in `LiteLLMCaller` before passing messages to `acompletion()`
 12. **Nginx `auth_request` vs HMAC tokens**: Do not apply nginx `auth_request` to endpoints that use application-layer HMAC capability tokens (e.g., `/api/files/download/`); non-browser clients like MCP servers lack session cookies and will get 302 redirects instead of the resource
 13. **Admin MCP reload after add/remove**: The admin add-server/remove-server endpoints must call `reload_config()` + `initialize_clients()` + `discover_tools()` + `discover_prompts()` in sequence; there is no single `reload_servers()` method on `MCPToolManager`. Also, `reload_config()` must clean up removed servers from `clients`, `available_tools`, and `available_prompts` dicts to prevent stale data
+14. **FastMCP 3.x compatibility**: The project requires `fastmcp>=3.0.0`; the codebase already uses the 3.x API (`list_tools()`, `list_prompts()`, `Client` constructor args), so no legacy `get_tools()`/`get_prompts()` calls should be introduced
 
 ## Critical Restrictions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "duckdb-engine",
     "duckduckgo-search",
     "fastapi",
-    "fastmcp>=2.10.0,<4.0.0",
+    "fastmcp>=3.0.0,<4.0.0",
     "httpx",
     "itsdangerous",
     "litellm>=1.81.14",

--- a/test/pr-validation/test_pr366_fastmcp3_upgrade.sh
+++ b/test/pr-validation/test_pr366_fastmcp3_upgrade.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# PR #366 - Upgrade to fastmcp>=3.0.0
+# Validates that the FastMCP 3.x upgrade works correctly with all MCP features.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# Activate virtual environment
+source .venv/bin/activate 2>/dev/null || true
+
+PASS=0
+FAIL=0
+
+check() {
+    local desc="$1"
+    shift
+    if "$@" >/dev/null 2>&1; then
+        echo "  $desc ... PASS"
+        ((PASS++))
+    else
+        echo "  $desc ... FAIL"
+        ((FAIL++))
+    fi
+}
+
+echo "================================================================"
+echo "PR #366 Validation: FastMCP 3.x Upgrade"
+echo "================================================================"
+
+# 1. Verify fastmcp>=3.0.0 is installed
+echo ""
+echo "-- Checking installed fastmcp version --"
+FASTMCP_VERSION=$(python -c "import fastmcp; print(fastmcp.__version__)" 2>&1)
+echo "  Installed fastmcp version: $FASTMCP_VERSION"
+MAJOR=$(echo "$FASTMCP_VERSION" | cut -d. -f1)
+if [ "$MAJOR" -ge 3 ]; then
+    echo "  FastMCP major version >= 3 ... PASS"
+    ((PASS++))
+else
+    echo "  FastMCP major version >= 3 ... FAIL (got $MAJOR)"
+    ((FAIL++))
+fi
+
+# 2. Verify pyproject.toml requires >=3.0.0
+echo ""
+echo "-- Checking pyproject.toml constraint --"
+check "pyproject.toml requires fastmcp>=3.0.0" \
+    grep -q 'fastmcp>=3.0.0' "$PROJECT_ROOT/pyproject.toml"
+
+# 3. Verify core imports work
+echo ""
+echo "-- Checking core FastMCP imports --"
+check "Import Client and FastMCP" \
+    python -c "from fastmcp import Client, FastMCP"
+
+check "Import StreamableHttpTransport" \
+    python -c "from fastmcp.client.transports import StreamableHttpTransport"
+
+check "Import StdioTransport" \
+    python -c "from fastmcp.client.transports import StdioTransport"
+
+check "Import ElicitResult" \
+    python -c "from fastmcp.client.elicitation import ElicitResult"
+
+check "Import ToolError" \
+    python -c "from fastmcp.exceptions import ToolError"
+
+check "Import server middleware" \
+    python -c "from fastmcp.server.middleware import Middleware, MiddlewareContext"
+
+check "Import server dependencies" \
+    python -c "from fastmcp.server.dependencies import get_http_headers"
+
+check "Import ToolResult" \
+    python -c "from fastmcp.tools.tool import ToolResult"
+
+check "Import StaticTokenVerifier" \
+    python -c "from fastmcp.server.auth.providers.jwt import StaticTokenVerifier"
+
+# 4. Verify Client has expected methods (3.x API)
+echo ""
+echo "-- Checking Client API compatibility --"
+check "Client has list_tools method" \
+    python -c "from fastmcp import Client; assert hasattr(Client, 'list_tools')"
+
+check "Client has list_prompts method" \
+    python -c "from fastmcp import Client; assert hasattr(Client, 'list_prompts')"
+
+check "Client has call_tool method" \
+    python -c "from fastmcp import Client; assert hasattr(Client, 'call_tool')"
+
+check "Client has get_prompt method" \
+    python -c "from fastmcp import Client; assert hasattr(Client, 'get_prompt')"
+
+check "Client has set_elicitation_callback method" \
+    python -c "from fastmcp import Client; assert hasattr(Client, 'set_elicitation_callback')"
+
+# 5. Verify MCP tool manager can be imported without errors
+echo ""
+echo "-- Checking atlas MCP module imports --"
+check "Import MCPToolManager" \
+    python -c "
+import os, sys
+sys.path.insert(0, '$PROJECT_ROOT')
+os.environ.setdefault('APP_CONFIG_DIR', '$PROJECT_ROOT/atlas/config')
+from atlas.modules.mcp_tools.client import MCPToolManager
+"
+
+# 6. End-to-end: Verify CLI can initialize with MCP tool discovery
+echo ""
+echo "-- End-to-end: CLI tool listing with calculator MCP server --"
+cd "$PROJECT_ROOT/atlas"
+LIST_OUTPUT=$(PYTHONPATH="$PROJECT_ROOT" python atlas_chat_cli.py --list-tools \
+    --mcp-config "$PROJECT_ROOT/atlas/config/mcp-example-configs/mcp-calculator.json" 2>&1 || true)
+
+if echo "$LIST_OUTPUT" | grep -q "calculator"; then
+    echo "  CLI --list-tools discovers calculator server ... PASS"
+    ((PASS++))
+else
+    echo "  CLI --list-tools discovers calculator server ... FAIL"
+    echo "  Output: $LIST_OUTPUT"
+    ((FAIL++))
+fi
+cd "$PROJECT_ROOT"
+
+# 7. Run backend unit tests
+echo ""
+echo "-- Running backend unit tests --"
+PYTHONPATH="$PROJECT_ROOT" "$PROJECT_ROOT/test/run_tests.sh" backend 2>&1 | tail -5
+BACKEND_EXIT=${PIPESTATUS[0]}
+if [ "$BACKEND_EXIT" -eq 0 ]; then
+    echo "  Backend tests ... PASS"
+    ((PASS++))
+else
+    echo "  Backend tests ... FAIL"
+    ((FAIL++))
+fi
+
+echo ""
+echo "================================================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================================================"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Bump `fastmcp` dependency floor from `>=2.10.0,<4.0.0` to `>=3.0.0,<4.0.0` in `pyproject.toml`
- No application code changes needed -- the codebase already used FastMCP 3.x-compatible APIs (`list_tools()`, `list_prompts()`, `Client` constructor with `log_handler`/`elicitation_handler`/`sampling_handler`)
- Verified all imports (`Client`, `FastMCP`, `StreamableHttpTransport`, `StdioTransport`, `ElicitResult`, `ToolError`, `Middleware`, `ToolResult`, `StaticTokenVerifier`) work with fastmcp 3.1.0

Closes #366

## Test plan
- [x] `ruff check atlas/` passes
- [x] `./test/run_tests.sh backend` passes (all backend tests)
- [x] `./test/run_tests.sh frontend` passes (all frontend tests)
- [x] `cd frontend && npm run lint` passes (no errors)
- [x] PR validation script `test/pr-validation/test_pr366_fastmcp3_upgrade.sh` passes (19/19 checks)
- [x] CLI `--list-tools` discovers calculator MCP server tools with fastmcp 3.x
- [x] All FastMCP import paths verified compatible with 3.x