### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Atlas UI 3 is a full-stack LLM chat interface with Model Context Protocol (MCP) 
 
 **Dependency Management**: All Python dependencies are defined in `pyproject.toml` (the single source of truth); there is no `requirements.txt` -- always use `uv pip install -e ".[dev]"` for development. Core dependencies are minimal; data-science and MCP demo packages (matplotlib, pandas, numpy, etc.) live in the `mcp-demos` optional extra and are pulled in automatically by `uv sync --dev`.
 
+**Version Bumps**: When bumping the version, update both `pyproject.toml` and `atlas/version.py` atomically in the same commit to keep them in sync.
+
 **Lazy Imports**: `atlas/__init__.py` uses `__getattr__` to lazily import `AtlasClient` and `ChatResult` so that lightweight CLIs like `atlas-init` do not pay the cost of loading the full dependency chain (SQLAlchemy, litellm, FastAPI, etc.).
 
 **LLM Streaming**: Token streaming uses `LiteLLMStreamingMixin` (in `litellm_streaming.py`) mixed into `LiteLLMCaller` to keep files under 400 lines; the frontend buffers tokens with `setTimeout(30ms)` -- never use `requestAnimationFrame` for token flushing as it breaks progressive rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #409 - 2026-03-12
+- **Release**: Bump version from 0.1.4 to 0.1.5.
+
 ### PR #407 - 2026-03-12
 - **Enhancement**: Split Python dependencies into core vs. `mcp-demos` optional extra. Core install is now lighter; `uv sync --dev` or `pip install atlas-chat[mcp-demos]` pulls in matplotlib, pandas, numpy, and other demo-only packages.
 - **Docs**: Added README section for extracting pre-built frontend from PyPI wheel on machines without Node.js.

--- a/atlas/version.py
+++ b/atlas/version.py
@@ -3,4 +3,4 @@
 Single source of truth for the application version number.
 """
 
-VERSION = "0.1.4"
+VERSION = "0.1.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-chat"
-version = "0.1.4"
+version = "0.1.5"
 description = "Full-stack LLM chat interface with Model Context Protocol (MCP) integration"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bump Python package version from 0.1.4 to 0.1.5

## Test plan
- [ ] CI passes
- [ ] `uv sync --dev` resolves successfully