### PR TITLE
Fix: RAG search-glass clears data sources, Sources button toggles sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,8 @@ frontend/src/
 
 **RAG+Tools `is_completion` Handling:** When both RAG and tools are active, RAG `is_completion=True` responses must NOT short-circuit the LLM call; instead inject the pre-synthesized content as context so tools remain available to the model.
 
+**RAG UI Toggle Pattern:** The chat input search-glass button and the header Sources button have distinct roles: the search glass controls RAG activation (green = active, click to clear; gray = inactive, click to open panel), while the header Sources button only toggles the Data Sources sidebar visibility without changing selection state. Panel-open callbacks from ChatArea to App.jsx are passed as props (`onOpenRagPanel`) since panel visibility lives in App.jsx state, not in ChatContext.
+
 **RAG Activation vs Selection:** In `ChatContext.sendChatMessage`, data sources are only sent to the backend when RAG is explicitly activated (`ragEnabled` toggle or `/search` command). Selecting data sources in the UI only marks availability; the backend orchestrator routes to RAG mode only when `selected_data_sources` is non-empty, so the frontend must gate what it sends.
 
 **3-State Save Mode:** Chat history uses a 3-state `saveMode` (`none`/`local`/`server`) persisted via `usePersistentState`. "local" mode saves conversations to IndexedDB in the browser (`localConversationDB.js`), "server" saves to the backend database, and "none" is incognito. The Sidebar calls both `useConversationHistory` and `useLocalConversationHistory` hooks unconditionally (React rules of hooks) then picks the active one based on `saveMode`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #449 - 2026-03-18
+- **Fix**: Chat input search-glass button now clears all selected data sources and disables RAG when clicked while active (green), and opens the Data Sources sidebar when clicked while inactive (gray). Header Sources button only toggles sidebar visibility.
+
 ### PR #426 - 2026-03-18
 - **Feature**: Add AI-generated follow-up question suggestion buttons after each chat response. Enabled via `FEATURE_FOLLOWUP_SUGGESTIONS_ENABLED=true`. Suggestions appear as clickable pill buttons below the messages and are cleared when a new message is sent.
 

--- a/docs/admin/external-rag-api.md
+++ b/docs/admin/external-rag-api.md
@@ -1,6 +1,6 @@
 # RAG Configuration
 
-Last updated: 2026-02-23
+Last updated: 2026-03-18
 
 This guide explains how to configure RAG (Retrieval-Augmented Generation) in Atlas UI.
 
@@ -256,6 +256,15 @@ When a RAG source returns a completion, Atlas:
 The `is_completion` flag on `RAGResponse` tracks whether the response is already LLM-interpreted. This is set automatically by `AtlasRAGClient` when it detects `"object": "chat.completion"` in the API response.
 
 This behavior applies to both `call_with_rag` (RAG-only mode) and `call_with_rag_and_tools` (RAG + tools mode) in the LLM caller.
+
+## UI Behavior (2026-03-18)
+
+The frontend provides two controls for RAG:
+
+- **Header Sources button** (Database icon): Toggles the Data Sources sidebar open/closed. It turns blue when data sources are selected but does not change selection state on click.
+- **Chat input search-glass button**: Controls RAG activation. When green (RAG active or data sources selected), clicking clears all selected data sources and disables RAG. When gray (RAG inactive), clicking opens the Data Sources sidebar so the user can select sources.
+
+Users must explicitly select data sources from the sidebar to enable RAG; there is no "search all sources" toggle from the chat input.
 
 ## Troubleshooting
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -133,7 +133,7 @@ function ChatInterface() {
           {/* Content Area - Chat and Canvas side by side */}
           <div className="flex flex-1 overflow-hidden min-h-0">
             {/* Chat Area */}
-            <ChatArea />
+            <ChatArea onOpenRagPanel={() => setRagPanelOpen(true)} />
 
             {/* Canvas Panel */}
             <CanvasPanel

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -7,7 +7,7 @@ import WelcomeScreen from './WelcomeScreen'
 import EnabledToolsIndicator from './EnabledToolsIndicator'
 import PromptSelector from './PromptSelector'
 
-const ChatArea = () => {
+const ChatArea = ({ onOpenRagPanel }) => {
   const [inputValue, setInputValue] = useState('')
   const [isMobile, setIsMobile] = useState(false)
   // uploadedFiles: { filename: { content: base64, extractMode: "full"|"preview"|"none" } }
@@ -51,6 +51,7 @@ const ChatArea = () => {
     ragEnabled,
     toggleRagEnabled,
     selectedDataSources,
+    clearDataSources,
     features,
     appName,
     user,
@@ -932,13 +933,22 @@ const ChatArea = () => {
               {features?.rag && (
                 <button
                   type="button"
-                  onClick={toggleRagEnabled}
+                  onClick={() => {
+                    if (ragEnabled || selectedDataSources?.size > 0) {
+                      // Turn off RAG: clear data sources and disable
+                      clearDataSources()
+                      if (ragEnabled) toggleRagEnabled()
+                    } else {
+                      // Turn on RAG: open the panel so user can select data sources
+                      onOpenRagPanel?.()
+                    }
+                  }}
                   className={`px-3 py-3 rounded-lg flex items-center justify-center transition-colors flex-shrink-0 ${
                     ragEnabled || hasSearchCommand || selectedDataSources?.size > 0
                       ? 'bg-green-600 hover:bg-green-700 text-white'
                       : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
                   }`}
-                  title={ragEnabled ? 'RAG enabled - click to disable' : hasSearchCommand ? 'RAG active for this search' : selectedDataSources?.size > 0 ? 'RAG active via selected data sources' : 'RAG disabled - click to enable'}
+                  title={ragEnabled || selectedDataSources?.size > 0 ? 'Click to disable RAG and clear data sources' : 'Click to select data sources'}
                 >
                   <Search className="w-5 h-5" />
                 </button>


### PR DESCRIPTION
## Summary
- Search-glass button (chat input) now clears all data sources when green (active), and opens the Data Sources sidebar when gray (inactive)
- Header Sources button only toggles sidebar visibility without changing selection state
- Adds `onOpenRagPanel` prop from App.jsx to ChatArea for panel control

Closes #437

## Test plan
- [ ] Select one or more data sources -- search glass turns green
- [ ] Click the green search glass -- all sources cleared, button turns gray
- [ ] Click the gray search glass -- Data Sources sidebar opens
- [ ] Click header Sources button -- sidebar toggles open/closed without affecting selections