### PR TITLE
fix: welcome screen logo clipping on short/narrow viewports

### DIFF
--- a/agent_start.sh
+++ b/agent_start.sh
@@ -226,7 +226,7 @@ start_mcp_mock() {
 
 build_frontend() {
     local use_new_frontend="${USE_NEW_FRONTEND:-true}"
-    
+
     echo "Building frontend..."
     cd "$PROJECT_ROOT/frontend"
     npm install
@@ -237,6 +237,11 @@ build_frontend() {
     fi
     npm run build
     cd "$PROJECT_ROOT"
+
+    # Copy build output to atlas/static/ so the backend always serves from one
+    # location, matching the PyPI package layout.
+    rm -rf "$PROJECT_ROOT/atlas/static"
+    cp -r "$PROJECT_ROOT/frontend/dist" "$PROJECT_ROOT/atlas/static"
 }
 
 # =============================================================================

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -786,7 +786,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
 
       <main
         ref={messagesRef}
-        className="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-4 min-h-0"
+        className={`overflow-y-auto custom-scrollbar p-4 space-y-4 min-h-0 ${isWelcomeVisible ? 'hidden' : 'flex-1'}`}
       >
         {messages.map((message, index) => (
           <Message

--- a/frontend/src/components/WelcomeScreen.jsx
+++ b/frontend/src/components/WelcomeScreen.jsx
@@ -8,24 +8,22 @@ const WelcomeScreen = () => {
   const { appName } = useChat()
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 min-h-0 p-4 sm:p-8 text-center">
-      <div className="flex-1 min-h-0 flex items-end mb-4 sm:mb-8">
-        {animatedLogoEnabled ? (
-          <AnimatedLogo appName={appName} />
-        ) : (
-          <img
-            src="/logo.png"
-            alt={`${appName} Logo`}
-            className="max-w-48 sm:max-w-80 md:max-w-4xl max-h-full mx-auto object-contain"
-            onError={(e) => {
-              e.target.style.display = 'none'
-              e.target.nextElementSibling.style.display = 'flex'
-            }}
-          />
-        )}
-      </div>
+    <div className="flex flex-col items-center justify-center flex-1 min-h-0 overflow-hidden p-4 sm:p-8 text-center">
+      {animatedLogoEnabled ? (
+        <AnimatedLogo appName={appName} />
+      ) : (
+        <img
+          src="/logo.png"
+          alt={`${appName} Logo`}
+          className="max-w-48 sm:max-w-80 md:max-w-2xl lg:max-w-4xl max-h-full mx-auto object-contain [@media(min-height:500px)]:mb-8"
+          onError={(e) => {
+            e.target.style.display = 'none'
+            e.target.nextElementSibling.style.display = 'flex'
+          }}
+        />
+      )}
 
-      <div className="max-w-md flex-shrink-0">
+      <div className="max-w-md flex-shrink-0 hidden [@media(min-height:500px)]:block">
         <p className="text-gray-400 text-lg">
           Select a model and start chatting. To explore available tools, click the Wrench icon or to view files, click the Folder icon in the top right.
         </p>

--- a/ps_agent_start.ps1
+++ b/ps_agent_start.ps1
@@ -270,6 +270,13 @@ function Build-Frontend {
 
     npm run build
     Set-Location $PROJECT_ROOT
+
+    # Copy build output to atlas/static/ so the backend always serves from one
+    # location, matching the PyPI package layout.
+    if (Test-Path "$PROJECT_ROOT/atlas/static") {
+        Remove-Item -Recurse -Force "$PROJECT_ROOT/atlas/static"
+    }
+    Copy-Item -Recurse "$PROJECT_ROOT/frontend/dist" "$PROJECT_ROOT/atlas/static"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixes logo being clipped/cut off on wide but short screens by hiding instruction text on short viewports (<500px height) and scaling logo to fit available space
- Fixes logo and text not being vertically centered by hiding the empty messages `main` element when the welcome screen is visible
- Adds intermediate `md:max-w-2xl` breakpoint to prevent logo overflow on ~950px wide screens
- Copies frontend build output to `atlas/static/` in build scripts so the backend always serves from one consistent location

## Test plan
- [ ] Verify logo is fully visible and centered at 1400x800 (desktop)
- [ ] Verify logo is fully visible, text hidden at 1400x400 (wide+short)
- [ ] Verify logo fits within viewport at 950x950
- [ ] Verify phone portrait (375x667) and landscape (667x375) look correct
- [ ] Verify `bash agent_start.sh` serves the latest frontend build