### PR TITLE
fix: prevent logo overlapping text on short screens

### DIFF
--- a/frontend/src/components/AnimatedLogo.jsx
+++ b/frontend/src/components/AnimatedLogo.jsx
@@ -190,7 +190,7 @@ const AnimatedLogo = ({ appName }) => {
                 ref={imgRef}
                 src="/logo.png"
                 alt={`${appName} Logo`}
-                className="max-w-48 sm:max-w-80 md:max-w-xl lg:max-w-3xl mx-auto object-contain"
+                className="max-w-48 sm:max-w-80 md:max-w-xl lg:max-w-3xl max-h-[50vh] mx-auto object-contain"
                 onLoad={handleImgLoad}
                 onError={(e) => { e.target.style.display = 'none' }}
                 draggable={false}

--- a/frontend/src/components/WelcomeScreen.jsx
+++ b/frontend/src/components/WelcomeScreen.jsx
@@ -9,14 +9,14 @@ const WelcomeScreen = () => {
 
   return (
     <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-hidden p-4 sm:p-8 text-center">
-      <div className={animatedLogoEnabled ? 'mb-6 sm:mb-10 flex-shrink-0' : 'mb-4 sm:mb-8 flex-shrink min-h-0'}>
+      <div className={animatedLogoEnabled ? 'mb-6 sm:mb-10 flex-shrink min-h-0' : 'mb-4 sm:mb-8 flex-shrink min-h-0'}>
         {animatedLogoEnabled ? (
           <AnimatedLogo appName={appName} />
         ) : (
           <img
             src="/logo.png"
             alt={`${appName} Logo`}
-            className="max-w-48 sm:max-w-80 md:max-w-4xl mx-auto mb-4 object-contain"
+            className="max-w-48 sm:max-w-80 md:max-w-4xl max-h-[50vh] mx-auto mb-4 object-contain"
             onError={(e) => {
               e.target.style.display = 'none'
               e.target.nextElementSibling.style.display = 'flex'


### PR DESCRIPTION
## Summary
- Allow logo container to shrink vertically (`flex-shrink min-h-0` instead of `flex-shrink-0`) so content fits in limited height
- Cap logo image height at `max-h-[50vh]` for both animated and static logos, preventing the logo from consuming more than half the viewport on short screens

Fixes #430

## Test plan
- [ ] Open the app in a wide but short browser window (e.g. 1920x400) — logo and text should both be visible without overlap
- [ ] Verify normal-sized windows still look correct
- [ ] Test with both animated and static logo (toggle `VITE_FEATURE_ANIMATED_LOGO`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)