### PR TITLE
Auto-activate RAG when data sources are selected

### DIFF
--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -50,6 +50,7 @@ const ChatArea = () => {
     fileExtraction,
     ragEnabled,
     toggleRagEnabled,
+    selectedDataSources,
     features,
     appName
   } = useChat()
@@ -853,11 +854,11 @@ const ChatArea = () => {
                   type="button"
                   onClick={toggleRagEnabled}
                   className={`px-3 py-3 rounded-lg flex items-center justify-center transition-colors flex-shrink-0 ${
-                    ragEnabled || hasSearchCommand
+                    ragEnabled || hasSearchCommand || selectedDataSources?.size > 0
                       ? 'bg-green-600 hover:bg-green-700 text-white'
                       : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
                   }`}
-                  title={ragEnabled ? 'RAG enabled - click to disable' : hasSearchCommand ? 'RAG active for this search' : 'RAG disabled - click to enable'}
+                  title={ragEnabled ? 'RAG enabled - click to disable' : hasSearchCommand ? 'RAG active for this search' : selectedDataSources?.size > 0 ? 'RAG active via selected data sources' : 'RAG disabled - click to enable'}
                 >
                   <Search className="w-5 h-5" />
                 </button>

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -275,11 +275,12 @@ export const ChatProvider = ({ children }) => {
 		const tagged = files.getTaggedFilesContent()
 
 		// Determine data sources to send:
-		// RAG is only invoked when explicitly activated via the search button (ragEnabled)
-		// or the /search command (forceRag). Data source selection alone just marks
-		// availability -- it does not trigger RAG.
-		const ragActivated = forceRag || ragEnabled
+		// RAG is activated when any of these are true:
+		//   1. The RAG toggle is on (ragEnabled)
+		//   2. The /search command was used (forceRag)
+		//   3. One or more data sources are selected (hasSelectedSources)
 		const hasSelectedSources = selectedDataSources.size > 0
+		const ragActivated = forceRag || ragEnabled || hasSelectedSources
 		const dataSourcesToSend = ragActivated
 			? (hasSelectedSources ? [...selectedDataSources] : getAllRagSourceIds())
 			: []

--- a/frontend/src/test/rag-activation-gating.test.js
+++ b/frontend/src/test/rag-activation-gating.test.js
@@ -1,9 +1,10 @@
 /**
- * Tests for RAG activation gating (GH #335)
+ * Tests for RAG activation gating (GH #335, #396)
  *
- * Verifies that selecting data sources alone does NOT trigger RAG.
- * RAG should only be invoked when explicitly activated via the search
- * button (ragEnabled toggle) or the /search command (forceRag flag).
+ * Verifies that RAG is activated when:
+ *   1. The ragEnabled toggle is on
+ *   2. The /search command is used (forceRag)
+ *   3. One or more data sources are selected
  */
 
 import { describe, it, expect } from 'vitest'
@@ -14,8 +15,8 @@ import { describe, it, expect } from 'vitest'
  * React context tree.
  */
 function computeDataSourcesToSend({ forceRag, ragEnabled, selectedDataSources, allRagSourceIds }) {
-  const ragActivated = forceRag || ragEnabled
   const hasSelectedSources = selectedDataSources.size > 0
+  const ragActivated = forceRag || ragEnabled || hasSelectedSources
   return ragActivated
     ? (hasSelectedSources ? [...selectedDataSources] : allRagSourceIds)
     : []
@@ -24,14 +25,14 @@ function computeDataSourcesToSend({ forceRag, ragEnabled, selectedDataSources, a
 describe('RAG activation gating', () => {
   const allSources = ['server:source1', 'server:source2', 'server:source3']
 
-  it('does NOT send data sources when sources are selected but RAG is not activated', () => {
+  it('sends selected data sources when sources are selected (even without ragEnabled toggle)', () => {
     const result = computeDataSourcesToSend({
       forceRag: false,
       ragEnabled: false,
       selectedDataSources: new Set(['server:source1', 'server:source2']),
       allRagSourceIds: allSources,
     })
-    expect(result).toEqual([])
+    expect(result).toEqual(['server:source1', 'server:source2'])
   })
 
   it('sends selected data sources when ragEnabled toggle is on', () => {


### PR DESCRIPTION
## Summary
- Selecting data sources now automatically activates RAG, eliminating the UX mismatch where sources appeared active but messages were sent without RAG
- RAG toggle button turns green when data sources are selected (tooltip: "RAG active via selected data sources")
- Updated tests to reflect the new behavior

Fixes #396

## Changes
- **ChatContext.jsx**: `ragActivated` now includes `hasSelectedSources` — selecting any data source triggers RAG
- **ChatArea.jsx**: RAG button shows green state and updated tooltip when data sources are selected
- **rag-activation-gating.test.js**: Updated to test that selected sources alone now activate RAG

## Test plan
- [x] 281/281 frontend tests pass
- [ ] Select data sources without toggling RAG → message should use RAG search
- [ ] RAG button shows green when sources selected
- [ ] Tooltip says "RAG active via selected data sources"
- [ ] Deselect all sources → RAG button returns to gray, messages sent without RAG