### PR TITLE
Remove tmux session step from worktree setup agent

### DIFF
--- a/.claude/agents/git-worktree-setup.md
+++ b/.claude/agents/git-worktree-setup.md
@@ -37,12 +37,7 @@ When given a branch name or PR number, you will:
    - Install frontend dependencies: `cd <worktree_path>/frontend && npm install`
    - Build the frontend: `cd <worktree_path>/frontend && npm run build`
 
-6. **Launch a tmux session with Claude Code:**
-   - Create a detached tmux session named after the sanitized branch: `tmux new-session -d -s <sanitized_branch_name> -c <worktree_path>`
-   - Activate the venv and launch Claude Code inside the session: `tmux send-keys -t <sanitized_branch_name> 'source .venv/bin/activate && claude' Enter`
-   - The user can attach later with: `tmux attach -t <sanitized_branch_name>`
-
-7. **Report the result** with the full path to the worktree and any issues encountered.
+6. **Report the result** with the full path to the worktree and any issues encountered.
 
 ## Important Rules
 
@@ -66,8 +61,6 @@ After setup, verify:
 - [ ] `config/overrides/` copied if it existed in the original
 - [ ] `.venv` exists and dependencies are installed
 - [ ] `frontend/dist` exists (frontend built successfully)
-- [ ] tmux session is running with Claude Code
-
 Report the checklist results to the user.
 
 ## Output Format
@@ -77,13 +70,9 @@ Provide a clear summary:
 Worktree created successfully:
   Branch: <branch_name>
   Path: <full_worktree_path>
-  tmux session: <session_name>
   Status: <ready / partial - details>
 
-To attach to the Claude Code session:
-  tmux attach -t <session_name>
-
-To start the app manually:
+To start working:
   cd <worktree_path>
   source .venv/bin/activate
   bash agent_start.sh


### PR DESCRIPTION
## Summary
- Removed the tmux session launch step from the git-worktree-setup subagent
- The subagent's sandboxed environment cannot reliably interact with the user's tmux server, so this step never actually worked
- Cleaned up related verification checklist item and output format references

## Test plan
- [ ] Verify worktree setup agent still creates worktrees correctly without the tmux step