### PR TITLE
Clean up AGENTS.md: remove duplicates and trim stale content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Last updated: 2026-03-12
+Last updated: 2026-03-19
 
 This project is developed for the U.S. Department of Energy (DOE). Operational security (OPSEC) requirements apply to all project artifacts -- see the Security section for details. Note: `AGENTS.md` is an industry-standard configuration format recognized by all major AI coding agents. The filename itself is not an OPSEC violation.
 
@@ -16,103 +16,86 @@ Atlas UI 3 is a full-stack LLM chat interface with Model Context Protocol (MCP) 
 - Python Package Manager: **uv** (NOT pip!)
 - Configuration: Pydantic with YAML/JSON configs
 
-**PyPI Packaging**: The CI workflow bundles the frontend into `atlas/static/` before building the wheel; at runtime `atlas/main.py` checks `atlas/static/` first (package install) then falls back to `frontend/dist/` (local dev), so both paths work transparently.
+**PyPI Packaging**: CI bundles the frontend into `atlas/static/` before building the wheel; at runtime `atlas/main.py` checks `atlas/static/` first (package install) then falls back to `frontend/dist/` (local dev).
 
-**Dependency Management**: All Python dependencies are defined in `pyproject.toml` (the single source of truth); there is no `requirements.txt` -- always use `uv pip install -e ".[dev]"` for development. Core dependencies are minimal; data-science and MCP demo packages (matplotlib, pandas, numpy, etc.) live in the `mcp-demos` optional extra and are pulled in automatically by `uv sync --dev`.
+**Dependency Management**: All Python dependencies are in `pyproject.toml` (single source of truth); no `requirements.txt`. Use `uv pip install -e ".[dev]"` for development. Data-science and MCP demo packages live in the `mcp-demos` optional extra.
 
-**Version Bumps**: When bumping the version, update both `pyproject.toml` and `atlas/version.py` atomically in the same commit to keep them in sync.
+**Version Bumps**: Update both `pyproject.toml` and `atlas/version.py` atomically in the same commit.
 
-**Lazy Imports**: `atlas/__init__.py` uses `__getattr__` to lazily import `AtlasClient` and `ChatResult` so that lightweight CLIs like `atlas-init` do not pay the cost of loading the full dependency chain (SQLAlchemy, litellm, FastAPI, etc.).
-
-**LLM Streaming**: Token streaming uses `LiteLLMStreamingMixin` (in `litellm_streaming.py`) mixed into `LiteLLMCaller` to keep files under 400 lines; the frontend buffers tokens with `setTimeout(30ms)` -- never use `requestAnimationFrame` for token flushing as it breaks progressive rendering.
-
-**Follow-up Suggestions**: The `FEATURE_FOLLOWUP_SUGGESTIONS_ENABLED` flag enables clickable follow-up question buttons after each assistant response; suggestions are generated via `POST /api/suggest_followups` and rendered in `ChatArea.jsx` above the input footer.
-
-**File Attachments**: The chat textarea supports click-to-upload, drag-and-drop, and paste (Ctrl+V / Cmd+V) for attaching images and documents; pasted files without a meaningful name receive a timestamped filename (e.g., `pasted_image_<timestamp>.png`).
+**LLM Streaming**: The frontend buffers tokens with `setTimeout(30ms)` -- never use `requestAnimationFrame` for token flushing as it breaks progressive rendering.
 
 ## Installation
 
-### As a Python Package (Recommended for Users)
+### As a Python Package
 
 ```bash
-# Install from PyPI
-pip install atlas-chat
-
-# Or with uv
-uv pip install atlas-chat
-
-# Use the CLI tools
-atlas-chat "Hello, how are you?" --model gpt-4o
+pip install atlas-chat       # or: uv pip install atlas-chat
+atlas-chat "Hello" --model gpt-4o
 atlas-server --port 8000
 
-# Or use programmatically
+# Programmatic use
 from atlas import AtlasClient
 client = AtlasClient()
 result = await client.chat("Hello!")
-print(result.message)
 ```
 
 ### For Development
 
 ```bash
-# Install uv (one-time)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Setup and run
+curl -LsSf https://astral.sh/uv/install.sh | sh   # one-time
 uv venv && source .venv/bin/activate
 uv pip install -e ".[dev]"
 bash agent_start.sh   # builds frontend, starts backend, seeds/mocks
 ```
 
-Manual quick run (alternative):
+Manual alternative:
 ```bash
-(frontend) cd frontend && npm install && npm run build
-(backend)  cd atlas && python main.py  # don't use uvicorn --reload
+cd frontend && npm install && npm run build
+cd atlas && python main.py  # don't use uvicorn --reload
 ```
 
 ## Style and Conventions
 
-**No Emojis**: No emojis should ever be added anywhere in this codebase (code, comments, docs, commit messages). If you find one, remove it.
+**No Emojis**: No emojis anywhere in the codebase. If you find one, remove it.
 
