### PR TITLE
fix: upgrade authlib and PyJWT to address 4 CVEs

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3186,11 +3186,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Upgrades **authlib** 1.6.8 → 1.6.9 fixing 3 CVEs:
  - CVE-2026-27962 (Critical) — JWS JWK Header Injection: Signature Verification Bypass
  - CVE-2026-28490 (High) — JWE RSA1_5 Bleichenbacher Padding Oracle
  - CVE-2026-28498 (High) — Fail-Open OIDC Hash Binding
- Upgrades **PyJWT** 2.11.0 → 2.12.1 fixing 1 CVE:
  - CVE-2026-32597 (High) — Accepts unknown `crit` header extensions

**Risk assessment:**
- Authlib is a transitive dependency (via `fastmcp`) — not directly imported in this repo. Low practical risk but patching eliminates latent exposure.
- PyJWT is a **direct dependency** used in `atlas/core/auth.py` for JWT verification — higher relevance.

## Test plan
- [ ] Verify `uv.lock` resolves cleanly
- [ ] Confirm existing tests pass (lockfile-only update, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)