### PR TITLE
Fix pptx_generator crash on FastMCP 3.x with stdio transport

### DIFF
--- a/atlas/mcp/pptx_generator/main.py
+++ b/atlas/mcp/pptx_generator/main.py
@@ -828,4 +828,8 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--host", default="0.0.0.0")
     args = parser.parse_args()
-    mcp.run(transport=args.transport, host=args.host, port=args.port, show_banner=False)
+    kwargs = {}
+    if args.transport != "stdio":
+        kwargs["host"] = args.host
+        kwargs["port"] = args.port
+    mcp.run(transport=args.transport, show_banner=False, **kwargs)


### PR DESCRIPTION
## Summary
- FastMCP 3.x changed `mcp.run()` to no longer accept `host`/`port` kwargs when running stdio transport, causing a `TypeError` crash
- Only pass `host`/`port` when a network transport (sse, streamable-http) is selected

## Verification
- Tested all 25 MCP servers with FastMCP 3.1.0 — all start successfully
- 179 MCP-related tests pass
- Full backend startup with all 5 production MCPs connecting
- End-to-end calculator tool call verified via Playwright

## Test plan
- [ ] `PYTHONPATH=$PWD python atlas/mcp/pptx_generator/main.py` starts without error (stdio)
- [ ] `PYTHONPATH=$PWD python atlas/mcp/pptx_generator/main.py --transport streamable-http` starts on port 8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)