-**File Naming**: Do not use generic names like `main.py`, `cli.py`, `utils.py`, or `helpers.py`. Use descriptive names that reflect the file's purpose (e.g., `chat_service.py`, `mcp_tool_manager.py`, `websocket_handler.py`). Exception: top-level entry points like `atlas/main.py` are acceptable.
+**File Naming**: Use descriptive names (e.g., `chat_service.py`, `mcp_tool_manager.py`), not generic ones (`utils.py`, `helpers.py`). Exception: top-level entry points like `atlas/main.py`.
 
-**File Size**: Prefer files with 400 lines or fewer when practical.
+**File Size**: Prefer 400 lines or fewer.
 
-**Documentation Requirements**: Every PR or feature implementation MUST include updates to relevant documentation in the `/docs` folder. This includes:
-- Architecture changes: Update architecture docs
-- New features: Add feature documentation with usage examples
-- API changes: Update API documentation
-- Configuration changes: Update configuration guides
-- Bug fixes: Update troubleshooting docs if applicable
+**Documentation**: PRs must update relevant docs in `/docs` (architecture, features, API, config, troubleshooting).
 
-**Changelog Maintenance**: For every PR, add an entry to CHANGELOG.md in the root directory. Each entry should be 1-2 lines describing the core features or changes. Format: "### PR #<number> - YYYY-MM-DD" followed by a bullet point list of changes.
+**Changelog**: Add a 1-2 line entry to `CHANGELOG.md` for every PR. Format: `### PR #<number> - YYYY-MM-DD`.
 
-**AI Instruction File Maintenance**: For every PR, you MUST:
-1. **Add one helpful sentence** to `AGENTS.md` that captures a useful insight, convention, or lesson learned from the PR's changes.
-2. **Scan `AGENTS.md` for stale or out-of-date information**. If stale content is found, **warn the user** about what is outdated and where, but do **NOT** delete or modify the stale content unless the user explicitly asks you to.
-
-**Documentation Date-Time Stamping**: When creating markdown (.md) files, always include date-time stamps either in the filename or as a header in key sections to help track if docs are stale. Format: `YYYY-MM-DD` or `YYYY-MM-DD HH:MM`. Examples:
-- Filename: `feature-plan-2025-11-02.md`
-- Section header: `## Implementation Plan (2025-11-02)`
-- Status update: `Last updated: 2025-11-02 14:30`
+**Date Stamps**: Include `YYYY-MM-DD` dates in doc filenames or section headers to track staleness.
 
 ## Claude Code Agents
 
-This project uses Claude Code agents to ensure quality and completeness. Use these agents frequently:
+**test-report-runner**: Run frequently after code changes to verify tests pass.
 
-**test-report-runner**: Use this agent frequently after making code changes to run tests and verify correctness. Invoke proactively after each logical chunk of work: implementing a feature, fixing a bug, or refactoring code.
-
-**final-checklist-reviewer**: Use this agent once at the end of a PR, feature, or bug fix to validate that all project requirements, coding standards, and quality gates have been met. This is a final validation step, not something to run after every change. Invoke when work is complete and you hear phrases like "I think I'm done", "ready to merge", "let's create a PR", or "branch is finished".
+**final-checklist-reviewer**: Run once at the end of a PR to validate requirements, standards, and quality gates.
 
 ## Tests
 
-Before you mark a job as finished, be sure to run the unit test script:
+Run all tests before marking work as finished:
 
 ```bash
-bash run_test_shortcut.sh
+bash run_test_shortcut.sh          # quick shortcut
+./test/run_tests.sh all            # full suite (~2 min, NEVER CANCEL)
+./test/run_tests.sh backend        # ~5 seconds
+./test/run_tests.sh frontend       # ~6 seconds
+./test/run_tests.sh e2e            # ~70 seconds (may need auth config)
+cd frontend && npm test            # Vitest directly
 ```
 
-All tests must pass before a feature is pushed.
+**Linting (run before every commit):**
+```bash
+ruff check atlas/ || (uv pip install ruff && ruff check atlas/)
+cd frontend && npm run lint
+```
+
+**Before committing:** lint, test, build frontend, verify in browser at http://localhost:8000.
+
+**Before creating/merging a PR:** run `cd frontend && npm run lint` and any PR validation scripts.
 
 ## Architecture Overview
 
