### PR TITLE
fix: paste-attach error handling and filename collision prevention

### DIFF
--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -624,7 +624,12 @@ const ChatArea = () => {
         }))
       }
       reader.onerror = () => {
-        console.error('Failed to read pasted file:', file.name)
+        console.error('Failed to read pasted file', {
+          name: file.name,
+          type: file.type,
+          index: idx,
+          error: reader.error
+        })
       }
       reader.readAsDataURL(file)
     })

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -600,7 +600,7 @@ const ChatArea = () => {
     const pastedFiles = Array.from(items).filter(item => item.kind === 'file')
     if (pastedFiles.length === 0) return
     e.preventDefault()
-    pastedFiles.forEach(item => {
+    pastedFiles.forEach((item, idx) => {
       const file = item.getAsFile()
       if (!file) return
       const reader = new FileReader()
@@ -611,7 +611,7 @@ const ChatArea = () => {
         const isGenericName = !file.name || /^image\.(png|jpe?g|gif|webp|bmp)$/i.test(file.name)
         const ext = file.type.includes('/') ? file.type.split('/')[1].split('+')[0] : 'bin'
         const rawName = isGenericName
-          ? `pasted_image_${Date.now()}.${ext}`
+          ? `pasted_image_${Date.now()}_${idx}.${ext}`
           : file.name
         const safeName = sanitizeFilename(rawName)
         const extractMode = canExtractFile(safeName) ? globalExtractMode : 'none'
@@ -622,6 +622,9 @@ const ChatArea = () => {
             extractMode
           }
         }))
+      }
+      reader.onerror = () => {
+        console.error('Failed to read pasted file:', file.name)
       }
       reader.readAsDataURL(file)
     })


### PR DESCRIPTION
## Summary
- Add `reader.onerror` handler to `handlePaste` so FileReader failures are logged instead of silently swallowed
- Append index to timestamped filenames (`pasted_image_<ts>_<idx>.<ext>`) to prevent collisions when multiple generic-named files are pasted in a single event

Follow-up to PR #423.

## Test plan
- [ ] Paste a single screenshot into chat — verify it attaches with a timestamped name
- [ ] Paste multiple images at once (if supported by browser) — verify each gets a unique filename
- [ ] Paste plain text — verify normal paste behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)