### PR TITLE
feat: RAG citation references section (#443)

### DIFF
--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -235,15 +235,17 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
         Returns:
             Formatted response string with RAG completion note and metadata
         """
+        from atlas.modules.rag.citation_formatter import build_references_marker
+
         response_parts = []
         response_parts.append(f"*Response from {display_source} (RAG completions endpoint):*\n")
         response_parts.append(rag_response.content)
 
-        # Append metadata if available
+        # Append structured references marker for frontend rendering
         if rag_response.metadata:
-            metadata_summary = self._format_rag_metadata(rag_response.metadata)
-            if metadata_summary and metadata_summary != "Metadata unavailable":
-                response_parts.append(f"\n\n---\n**RAG Sources & Processing Info:**\n{metadata_summary}")
+            marker = build_references_marker(rag_response.metadata, display_source)
+            if marker:
+                response_parts.append(f"\n\n{marker}")
 
         return "\n".join(response_parts)
 
@@ -621,23 +623,27 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
                 rag_content = rag_response.content
                 rag_metadata = rag_response.metadata
                 context_label = f"Retrieved context from {display_source}"
+                refs_display_source = display_source
             else:
                 # Multiple sources: combine all as raw context
                 rag_content, rag_metadata = self._combine_rag_contexts(source_responses)
                 context_label = f"Retrieved context from {len(source_responses)} RAG sources"
+                refs_display_source = f"{len(source_responses)} sources"
 
-            # Integrate RAG context into messages
+            # Integrate RAG context into messages with citation instructions
+            from atlas.modules.rag.citation_formatter import build_citation_context, build_references_marker
+
             messages_with_rag = messages.copy()
             rag_context_message = {
                 "role": "system",
-                "content": f"{context_label}:\n\n{rag_content}\n\nUse this context to inform your response."
+                "content": build_citation_context(rag_content, rag_metadata, context_label),
             }
             messages_with_rag.insert(-1, rag_context_message)
 
             logger.debug("[LLM+RAG] Calling LLM with RAG-enriched context...")
             llm_response = await self.call_plain(model_name, messages_with_rag, temperature=temperature, user_email=user_email)
 
-            # Only append metadata if RAG actually provided useful content
+            # Only append references marker if RAG actually provided useful content
             rag_content_useful = bool(
                 rag_content
                 and rag_content.strip()
@@ -649,9 +655,9 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             )
 
             if rag_content_useful and rag_metadata:
-                metadata_summary = self._format_rag_metadata(rag_metadata)
-                if metadata_summary and metadata_summary != "Metadata unavailable":
-                    llm_response += f"\n\n---\n**RAG Sources & Processing Info:**\n{metadata_summary}"
+                marker = build_references_marker(rag_metadata, refs_display_source)
+                if marker:
+                    llm_response += f"\n\n{marker}"
 
             logger.info(
                 "[LLM+RAG] RAG-integrated query complete: response_length=%d, rag_content_useful=%s",
@@ -818,23 +824,27 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
                     rag_content = rag_response.content
                     context_label = f"Retrieved context from {display_source}"
                 rag_metadata = rag_response.metadata
+                refs_display_source = display_source
             else:
                 # Multiple sources: combine all as raw context
                 rag_content, rag_metadata = self._combine_rag_contexts(source_responses)
                 context_label = f"Retrieved context from {len(source_responses)} RAG sources"
+                refs_display_source = f"{len(source_responses)} sources"
 
-            # Integrate RAG context into messages
+            # Integrate RAG context into messages with citation instructions
+            from atlas.modules.rag.citation_formatter import build_citation_context, build_references_marker
+
             messages_with_rag = messages.copy()
             rag_context_message = {
                 "role": "system",
-                "content": f"{context_label}:\n\n{rag_content}\n\nUse this context to inform your response."
+                "content": build_citation_context(rag_content, rag_metadata, context_label),
             }
             messages_with_rag.insert(-1, rag_context_message)
 
             logger.debug("[LLM+RAG+Tools] Calling LLM with RAG-enriched context and tools...")
             llm_response = await self.call_with_tools(model_name, messages_with_rag, tools_schema, tool_choice, temperature=temperature, user_email=user_email)
 
-            # Only append metadata if RAG actually provided useful content
+            # Only append references marker if RAG actually provided useful content
             rag_content_useful = bool(
                 rag_content
                 and rag_content.strip()
@@ -846,9 +856,9 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             )
 
             if rag_content_useful and rag_metadata and not llm_response.has_tool_calls():
-                metadata_summary = self._format_rag_metadata(rag_metadata)
-                if metadata_summary and metadata_summary != "Metadata unavailable":
-                    llm_response.content += f"\n\n---\n**RAG Sources & Processing Info:**\n{metadata_summary}"
+                marker = build_references_marker(rag_metadata, refs_display_source)
+                if marker:
+                    llm_response.content += f"\n\n{marker}"
 
             logger.info(
                 "[LLM+RAG+Tools] RAG+tools query complete: response_length=%d, has_tool_calls=%s, rag_content_useful=%s",
@@ -869,7 +879,7 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
         """Format RAG metadata into a user-friendly summary."""
         # Import here to avoid circular imports
         try:
-            from atlas.modules.rag.models import RAGMetadata
+            from atlas.modules.rag.client import RAGMetadata
             if not isinstance(metadata, RAGMetadata):
                 return "Metadata unavailable"
         except ImportError:

--- a/atlas/modules/llm/litellm_streaming.py
+++ b/atlas/modules/llm/litellm_streaming.py
@@ -230,26 +230,39 @@ class LiteLLMStreamingMixin:
                 yield chunk
             return
 
+        from atlas.modules.rag.citation_formatter import build_citation_context, build_references_marker
+
         # Single source with direct completion
+        rag_metadata = None
+        refs_display_source = None
         if len(data_sources) == 1:
             display_source, rag_response = source_responses[0]
             if rag_response.is_completion:
                 yield self._build_rag_completion_response(rag_response, display_source)
                 return
             rag_content = rag_response.content
+            rag_metadata = rag_response.metadata
             context_label = f"Retrieved context from {display_source}"
+            refs_display_source = display_source
         else:
-            rag_content, _ = self._combine_rag_contexts(source_responses)
+            rag_content, rag_metadata = self._combine_rag_contexts(source_responses)
             context_label = f"Retrieved context from {len(source_responses)} RAG sources"
+            refs_display_source = f"{len(source_responses)} sources"
 
         messages_with_rag = messages.copy()
         messages_with_rag.insert(-1, {
             "role": "system",
-            "content": f"{context_label}:\n\n{rag_content}\n\nUse this context to inform your response.",
+            "content": build_citation_context(rag_content, rag_metadata, context_label),
         })
 
         async for chunk in self.stream_plain(model_name, messages_with_rag, temperature=temperature, user_email=user_email):
             yield chunk
+
+        # After streaming completes, yield the references marker
+        if rag_metadata:
+            marker = build_references_marker(rag_metadata, refs_display_source)
+            if marker:
+                yield f"\n\n{marker}"
 
     async def stream_with_rag_and_tools(
         self,
@@ -289,6 +302,10 @@ class LiteLLMStreamingMixin:
                 yield item
             return
 
+        from atlas.modules.rag.citation_formatter import build_citation_context, build_references_marker
+
+        rag_metadata = None
+        refs_display_source = None
         if len(data_sources) == 1:
             display_source, rag_response = source_responses[0]
             if rag_response.is_completion:
@@ -297,17 +314,26 @@ class LiteLLMStreamingMixin:
             else:
                 rag_content = rag_response.content
                 context_label = f"Retrieved context from {display_source}"
+            rag_metadata = rag_response.metadata
+            refs_display_source = display_source
         else:
-            rag_content, _ = self._combine_rag_contexts(source_responses)
+            rag_content, rag_metadata = self._combine_rag_contexts(source_responses)
             context_label = f"Retrieved context from {len(source_responses)} RAG sources"
+            refs_display_source = f"{len(source_responses)} sources"
 
         messages_with_rag = messages.copy()
         messages_with_rag.insert(-1, {
             "role": "system",
-            "content": f"{context_label}:\n\n{rag_content}\n\nUse this context to inform your response.",
+            "content": build_citation_context(rag_content, rag_metadata, context_label),
         })
 
         async for item in self.stream_with_tools(
             model_name, messages_with_rag, tools_schema, tool_choice, temperature=temperature, user_email=user_email
         ):
             yield item
+
+        # Yield references marker after streaming if metadata available
+        if rag_metadata:
+            marker = build_references_marker(rag_metadata, refs_display_source)
+            if marker:
+                yield f"\n\n{marker}"

--- a/atlas/modules/rag/citation_formatter.py
+++ b/atlas/modules/rag/citation_formatter.py
@@ -1,0 +1,148 @@
+"""Utilities for formatting RAG citations and references.
+
+Provides functions to:
+- Build LLM context messages with numbered source references
+- Generate structured reference markers for frontend rendering
+- Extract reference data from response content
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+_MARKER_PREFIX = "<!-- RAG_REFERENCES_JSON:"
+_MARKER_SUFFIX = "-->"
+
+
+def format_source_list(metadata) -> List[Dict[str, Any]]:
+    """Extract numbered source list from RAG metadata.
+
+    Args:
+        metadata: RAGMetadata instance or None.
+
+    Returns:
+        List of dicts with keys: index, source, content_type, confidence, chunk_id.
+    """
+    if metadata is None:
+        return []
+    docs = getattr(metadata, "documents_found", None) or []
+    sources = []
+    for i, doc in enumerate(docs, start=1):
+        sources.append({
+            "index": i,
+            "source": doc.source,
+            "content_type": getattr(doc, "content_type", "unknown"),
+            "confidence": doc.confidence_score,
+            "chunk_id": getattr(doc, "chunk_id", None),
+        })
+    return sources
+
+
+def build_citation_context(
+    rag_content: str,
+    metadata,
+    context_label: str,
+) -> str:
+    """Build an LLM system message with RAG context and citation instructions.
+
+    When metadata contains document sources, the message instructs the LLM to
+    use inline citations like [1], [2] and includes a numbered source list.
+
+    Args:
+        rag_content: Retrieved text from RAG backend.
+        metadata: RAGMetadata instance or None.
+        context_label: Display name of the data source.
+
+    Returns:
+        Formatted system message content string.
+    """
+    sources = format_source_list(metadata)
+
+    if not sources:
+        return (
+            f"Retrieved context from {context_label}:\n\n"
+            f"{rag_content}\n\n"
+            f"Use this context to inform your response."
+        )
+
+    # Build numbered source reference block
+    source_lines = []
+    for s in sources:
+        line = f"[{s['index']}] {s['source']}"
+        if s.get("content_type"):
+            line += f" ({s['content_type']})"
+        if s.get("confidence"):
+            line += f" — {int(s['confidence'] * 100)}% relevance"
+        source_lines.append(line)
+
+    sources_block = "\n".join(source_lines)
+
+    return (
+        f"Retrieved context from {context_label}:\n\n"
+        f"{rag_content}\n\n"
+        f"---\n"
+        f"Sources:\n{sources_block}\n\n"
+        f"IMPORTANT: When you use information from the retrieved context above, "
+        f"cite the source using inline numbered references like [1], [2], etc. "
+        f"corresponding to the source numbers listed above. Place citations at "
+        f"the end of the relevant sentence or claim. You do not need to add a "
+        f"separate references section — one will be generated automatically."
+    )
+
+
+def build_references_marker(metadata, display_source: str) -> str:
+    """Build an HTML comment marker carrying structured citation data.
+
+    The marker is appended to the LLM response so the frontend can parse
+    it and render a styled references section.
+
+    Args:
+        metadata: RAGMetadata instance or None.
+        display_source: Display name of the data source.
+
+    Returns:
+        HTML comment string, or empty string if no metadata.
+    """
+    sources = format_source_list(metadata)
+    if not sources:
+        return ""
+
+    payload = {
+        "data_source": display_source,
+        "retrieval_method": getattr(metadata, "retrieval_method", "unknown"),
+        "processing_time_ms": getattr(metadata, "query_processing_time_ms", 0),
+        "total_searched": getattr(metadata, "total_documents_searched", 0),
+        "sources": sources,
+    }
+    return f"{_MARKER_PREFIX}{json.dumps(payload, separators=(',', ':'))}{_MARKER_SUFFIX}"
+
+
+def extract_references_json(content: str) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Extract RAG references JSON from response content.
+
+    Looks for the <!-- RAG_REFERENCES_JSON:{...}--> marker, strips it from
+    the content, and returns the parsed data alongside the clean text.
+
+    Args:
+        content: Response text possibly containing a references marker.
+
+    Returns:
+        Tuple of (clean_content, references_dict_or_None).
+    """
+    pattern = re.compile(
+        re.escape(_MARKER_PREFIX) + r"(.+?)" + re.escape(_MARKER_SUFFIX),
+        re.DOTALL,
+    )
+    match = pattern.search(content)
+    if not match:
+        return content, None
+
+    try:
+        refs = json.loads(match.group(1))
+    except (json.JSONDecodeError, ValueError):
+        return content, None
+
+    clean = content[: match.start()].rstrip()
+    return clean, refs

--- a/atlas/tests/test_rag_citation_formatter.py
+++ b/atlas/tests/test_rag_citation_formatter.py
@@ -1,0 +1,152 @@
+"""Tests for RAG citation formatting utilities."""
+
+import json
+
+import pytest
+
+from atlas.modules.rag.client import DocumentMetadata, RAGMetadata, RAGResponse
+
+
+def _sample_metadata():
+    return RAGMetadata(
+        query_processing_time_ms=150,
+        total_documents_searched=100,
+        documents_found=[
+            DocumentMetadata(
+                source="technical-manual-v3.pdf",
+                content_type="pdf",
+                confidence_score=0.95,
+                chunk_id="chunk-42",
+            ),
+            DocumentMetadata(
+                source="safety-guidelines.docx",
+                content_type="docx",
+                confidence_score=0.82,
+            ),
+        ],
+        data_source_name="engineering-docs",
+        retrieval_method="similarity",
+    )
+
+
+class TestFormatSourceList:
+    def test_extracts_source_info(self):
+        from atlas.modules.rag.citation_formatter import format_source_list
+
+        meta = _sample_metadata()
+        sources = format_source_list(meta)
+        assert len(sources) == 2
+        assert sources[0]["index"] == 1
+        assert sources[0]["source"] == "technical-manual-v3.pdf"
+        assert sources[0]["confidence"] == 0.95
+        assert sources[1]["index"] == 2
+
+    def test_empty_metadata(self):
+        from atlas.modules.rag.citation_formatter import format_source_list
+
+        meta = RAGMetadata(
+            query_processing_time_ms=0,
+            total_documents_searched=0,
+            documents_found=[],
+            data_source_name="empty",
+            retrieval_method="none",
+        )
+        assert format_source_list(meta) == []
+
+    def test_none_metadata(self):
+        from atlas.modules.rag.citation_formatter import format_source_list
+
+        assert format_source_list(None) == []
+
+
+class TestBuildCitationContext:
+    def test_includes_numbered_sources(self):
+        from atlas.modules.rag.citation_formatter import build_citation_context
+
+        meta = _sample_metadata()
+        result = build_citation_context(
+            rag_content="Some retrieved text",
+            metadata=meta,
+            context_label="engineering-docs",
+        )
+        assert "[1]" in result
+        assert "[2]" in result
+        assert "technical-manual-v3.pdf" in result
+        assert "safety-guidelines.docx" in result
+
+    def test_includes_citation_instructions(self):
+        from atlas.modules.rag.citation_formatter import build_citation_context
+
+        meta = _sample_metadata()
+        result = build_citation_context("text", meta, "docs")
+        assert "cite" in result.lower() or "[1]" in result
+
+    def test_no_metadata_returns_plain_context(self):
+        from atlas.modules.rag.citation_formatter import build_citation_context
+
+        result = build_citation_context("plain text", None, "docs")
+        assert "plain text" in result
+        assert "[1]" not in result
+
+    def test_empty_documents_returns_plain_context(self):
+        from atlas.modules.rag.citation_formatter import build_citation_context
+
+        meta = RAGMetadata(
+            query_processing_time_ms=0,
+            total_documents_searched=0,
+            documents_found=[],
+            data_source_name="empty",
+            retrieval_method="none",
+        )
+        result = build_citation_context("text", meta, "docs")
+        assert "cite" not in result.lower()
+
+
+class TestBuildReferencesMarker:
+    def test_produces_html_comment(self):
+        from atlas.modules.rag.citation_formatter import build_references_marker
+
+        meta = _sample_metadata()
+        marker = build_references_marker(meta, "engineering-docs")
+        assert marker.startswith("<!-- RAG_REFERENCES_JSON:")
+        assert marker.endswith("-->")
+
+    def test_valid_json_payload(self):
+        from atlas.modules.rag.citation_formatter import build_references_marker
+
+        meta = _sample_metadata()
+        marker = build_references_marker(meta, "engineering-docs")
+        json_str = marker.replace("<!-- RAG_REFERENCES_JSON:", "").replace("-->", "")
+        data = json.loads(json_str)
+        assert "sources" in data
+        assert len(data["sources"]) == 2
+        assert data["data_source"] == "engineering-docs"
+        assert data["retrieval_method"] == "similarity"
+
+    def test_none_metadata_returns_empty_string(self):
+        from atlas.modules.rag.citation_formatter import build_references_marker
+
+        assert build_references_marker(None, "x") == ""
+
+
+class TestExtractReferencesJson:
+    def test_extracts_from_content(self):
+        from atlas.modules.rag.citation_formatter import (
+            build_references_marker,
+            extract_references_json,
+        )
+
+        meta = _sample_metadata()
+        marker = build_references_marker(meta, "docs")
+        content = f"Some response text.\n\n{marker}"
+        clean, refs = extract_references_json(content)
+        assert clean.strip() == "Some response text."
+        assert refs is not None
+        assert len(refs["sources"]) == 2
+
+    def test_no_marker_returns_none(self):
+        from atlas.modules.rag.citation_formatter import extract_references_json
+
+        clean, refs = extract_references_json("No citations here.")
+        assert clean == "No citations here."
+        assert refs is None

--- a/atlas/tests/test_rag_citation_integration.py
+++ b/atlas/tests/test_rag_citation_integration.py
@@ -1,0 +1,128 @@
+"""Integration tests for RAG citation output from LiteLLMCaller."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from atlas.modules.rag.client import DocumentMetadata, RAGMetadata, RAGResponse
+from atlas.modules.rag.citation_formatter import extract_references_json
+
+
+def _make_caller():
+    from atlas.modules.llm.litellm_caller import LiteLLMCaller
+
+    caller = LiteLLMCaller.__new__(LiteLLMCaller)
+    caller._rag_service = MagicMock()
+    caller.llm_config = MagicMock()
+    caller.llm_config.models = {}
+    return caller
+
+
+def _rag_response_with_metadata(content="Retrieved docs", is_completion=False):
+    meta = RAGMetadata(
+        query_processing_time_ms=100,
+        total_documents_searched=50,
+        documents_found=[
+            DocumentMetadata(source="manual.pdf", content_type="pdf", confidence_score=0.9),
+            DocumentMetadata(source="guide.docx", content_type="docx", confidence_score=0.75),
+        ],
+        data_source_name="test-source",
+        retrieval_method="similarity",
+    )
+    return RAGResponse(content=content, metadata=meta, is_completion=is_completion)
+
+
+@pytest.mark.asyncio
+async def test_call_with_rag_appends_references_marker():
+    """call_with_rag should append a RAG_REFERENCES_JSON marker when metadata exists."""
+    caller = _make_caller()
+    rag_resp = _rag_response_with_metadata()
+
+    caller._query_all_rag_sources = AsyncMock(return_value=[("test-source", rag_resp)])
+    caller.call_plain = AsyncMock(return_value="LLM synthesized answer with citations [1].")
+
+    result = await caller.call_with_rag(
+        model_name="test-model",
+        messages=[{"role": "user", "content": "How does X work?"}],
+        data_sources=["test:test-source"],
+        user_email="user@example.com",
+    )
+
+    assert "RAG_REFERENCES_JSON" in result
+    clean, refs = extract_references_json(result)
+    assert refs is not None
+    assert len(refs["sources"]) == 2
+    assert refs["sources"][0]["source"] == "manual.pdf"
+
+
+@pytest.mark.asyncio
+async def test_call_with_rag_citation_instructions_in_system_message():
+    """The RAG context message should include citation instructions."""
+    caller = _make_caller()
+    rag_resp = _rag_response_with_metadata()
+
+    caller._query_all_rag_sources = AsyncMock(return_value=[("test-source", rag_resp)])
+
+    captured_messages = []
+
+    async def capture_call_plain(model, messages, **kwargs):
+        captured_messages.extend(messages)
+        return "Answer"
+
+    caller.call_plain = AsyncMock(side_effect=capture_call_plain)
+
+    await caller.call_with_rag(
+        model_name="test-model",
+        messages=[{"role": "user", "content": "question"}],
+        data_sources=["test:test-source"],
+        user_email="user@example.com",
+    )
+
+    # Find the RAG context system message
+    rag_msgs = [
+        m
+        for m in captured_messages
+        if m["role"] == "system" and "Retrieved context" in m.get("content", "")
+    ]
+    assert len(rag_msgs) == 1
+    assert "[1]" in rag_msgs[0]["content"]
+    assert "cite" in rag_msgs[0]["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_call_with_rag_completion_includes_marker():
+    """Direct RAG completions (is_completion=True) should also include the marker."""
+    caller = _make_caller()
+    rag_resp = _rag_response_with_metadata(content="Direct answer", is_completion=True)
+
+    caller._query_all_rag_sources = AsyncMock(return_value=[("test-source", rag_resp)])
+
+    result = await caller.call_with_rag(
+        model_name="test-model",
+        messages=[{"role": "user", "content": "question"}],
+        data_sources=["test:test-source"],
+        user_email="user@example.com",
+    )
+
+    assert "RAG_REFERENCES_JSON" in result
+    clean, refs = extract_references_json(result)
+    assert refs is not None
+
+
+@pytest.mark.asyncio
+async def test_call_with_rag_no_metadata_no_marker():
+    """When RAG has no metadata, no references marker should be appended."""
+    caller = _make_caller()
+    rag_resp = RAGResponse(content="Answer without metadata", metadata=None, is_completion=False)
+
+    caller._query_all_rag_sources = AsyncMock(return_value=[("test-source", rag_resp)])
+    caller.call_plain = AsyncMock(return_value="LLM answer")
+
+    result = await caller.call_with_rag(
+        model_name="test-model",
+        messages=[{"role": "user", "content": "question"}],
+        data_sources=["test:test-source"],
+        user_email="user@example.com",
+    )
+
+    assert "RAG_REFERENCES_JSON" not in result

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -334,6 +334,75 @@ const copyMessageContent = (content, button) => {
   }
 }
 
+// Extract RAG references JSON marker from response content
+const RAG_REFS_PATTERN = /<!-- RAG_REFERENCES_JSON:([\s\S]+?)-->/
+const extractRagReferences = (content) => {
+  if (typeof content !== 'string') return { clean: content, refs: null }
+  const match = content.match(RAG_REFS_PATTERN)
+  if (!match) return { clean: content, refs: null }
+  try {
+    const refs = JSON.parse(match[1])
+    const clean = content.slice(0, match.index).trimEnd()
+    return { clean, refs }
+  } catch {
+    return { clean: content, refs: null }
+  }
+}
+
+// Collapsible RAG References section
+const RagReferences = ({ refs }) => {
+  const [expanded, setExpanded] = useState(false)
+  if (!refs || !refs.sources || refs.sources.length === 0) return null
+
+  return (
+    <div className="mt-4 border border-gray-600 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setExpanded(e => !e)}
+        className="w-full flex items-center justify-between px-4 py-2 bg-gray-700/50 hover:bg-gray-700 transition-colors text-sm text-gray-300 cursor-pointer"
+        type="button"
+      >
+        <span className="font-medium">
+          References ({refs.sources.length} source{refs.sources.length !== 1 ? 's' : ''})
+        </span>
+        <svg
+          className={`w-4 h-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {expanded && (
+        <div className="px-4 py-3 bg-gray-800/50 space-y-2">
+          {refs.sources.map((s, i) => (
+            <div key={i} className="flex items-start gap-2 text-sm">
+              <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-600/20 text-blue-400 text-xs font-bold flex-shrink-0 mt-0.5">
+                {s.index}
+              </span>
+              <div className="min-w-0">
+                <span className="text-gray-200 font-medium break-all">{s.source}</span>
+                <div className="flex flex-wrap gap-2 mt-0.5">
+                  {s.content_type && (
+                    <span className="text-xs text-gray-500 uppercase">{s.content_type}</span>
+                  )}
+                  {s.confidence != null && (
+                    <span className="text-xs text-gray-500">{Math.round(s.confidence * 100)}% relevance</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+          {refs.retrieval_method && (
+            <div className="text-xs text-gray-500 pt-1 border-t border-gray-700">
+              Retrieved via {refs.retrieval_method} from {refs.data_source}
+              {refs.processing_time_ms > 0 && ` in ${refs.processing_time_ms}ms`}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // Helper function to process message content (strings and structured objects)
 const processMessageContent = (content) => {
   let processedContent = ''
@@ -1156,24 +1225,31 @@ const renderContent = () => {
     // Process content to handle both strings and structured objects
     const content = processMessageContent(message.content)
 
+    // Extract RAG references before markdown processing
+    const { clean: cleanContent, refs: ragRefs } = extractRagReferences(content)
+
     try {
-      const { result: latexProcessed, placeholders } = preProcessLatex(content)
+      const { result: latexProcessed, placeholders } = preProcessLatex(cleanContent)
       const markdownHtml = marked.parse(latexProcessed)
       const latexRestoredHtml = restoreLatexPlaceholders(markdownHtml, placeholders)
       const sanitizedHtml = DOMPurify.sanitize(latexRestoredHtml, DOMPURIFY_CONFIG)
 
       return (
-        <div
-          className="prose prose-invert max-w-none selectable-markdown"
-          dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-        />
+        <>
+          <div
+            className="prose prose-invert max-w-none selectable-markdown"
+            dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+          />
+          <RagReferences refs={ragRefs} />
+        </>
       )
     } catch (error) {
       console.error('Error parsing markdown content:', error)
       // Fallback to plain text if markdown parsing fails
       return (
         <div className="text-gray-200">
-          <pre className="whitespace-pre-wrap">{content}</pre>
+          <pre className="whitespace-pre-wrap">{cleanContent}</pre>
+          <RagReferences refs={ragRefs} />
         </div>
       )
     }


### PR DESCRIPTION
## Summary

- Adds inline citations `[1]`, `[2]` to RAG responses via LLM prompt engineering — the system message now includes numbered source references and instructs the LLM to cite sources inline
- Renders a collapsible **References** section below RAG responses showing sources, confidence scores, content types, and retrieval metadata
- Backend passes structured citation data via an HTML comment marker (`<!-- RAG_REFERENCES_JSON:... -->`) for clean frontend parsing that doesn't interfere with markdown rendering
- Fixes an existing import bug in `_format_rag_metadata` (was importing from non-existent `atlas.modules.rag.models`)

Closes #443

## Changes

### Backend
- **New module** `atlas/modules/rag/citation_formatter.py` — shared functions for building citation context, reference markers, and parsing
- **Modified** `atlas/modules/llm/litellm_caller.py` — `call_with_rag`, `call_with_rag_and_tools`, and `_build_rag_completion_response` now use citation-aware context and append structured reference markers
- **Modified** `atlas/modules/llm/litellm_streaming.py` — `stream_with_rag` and `stream_with_rag_and_tools` yield reference markers after streaming completes

### Frontend
- **Modified** `frontend/src/components/Message.jsx` — extracts RAG references marker before markdown processing, renders collapsible `RagReferences` component with numbered source badges

### Tests
- 12 unit tests for `citation_formatter` module
- 4 integration tests for `call_with_rag` citation output
- All 980 existing tests pass (0 regressions)

## Test plan

- [x] Unit tests for citation_formatter module (12/12 pass)
- [x] Integration tests for call_with_rag citation output (4/4 pass)
- [x] Full backend test suite passes (980 passed, 14 skipped)
- [x] Frontend builds successfully
- [ ] Manual verification with RAG data sources enabled
- [ ] Verify no References section appears for non-RAG messages
- [ ] Verify streaming responses show References after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)