@@ -169,226 +152,101 @@ frontend/src/
    handlers/         # WebSocket message handlers
 ```
 
-**Config Loading Strategy:** The frontend uses a three-phase startup: (1) instant hydration from localStorage-cached config, (2) fast `/api/config/shell` fetch for feature flags and models (no MCP/RAG discovery), (3) full `/api/config` for tools/prompts/RAG. The `configReady` flag on `useChatConfig` indicates when at least one source has loaded. New config fields that are UI-affecting should be included in the shell endpoint.
-
-**Stale Selection Cleanup:** ChatContext validates persisted tool/prompt selections against the current `/api/config` response and removes entries that no longer exist (e.g., removed servers, changed authorization). MarketplaceContext similarly prunes stale server selections. Follow this pattern when adding new persisted selections.
-
-**Polling with Backoff:** All frontend polling must use exponential backoff with jitter on failures to prevent backend DOS. Use the shared `usePollingWithBackoff` hook or `calculateBackoffDelay` from `hooks/usePollingWithBackoff.js`. Never use bare `setInterval` for backend polling.
-
-**RAG+Tools `is_completion` Handling:** When both RAG and tools are active, RAG `is_completion=True` responses must NOT short-circuit the LLM call; instead inject the pre-synthesized content as context so tools remain available to the model.
-
-**RAG UI Toggle Pattern:** The chat input search-glass button and the header Sources button have distinct roles: the search glass controls RAG activation (green = active, click to clear; gray = inactive, click to open panel), while the header Sources button only toggles the Data Sources sidebar visibility without changing selection state. Panel-open callbacks from ChatArea to App.jsx are passed as props (`onOpenRagPanel`) since panel visibility lives in App.jsx state, not in ChatContext.
-
-**RAG Activation vs Selection:** In `ChatContext.sendChatMessage`, data sources are only sent to the backend when RAG is explicitly activated (`ragEnabled` toggle or `/search` command). Selecting data sources in the UI only marks availability; the backend orchestrator routes to RAG mode only when `selected_data_sources` is non-empty, so the frontend must gate what it sends.
-
-**3-State Save Mode:** Chat history uses a 3-state `saveMode` (`none`/`local`/`server`) persisted via `usePersistentState`. "local" mode saves conversations to IndexedDB in the browser (`localConversationDB.js`), "server" saves to the backend database, and "none" is incognito. The Sidebar calls both `useConversationHistory` and `useLocalConversationHistory` hooks unconditionally (React rules of hooks) then picks the active one based on `saveMode`.
-
-**Event Flow:**
-```
-User Input -> ChatContext -> WebSocket -> Backend ChatService
-  <- Streaming Updates <- tool_use/canvas_content/files_update <-
-```
-
 ### Key Architectural Patterns
 
-1. **Protocol-Based Dependency Injection**: Uses Python `Protocol` (structural subtyping) instead of ABC inheritance for loose coupling
+1. **Protocol-Based DI**: Uses Python `Protocol` (structural subtyping) instead of ABC for loose coupling
 
-2. **Agent Loop Strategy Pattern**: Four implementations selectable via `APP_AGENT_LOOP_STRATEGY`:
+2. **Agent Loop Strategy Pattern**: Four strategies via `APP_AGENT_LOOP_STRATEGY`:
    - `agentic`: Claude-native loop, no control tools, `tool_choice="auto"` (best for Anthropic models)
    - `react`: Reason-Act-Observe cycle (structured reasoning)
    - `think-act`: Extended thinking (slower, complex reasoning)
    - `act`: Pure action loop (fastest, minimal overhead)
+   The `agentic` strategy lets the model manage its own control flow (text-only = done); `react`/`think-act`/`act` use scaffolding tools like `finished` and `agent_decide_next`.
 
-3. **MCP Transport Auto-Detection**: Automatically detects stdio, HTTP, or SSE based on config
+3. **MCP Transport Auto-Detection**: Detects stdio, HTTP, or SSE based on config
 
-4. **Two-Layer Configuration**: User config in `config/` (created by `atlas-init`) overrides package defaults in `atlas/config/`. Set `APP_CONFIG_DIR` to customize the user config directory. `atlas-server` auto-detects a `config/` directory next to the loaded `.env` file, so package installs work without explicit `--config-folder` flags.
+4. **Two-Layer Configuration**: User config in `config/` (created by `atlas-init`) overrides package defaults in `atlas/config/`. Set `APP_CONFIG_DIR` to customize. `atlas-server` auto-detects a `config/` directory next to the loaded `.env` file.
 
-## Configuration and Feature Flags
+5. **Multi-Tool Calling**: All agent loops execute multiple tool calls from a single LLM response in parallel via `asyncio.gather`; individual failures become error `ToolResult`s so other tools still succeed.
 
-### Configuration Files
-- **LLM Config**: `atlas/config/llmconfig.yml` (user overrides in `config/llmconfig.yml` or via `--llm-config`)
-- **MCP Servers**: `atlas/config/mcp.json` (user overrides in `config/mcp.json` or via `--mcp-config`)
-- **RAG Sources**: `atlas/config/rag-sources.json` (user overrides in `config/rag-sources.json` or via `--rag-sources-config`)
-- **Help Config**: `atlas/config/help-config.json`
+### Frontend Patterns
+
+**Config Loading**: Three-phase startup: (1) localStorage cache, (2) `/api/config/shell` for feature flags/models, (3) full `/api/config`. New UI-affecting config fields should go in the shell endpoint.
+
+**Polling**: All polling must use exponential backoff with jitter. Use `usePollingWithBackoff` hook. Never use bare `setInterval`.
+
+**RAG+Tools**: When both RAG and tools are active, RAG `is_completion=True` responses must NOT short-circuit the LLM call; inject as context so tools remain available.
+
+**RAG Activation vs Selection**: Data sources are only sent to backend when RAG is explicitly activated (`ragEnabled` or `/search`). Selecting sources only marks availability.
+
+## Configuration
+
+### Config Files
+- **LLM**: `atlas/config/llmconfig.yml` (user overrides in `config/llmconfig.yml`)
+- **MCP Servers**: `atlas/config/mcp.json` (user overrides in `config/mcp.json`)
+- **RAG Sources**: `atlas/config/rag-sources.json` (user overrides in `config/rag-sources.json`)
+- **Help**: `atlas/config/help-config.json`
 - **Compliance Levels**: `atlas/config/compliance-levels.json`
-- **MCP Examples**: `atlas/config/mcp-example-configs/` (shipped with package)
+- **MCP Examples**: `atlas/config/mcp-example-configs/`
 - **Environment**: `.env` (copy from `.env.example`)
 
 ### Feature Flags (AppSettings)
-- `FEATURE_TOOLS_ENABLED` - Enable/disable MCP tools
-- `FEATURE_RAG_MCP_ENABLED` - Enable/disable RAG over MCP
-- `FEATURE_COMPLIANCE_LEVELS_ENABLED` - Enable/disable compliance level enforcement
-- `FEATURE_AGENT_MODE_AVAILABLE` - Enable/disable agent mode UI toggle
-- `VITE_FEATURE_ANIMATED_LOGO` - Enable/disable animated logo on welcome screen (build-time Vite flag; must also be added to `Dockerfile` ARG and to the `test_docker_env_sync.py` exclusion list when introducing new `VITE_FEATURE_*` flags)
+- `FEATURE_TOOLS_ENABLED` - MCP tools
+- `FEATURE_RAG_MCP_ENABLED` - RAG over MCP
+- `FEATURE_COMPLIANCE_LEVELS_ENABLED` - Compliance level enforcement
+- `FEATURE_AGENT_MODE_AVAILABLE` - Agent mode UI toggle
+- `VITE_FEATURE_ANIMATED_LOGO` - Animated logo (build-time Vite flag; must also be added to `Dockerfile` ARG and `test_docker_env_sync.py` exclusion list)
 
 ## Per-User LLM API Keys
 
-Models in `llmconfig.yml` can set `api_key_source: "user"` to require per-user API keys instead of system env vars. The `MCPTokenStorage` is reused with `"llm:{model_name}"` as the server_name key, and `user_email` is threaded through all LLM call paths (`LLMProtocol`, `LiteLLMCaller`, agent loops, orchestrator). REST endpoints live at `/api/llm/auth/` and the frontend reuses `TokenInputModal`.
+Models in `llmconfig.yml` can set `api_key_source: "user"` to require per-user keys. Reuses `MCPTokenStorage` with `"llm:{model_name}"` as key. REST endpoints at `/api/llm/auth/`, frontend reuses `TokenInputModal`.
 
 ## Globus OAuth for ALCF Endpoints
 
-Models can also set `api_key_source: "globus"` with a `globus_scope` field (the Globus resource server UUID) to use tokens obtained via Globus OAuth. The Globus auth flow stores scoped tokens in MCPTokenStorage keyed as `"globus:{resource_server}"`. Browser-facing OAuth routes at `/auth/globus/` are excluded from the AuthMiddleware and require SessionMiddleware for CSRF state.
+Models can set `api_key_source: "globus"` with a `globus_scope` field. The Globus auth flow stores scoped tokens in MCPTokenStorage keyed as `"globus:{resource_server}"`. OAuth routes at `/auth/globus/` are excluded from AuthMiddleware and require SessionMiddleware for CSRF state.
 
-## MCP and RAG Conventions
+## MCP and RAG
 
 ### MCP Servers
-- MCP tool servers live in `mcp.json` (tools/prompts)
-- RAG sources (both MCP and HTTP) are configured in `rag-sources.json`
+- Tool servers in `mcp.json`, RAG sources in `rag-sources.json`
 - Fields: `groups`, `transport|type`, `url|command/cwd`, `compliance_level`
-- Transport detection order: explicit transport -> command (stdio) -> URL protocol (http/sse) -> type fallback
-- Tool names exposed to LLM are fully-qualified: `server_toolName`. `canvas_canvas` is a pseudo-tool always available
+- Transport detection: explicit transport -> command (stdio) -> URL protocol (http/sse) -> type fallback
+- Tool names exposed to LLM: `server_toolName`. `canvas_canvas` is always available
 
 ### RAG Over MCP
-- RAG MCP tools expected: `rag_discover_resources`, `rag_get_raw_results`, optional `rag_get_synthesized_results`
-- RAG resources and servers may include `complianceLevel`
-- `domain/rag_mcp_service.py` handles RAG discovery/search/synthesis
-- HTTP RAG discovery (ATLAS RAG API v2) returns `{data_sources: [{id, label, compliance_level, description}]}`; the `DataSource` model in `client.py` mirrors this schema and `UnifiedRAGService` maps `label`/`description` into the UI sources array
+- Expected tools: `rag_discover_resources`, `rag_get_raw_results`, optional `rag_get_synthesized_results`
+- Resources and servers may include `complianceLevel`
+- HTTP RAG discovery (ATLAS RAG API v2) returns `{data_sources: [{id, label, compliance_level, description}]}`
 
-### PPTX Generator MCP Server
-The `pptx_generator` MCP server (`atlas/mcp/pptx_generator/main.py`) uses a three-tier layout strategy: custom template file (via `PPTX_TEMPLATE_PATH` env var or search paths) -> built-in Office "Title and Content" layout -> blank layout with manual textboxes.
-
-### Testing MCP Features
-When testing or developing MCP-related features, example configurations can be found in `atlas/config/mcp-example-configs/` with individual `mcp-{servername}.json` files for testing individual servers.
+### Testing MCP
+Example configs in `atlas/config/mcp-example-configs/`.
 
 ## Compliance Levels
 
 Definitions in `atlas/config/compliance-levels.json` with user overrides in `config/compliance-levels.json`. `core/compliance.py` loads, normalizes aliases, and enforces `allowed_with`.
 
-When `FEATURE_COMPLIANCE_LEVELS_ENABLED=true`:
-- `/api/config` includes model and server `compliance_level`
-- `domain/rag_mcp_service` filters servers and per-resource `complianceLevel` using `ComplianceLevelManager.is_accessible(user, resource)`
-- Validated on load for LLM models, MCP servers, and RAG MCP servers
+When enabled: `/api/config` includes model/server `compliance_level`, `domain/rag_mcp_service` filters using `ComplianceLevelManager.is_accessible(user, resource)`, validated on load for LLM models, MCP servers, and RAG servers.
 
-## Key APIs and Contracts
+## Key APIs
 
-### WebSocket API (`/ws`)
-**Client Messages:**
-- `chat` - User sends message
-- `download_file` - Request file from S3
-- `reset_session` - Clear conversation history
-- `attach_file` - Attach file to conversation
+### WebSocket (`/ws`)
+**Client:** `chat`, `download_file`, `reset_session`, `attach_file`
+**Server:** `token_stream`, `tool_use`, `tool_start`/`tool_progress`/`tool_complete` (status: `calling`->`in_progress`->`completed`/`failed`), `canvas_content`, `intermediate_update`, `conversation_saved` (carries `conversation_id`)
 
-**Server Messages:**
-- `token_stream` - Text chunks
-- `tool_use` - Tool execution events
-- `tool_start` / `tool_progress` / `tool_complete` - Direct tool lifecycle events with status transitions (`calling` -> `in_progress` -> `completed`/`failed`); Message.jsx renders spinners and elapsed timers for active states
-- `canvas_content` - HTML/markdown for canvas
-- `intermediate_update` - Files, images, etc.
-- `conversation_saved` - Sent after backend persists a conversation; carries `conversation_id` so the frontend can set `activeConversationId` and avoid duplicate sidebar entries
-
-### REST API
-- `/api/heartbeat` - Minimal uptime check (`{"status":"ok"}`), no auth, rate-limited
-- `/api/health` - Service status with version and timestamp, no auth, rate-limited
+### REST
+- `/api/heartbeat` - Uptime check, no auth, rate-limited
+- `/api/health` - Service status with version, no auth, rate-limited
 - `/api/config` - Models, tools, prompts, data_sources, rag_servers, features
+- `/api/config/shell` - Lightweight config for fast startup
 - `/api/compliance-levels` - Compliance level definitions
-- `/api/feedback` - Submit (POST) and view (GET, admin) user feedback; conversation history is stored inline in the feedback JSON when the user opts in
-- `/api/conversations/export` - Download all conversations with full messages as JSON (GET, auth required)
+- `/api/feedback` - Submit (POST) and view (GET, admin) feedback
+- `/api/conversations/export` - Download all conversations as JSON
 - `/admin/*` - Configs and logs (admin group required)
 
-## Development Commands
+## S3 Storage
 
-### Quick Start (Recommended)
-```bash
-bash agent_start.sh
-```
-This script handles: killing old processes, clearing logs, building frontend, starting S3 storage (MinIO or Mock based on `USE_MOCK_S3` in `.env`), and starting backend.
-
-**Options:**
-- `bash agent_start.sh -f` - Only rebuild frontend
-- `bash agent_start.sh -b` - Only restart backend
-
-### S3 Storage (Mock vs MinIO)
-
-The project supports two S3 storage backends:
-
-1. **Mock S3 (Default, Recommended for Development)**
-   - Set `USE_MOCK_S3=true` in `.env`
-   - Uses in-process FastAPI TestClient (no Docker required)
-   - Files stored in `minio-data/chatui/` on disk
-   - Faster startup, simpler development workflow
-
-2. **MinIO (Production-like)**
-   - Set `USE_MOCK_S3=false` in `.env`
-   - Requires Docker: `docker-compose up -d minio minio-init`
-   - Full S3 compatibility with all features
-
-### Testing
-
-**Run all tests:**
-```bash
-./test/run_tests.sh all  # Takes ~2 minutes, NEVER CANCEL
-```
-
-**Individual test suites:**
-```bash
-./test/run_tests.sh backend   # ~5 seconds
-./test/run_tests.sh frontend  # ~6 seconds
-./test/run_tests.sh e2e       # ~70 seconds (may fail without auth config)
-```
-
-**Frontend unit tests:**
-```bash
-cd frontend
-npm test              # Run with Vitest
-npm run test:ui       # Interactive UI
-```
-
-### Linting
-
-**IMPORTANT: Run linting before every commit to catch style issues early.**
-
-**Python:**
-```bash
-ruff check atlas/ || (uv pip install ruff && ruff check atlas/)
-```
-
-**Frontend:**
-```bash
-cd frontend && npm run lint
-```
-
-### Docker
-
-```bash
-docker build -t atlas-ui-3 .
-docker run -p 8000:8000 atlas-ui-3
-```
-
-**Container uses RHEL 9 UBI** (note: GitHub Actions use Ubuntu runners).
-
-## Agent Modes
-
-Four agent loop strategies implement different reasoning patterns:
-
-- **Agentic** (`atlas/application/chat/agent/agentic_loop.py`): Claude-native loop with zero control tools and `tool_choice="auto"`. The model decides when to call tools and when to respond with text. 1 LLM call per step. Best for Anthropic models but works with all providers via LiteLLM.
-- **ReAct** (`atlas/application/chat/agent/react_loop.py`): Reason-Act-Observe cycle, good for tool-heavy tasks with structured reasoning
-- **Think-Act** (`atlas/application/chat/agent/think_act_loop.py`): Deep reasoning with explicit thinking steps, slower but more thoughtful
-- **Act** (`atlas/application/chat/agent/act_loop.py`): Pure action loop without explicit reasoning steps, fastest with minimal overhead. LLM calls tools directly and signals completion via the "finished" tool
-
-Change agent loop: set `APP_AGENT_LOOP_STRATEGY` to `agentic | react | think-act | act`; ChatService uses `app_settings.agent_loop_strategy`.
-
-**Agentic vs Scaffolded Loops**: The `agentic` strategy uses no control tools and lets the model manage its own control flow (text-only response = done), while `react`/`think-act`/`act` use scaffolding tools like `finished` and `agent_decide_next` to force structure -- choose `agentic` for Anthropic models where native tool-use training makes scaffolding counterproductive.
-
-**Multi-Tool Calling**: All agent loops and the tools mode runner execute multiple tool calls from a single LLM response in parallel via `asyncio.gather` (`tool_executor.execute_multiple_tools`); individual failures are converted to error `ToolResult`s so other tools still succeed.
-
-## Prompt System
-
-The application uses a prompt system to manage various LLM prompts:
-
-- **System Prompt**: `prompts/system_prompt.md` - Default system prompt prepended to all conversations
-  - Configurable via `system_prompt_filename` in AppSettings (default: `system_prompt.md`)
-  - Supports `{user_email}` template variable
-  - Can be overridden by MCP-provided prompts
-  - Loaded by `PromptProvider.get_system_prompt()`
-  - Automatically injected by `MessageBuilder` at conversation start
-
-- **Agent Prompts**: Used in agent loop strategies
-  - `prompts/agent_reason_prompt.md` - Reasoning phase
-  - `prompts/agent_observe_prompt.md` - Observation phase
-
-- **Tool Synthesis**: `prompts/tool_synthesis_prompt.md` - Tool selection guidance
-
-All prompts are loaded from the directory specified by `prompt_base_path` (default: `prompts/`). The system caches loaded prompts for performance.
+- **Mock S3 (default)**: `USE_MOCK_S3=true` -- in-process, no Docker needed
+- **MinIO**: `USE_MOCK_S3=false` -- requires `docker-compose up -d minio minio-init`
 
 ## Security
 
@@ -397,7 +255,7 @@ All prompts are loaded from the directory specified by `prompt_base_path` (defau
 Request -> SecurityHeaders -> RateLimit -> Auth -> Route
 ```
 - Rate limiting before auth to prevent abuse
-- To bypass auth for a new endpoint, add it to the path check in `AuthMiddleware.dispatch()` (`atlas/core/middleware.py`); rate limiting still applies to bypassed routes
+- To bypass auth for a new endpoint, add to path check in `AuthMiddleware.dispatch()` (`atlas/core/middleware.py`)
 - Prompt injection risk detection in `atlas/core/prompt_risk.py`
 - Group-based MCP server access control
 
@@ -411,107 +269,52 @@ In production, reverse proxy injects `X-User-Email` (after stripping client head
 
 ## Extend by Example
 
-**Add a tool server:**
-Edit `config/mcp.json` (your local config, created by `atlas-init`). Set `groups`, `transport`, `url/command`, `compliance_level`. Restart or call discovery on startup.
+**Add a tool server:** Edit `config/mcp.json`, set `groups`, `transport`, `url/command`, `compliance_level`. Restart or call discovery.
 
-**Add a RAG provider:**
-Edit `config/rag-sources.json` (your local config). For MCP RAG servers, set `type: "mcp"` and ensure it exposes `rag_*` tools. For HTTP RAG APIs, set `type: "http"` with `url` and `bearer_token`. UI consumes `/api/config.rag_servers`.
+**Add a RAG provider:** Edit `config/rag-sources.json`. MCP: set `type: "mcp"` with `rag_*` tools. HTTP: set `type: "http"` with `url` and `bearer_token`.
 
-**Change agent loop:**
-Set `APP_AGENT_LOOP_STRATEGY` to `agentic | react | think-act | act`; ChatService uses `app_settings.agent_loop_strategy`.
-
-**Build-time constants**: `vite.config.js` injects `__APP_VERSION__`, `__GIT_HASH__`, and `__BUILD_TIME__` via `define`; in Docker these come from `GIT_HASH`/`APP_VERSION` build args since `.git/` and `atlas/version.py` are unavailable during the frontend build stage.
+**Build-time constants**: `vite.config.js` injects `__APP_VERSION__`, `__GIT_HASH__`, `__BUILD_TIME__` via `define`; in Docker these come from build args since `.git/` and `atlas/version.py` are unavailable during frontend build.
 
 ## Common Issues
 
-1. **"uv not found"**: Install uv package manager (most common)
-2. **WebSocket fails**: Use `npm run build` instead of `npm run dev`
-3. **Backend won't start**: Check `.env` exists and `APP_LOG_DIR` is valid
-4. **Frontend not loading**: Verify `npm run build` completed
-5. **Container build SSL errors**: Use local development instead
-6. **Missing tools**: Check MCP transport/URL and server logs
-7. **Empty lists**: Check auth groups and compliance filtering
-8. **Host binding ignored**: `agent_start.sh` and the Dockerfile both use `ATLAS_HOST` env var for host binding; `main.py` also reads it directly -- keep all three in sync when changing network configuration
-9. **DuckDB FK constraints**: DuckDB does not support CASCADE or UPDATE on foreign-key-constrained tables; the `chat_history` module avoids all database-level ForeignKey constraints and enforces referential integrity manually in the repository layer instead
-10. **Chat history default**: Chat history with DuckDB is enabled by default in `.env.example`; new setups get conversation persistence without extra configuration
-11. **Empty `tool_calls` arrays**: OpenAI and compatible providers reject messages where `tool_calls` is present but empty (`[]`); always call `_sanitize_messages()` in `LiteLLMCaller` before passing messages to `acompletion()`
-12. **Dual file download paths**: MCP servers use `/mcp/files/download/` (HMAC token auth, bypasses nginx `auth_request`) while browsers use `/api/files/download/` (nginx-injected `X-User-Email`). `create_download_url()` in `capabilities.py` generates `/mcp/` URLs. `CanvasPanel.jsx` must use `currentFile.download_url` from the WebSocket `canvas_files` event (tokenized `/mcp/` path) rather than constructing `/api/files/download/` URLs directly. Both paths share `_handle_file_download()` in `files_routes.py`
-13. **Admin MCP reload after add/remove**: The admin add-server/remove-server endpoints must call `reload_config()` + `initialize_clients()` + `discover_tools()` + `discover_prompts()` in sequence; there is no single `reload_servers()` method on `MCPToolManager`. Also, `reload_config()` must clean up removed servers from `clients`, `available_tools`, and `available_prompts` dicts to prevent stale data
-14. **LLM errors must raise domain errors**: `LiteLLMCaller` must raise domain-specific errors (`RateLimitError`, `LLMTimeoutError`, `LLMAuthenticationError`, `LLMServiceError`) instead of generic `Exception` so the WebSocket handler can send typed error messages to the frontend; use `_raise_llm_domain_error()` in all except blocks
-15. **FastMCP 3.x compatibility**: The project requires `fastmcp[tasks]>=3.0.0`; the codebase already uses the 3.x API (`list_tools()`, `list_prompts()`, `Client` constructor args), so no legacy `get_tools()`/`get_prompts()` calls should be introduced
-16. **MCP session isolation**: STDIO MCP servers must use `create_stdio_server()` from `atlas/mcp_shared/server_factory.py` (which wires `BlockedStateStore`) instead of `FastMCP()` directly; stateful servers requiring per-user session state must use HTTP transport with per-user client routing
+1. **WebSocket fails**: Use `npm run build` not `npm run dev`
+2. **Backend won't start**: Check `.env` exists and `APP_LOG_DIR` is valid
+3. **Host binding**: `agent_start.sh`, Dockerfile, and `main.py` all read `ATLAS_HOST` -- keep in sync
+4. **DuckDB FK constraints**: DuckDB doesn't support CASCADE; referential integrity is enforced manually
+5. **Empty `tool_calls` arrays**: OpenAI rejects empty `[]`; always call `_sanitize_messages()` before `acompletion()`
+6. **Dual file download paths**: MCP uses `/mcp/files/download/` (HMAC), browsers use `/api/files/download/` (nginx). Use `currentFile.download_url` from WebSocket events
+7. **LLM errors**: Must raise domain-specific errors (`RateLimitError`, etc.) via `_raise_llm_domain_error()`, not generic `Exception`
+8. **FastMCP 3.x**: Uses 3.x API (`list_tools()`, `list_prompts()`); don't introduce legacy `get_tools()` calls
 
-## PR Validation Scripts (Required)
+## PR Validation Scripts
 
-**Any PR that changes backend code MUST include a validation script** in `test/pr-validation/` before the code is committed, the PR is created, or the PR is reviewed/merged.
+Backend PRs should include a validation script in `test/pr-validation/`:
 
-**Naming:** `test_pr{NUMBER}_{short_description}.sh` (e.g., `test_pr271_cli_rag_features.sh`)
+**Naming:** `test_pr{NUMBER}_{short_description}.sh`
 
-**What goes in the script:** Every item from the PR's "Test plan" section, plus a backend unit test run at the end. See `test/pr-validation/README.md` for the full template and structure.
+Scripts must exercise features end-to-end using actual CLI commands, API calls, or tool invocations -- not just import checks or unit tests. Store test-specific configs in `test/pr-validation/fixtures/pr{NUMBER}/`.
 
-**IMPORTANT: Scripts must exercise features end-to-end using actual CLI commands and tools.** Do not write validation scripts that only check imports, parse flags, or run unit tests. The script must invoke the feature as a real user would -- by running CLI commands (`python atlas_chat_cli.py ...`), calling API endpoints (`curl`), starting the backend and checking behavior, or running actual tooling. Import checks and unit tests are supplementary, not the primary validation.
-
-Examples of end-to-end validation:
-- Run `python atlas_chat_cli.py --list-tools` to verify CLI features work
-- Start the backend and hit API endpoints with `curl` to verify behavior
-- Set environment variables and run commands to verify feature flags take effect
-- Invoke tool use via CLI: `python atlas_chat_cli.py "query" --tools tool_name`
-
-**Custom .env and config files for testing:** PR validation scripts can and should create custom `.env` files and config overrides to test different feature flag combinations. Store test-specific config files in `test/pr-validation/fixtures/pr{NUMBER}/` (e.g., `test/pr-validation/fixtures/pr264/.env`). This allows testing with `FEATURE_*` flags set to specific values without modifying the project's real `.env` or config files.
-
-**Running:**
 ```bash
 bash test/run_pr_validation.sh 271       # Run one PR
 bash test/run_pr_validation.sh            # Run all
 bash test/run_pr_validation.sh --list     # List available
 ```
 
-**When creating a PR validation script:**
-1. Write the script in `test/pr-validation/test_pr{NUMBER}_{description}.sh`
-2. Use `PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"` to locate the project root
-3. Activate `.venv/bin/activate`, run assertions, print PASSED/FAILED per check
-4. **Run actual CLI commands and tools** to exercise the feature end-to-end
-5. Always run `./test/run_tests.sh backend` as the final step
-6. Exit 0 on success, non-zero on failure
-
-**When reviewing a PR:** Verify the validation script exists and passes before approving.
-
-## Validation Workflow
-
-Before committing:
-1. **Lint**: Address style issues before running tests
-   - Python: `ruff check atlas/ || (uv pip install ruff && ruff check atlas/)`
-   - Frontend: `cd frontend && npm run lint`
-2. **PR validation script**: If backend code changed, write and run `test/pr-validation/test_pr{N}_{desc}.sh`
-3. **Test**: `./test/run_tests.sh all`
-4. **Build**: Frontend and backend build successfully
-5. **Manual**: Test in browser at http://localhost:8000
-6. **Exercise**: Test specific modified functionality
-
-Before creating or accepting a PR:
-- Run `cd frontend && npm run lint` to ensure no frontend syntax errors or style issues
-- Run `bash test/run_pr_validation.sh {PR_NUMBER}` to verify the PR validation script passes
-
-## Key File References
-
-When referencing code locations, use `file_path:line_number` format for easy navigation.
-
-**Core Entry Points:**
-- Backend: `atlas/main.py` - FastAPI app + WebSocket
-- Frontend: `frontend/src/main.jsx` - React app entry
-- Chat Service: `atlas/application/chat/service.py:ChatService`
-- Config Management: `atlas/modules/config/config_manager.py`
-- MCP Integration: `atlas/modules/mcp_tools/mcp_tool_manager.py`
-
-**Protocol Definitions:**
-- `atlas/interfaces/llm.py:LLMProtocol`
-- `atlas/interfaces/tools.py:ToolManagerProtocol`
-- `atlas/interfaces/transport.py:ChatConnectionProtocol`
+See `test/pr-validation/README.md` for the full template.
 
 ## Critical Restrictions
 
 - **NEVER use `uvicorn --reload`** - causes development issues
-- **NEVER use `npm run dev`** - has WebSocket connection problems
-- **ALWAYS use `npm run build`** for frontend development
+- **NEVER use `npm run dev`** - WebSocket connection problems
+- **ALWAYS use `npm run build`** for frontend
 - **NEVER use pip** - this project requires `uv`
-- **NEVER CANCEL builds or tests** - they may take time but must complete
+- **NEVER CANCEL builds or tests** - they must complete
+
+## Docker
+
+```bash
+docker build -t atlas-ui-3 .
+docker run -p 8000:8000 atlas-ui-3
+```
+
+Container uses RHEL 9 UBI (GitHub Actions use Ubuntu runners).


### PR DESCRIPTION
## Summary

- Remove redundant sections (duplicate agent loop docs, Key File References, overlapping Validation Workflow)
- Trim implementation details agents can derive from code (Lazy Imports, Follow-up Suggestions, File Attachments, PPTX Generator, Prompt System, 3-State Save Mode, etc.)
- Shorten Common Issues from 14 to 8, keeping non-obvious gotchas
- Consolidate testing/linting into one section
- Remove prescriptive "add one sentence to AGENTS.md" mandate
- 518 -> 320 lines (38% reduction)
- OPSEC section preserved in full

## Test plan

- [ ] Review that no critical guidance was lost
- [ ] Verify OPSEC section is unchanged