### PR TITLE
feat: gate RAG citations UI behind VITE_FEATURE_RAG_CITATIONS flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,11 @@ VITE_FEATURE_POWERED_BY_ATLAS=false
 # When false, a static logo image is shown.
 VITE_FEATURE_ANIMATED_LOGO=true
 
+# Frontend build-time flag to enable Perplexity-style inline citations and the
+# collapsible Sources/References section on RAG responses. When false (default),
+# RAG output renders as plain markdown with no citation badges.
+VITE_FEATURE_RAG_CITATIONS=false
+
 # OpenTelemetry configuration (optional - for future use)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # OTEL_SERVICE_NAME=atlas-ui-3-backend

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build frontend
       run: |
         cd frontend
-        VITE_APP_NAME="ATLAS" VITE_FEATURE_ANIMATED_LOGO="true" VITE_FEATURE_POWERED_BY_ATLAS="false" npm run build
+        VITE_APP_NAME="ATLAS" VITE_FEATURE_ANIMATED_LOGO="true" VITE_FEATURE_POWERED_BY_ATLAS="false" VITE_FEATURE_RAG_CITATIONS="false" npm run build
 
     - name: Create build directory structure
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
           VITE_APP_NAME=ATLAS
           VITE_FEATURE_ANIMATED_LOGO=true
           VITE_FEATURE_POWERED_BY_ATLAS=false
+          VITE_FEATURE_RAG_CITATIONS=false
           GIT_HASH=${{ steps.build_meta.outputs.sha_short }}
           APP_VERSION=${{ steps.build_meta.outputs.version }}
         tags: ${{ steps.meta.outputs.tags }}
@@ -98,6 +99,7 @@ jobs:
           VITE_APP_NAME=ATLAS
           VITE_FEATURE_ANIMATED_LOGO=true
           VITE_FEATURE_POWERED_BY_ATLAS=false
+          VITE_FEATURE_RAG_CITATIONS=false
           GIT_HASH=${{ steps.build_meta.outputs.sha_short }}
           APP_VERSION=${{ steps.build_meta.outputs.version }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -37,6 +37,8 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Build frontend
+        env:
+          VITE_FEATURE_RAG_CITATIONS: "false"
         run: cd frontend && npm ci && npm run build
 
       - name: Bundle frontend into package

--- a/.github/workflows/quay-publish.yml
+++ b/.github/workflows/quay-publish.yml
@@ -59,6 +59,7 @@ jobs:
           VITE_APP_NAME=ATLAS
           VITE_FEATURE_ANIMATED_LOGO=true
           VITE_FEATURE_POWERED_BY_ATLAS=false
+          VITE_FEATURE_RAG_CITATIONS=false
           GIT_HASH=${{ steps.build_meta.outputs.sha_short }}
           APP_VERSION=${{ steps.build_meta.outputs.version }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ frontend/src/
 - `FEATURE_COMPLIANCE_LEVELS_ENABLED` - Compliance level enforcement
 - `FEATURE_AGENT_MODE_AVAILABLE` - Agent mode UI toggle
 - `VITE_FEATURE_ANIMATED_LOGO` - Animated logo (build-time Vite flag; must also be added to `Dockerfile` ARG and `test_docker_env_sync.py` exclusion list)
+- `VITE_FEATURE_RAG_CITATIONS` - Perplexity-style inline citations & collapsible Sources section for RAG responses (build-time Vite flag; defaults to `false`; must also be added to `Dockerfile` ARG and `test_docker_env_sync.py` exclusion list)
 
 ## Per-User LLM API Keys
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ ENV VITE_FEATURE_POWERED_BY_ATLAS=${VITE_FEATURE_POWERED_BY_ATLAS}
 # Enable animated logo on welcome screen (can be overridden via build arg)
 ARG VITE_FEATURE_ANIMATED_LOGO="true"
 ENV VITE_FEATURE_ANIMATED_LOGO=${VITE_FEATURE_ANIMATED_LOGO}
+# Enable Perplexity-style inline citations for RAG output (can be overridden via build arg)
+ARG VITE_FEATURE_RAG_CITATIONS="false"
+ENV VITE_FEATURE_RAG_CITATIONS=${VITE_FEATURE_RAG_CITATIONS}
 # Git hash and version injected at build time for console/health display
 ARG GIT_HASH="unknown"
 ARG APP_VERSION="unknown"

--- a/agent_start.sh
+++ b/agent_start.sh
@@ -235,6 +235,10 @@ build_frontend() {
     if [ -z "$VITE_APP_NAME" ]; then
         export VITE_APP_NAME="Chat UI 13"
     fi
+    # RAG citations UI is opt-in at build time; default to off if unset.
+    if [ -z "$VITE_FEATURE_RAG_CITATIONS" ]; then
+        export VITE_FEATURE_RAG_CITATIONS="false"
+    fi
     npm run build
     cd "$PROJECT_ROOT"
 

--- a/atlas/tests/test_docker_env_sync.py
+++ b/atlas/tests/test_docker_env_sync.py
@@ -114,6 +114,7 @@ def test_docker_compose_has_required_env_vars():
         'VITE_APP_NAME',  # Build-time arg, not runtime env var in docker-compose
         'VITE_FEATURE_POWERED_BY_ATLAS',  # Build-time arg, not runtime env var in docker-compose
         'VITE_FEATURE_ANIMATED_LOGO',  # Build-time arg, not runtime env var in docker-compose
+        'VITE_FEATURE_RAG_CITATIONS',  # Build-time arg, not runtime env var in docker-compose
         # Note: The following are in .env.example as commented out, not as active vars,
         # so they won't appear in env_example_vars and don't need to be listed here:
         # - ATLAS_HOST (Docker-specific, set to 0.0.0.0 for container networking)

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -47,6 +47,11 @@ hljs.registerLanguage('bash', bash)
 hljs.registerLanguage('shell', bash)
 hljs.registerLanguage('sh', bash)
 
+// Feature flag: Perplexity-style inline citations & references for RAG.
+// Off by default; enable at Vite build time with VITE_FEATURE_RAG_CITATIONS=true.
+const ragCitationsEnabled =
+  import.meta.env.VITE_FEATURE_RAG_CITATIONS === 'true'
+
 // DOMPurify configuration that permits KaTeX-generated HTML.
 // KaTeX renders almost exclusively with <span> (allowed by default) but also
 // uses <svg>, <path>, and a handful of MathML elements for some symbols.
@@ -1306,10 +1311,11 @@ const renderContent = () => {
       const markdownHtml = marked.parse(latexProcessed)
       const latexRestoredHtml = restoreLatexPlaceholders(markdownHtml, placeholders)
       // Skip citation pipeline for non-RAG messages (no References section)
-      const hasReferences = latexRestoredHtml.includes('References')
+      // or when the RAG citations feature flag is disabled.
+      const hasReferences = ragCitationsEnabled && latexRestoredHtml.includes('References')
       const sourceLabels = hasReferences ? extractSourceLabels(latexRestoredHtml) : new Map()
       const citationHtml = hasReferences ? processCitationBadges(latexRestoredHtml, messageScope) : latexRestoredHtml
-      const referencesHtml = processReferencesSection(citationHtml, messageScope, sourceLabels)
+      const referencesHtml = hasReferences ? processReferencesSection(citationHtml, messageScope, sourceLabels) : citationHtml
       const sanitizedHtml = DOMPurify.sanitize(referencesHtml, DOMPURIFY_CONFIG)
 
       return (

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -23,6 +23,7 @@ const logViteEnv = () => {
     VITE_APP_NAME: process.env.VITE_APP_NAME,
     VITE_FEATURE_POWERED_BY_ATLAS: process.env.VITE_FEATURE_POWERED_BY_ATLAS,
     VITE_FEATURE_ANIMATED_LOGO: process.env.VITE_FEATURE_ANIMATED_LOGO,
+    VITE_FEATURE_RAG_CITATIONS: process.env.VITE_FEATURE_RAG_CITATIONS,
   }
 
   console.log('\n[atlas-ui-3] Vite build-time environment:')

--- a/ps_agent_start.ps1
+++ b/ps_agent_start.ps1
@@ -268,6 +268,11 @@ function Build-Frontend {
         $env:VITE_APP_NAME = "Chat UI 13"
     }
 
+    # RAG citations UI is opt-in at build time; default to off if unset.
+    if (-not $env:VITE_FEATURE_RAG_CITATIONS) {
+        $env:VITE_FEATURE_RAG_CITATIONS = "false"
+    }
+
     npm run build
     Set-Location $PROJECT_ROOT
 


### PR DESCRIPTION
## Summary
- Put the Perplexity-style inline citations & collapsible Sources/References section (from #500) behind a new Vite build-time feature flag, `VITE_FEATURE_RAG_CITATIONS`.
- Flag defaults to **off** — RAG responses render as plain markdown unless the flag is explicitly set at build time.
- Wired the flag through every production frontend build path: `Dockerfile` ARG/ENV, `vite.config.js` build log, `agent_start.sh` / `ps_agent_start.ps1`, and the CI workflows (`ci.yml`, `build-artifacts.yml`, `quay-publish.yml`, `pypi-publish.yml`).
- Added the flag to `.env.example`, to the `test_docker_env_sync.py` exclusion list, and to the `AGENTS.md` feature-flag inventory so the contract checks stay in sync.
- Enable with: `VITE_FEATURE_RAG_CITATIONS=true npm run build` (or the matching Docker build arg).

## Test plan
- [x] `npx vitest run src/test/rag-citation-rendering.test.js` — 23 tests pass (pure helpers unchanged).
- [x] `VITE_FEATURE_RAG_CITATIONS=false npm run build` — clean production build.
- [x] `pytest atlas/tests/test_docker_env_sync.py` — 3 tests pass.
- [ ] Manual: default build hides citation badges and the Sources toggle on a RAG response.
- [ ] Manual: `VITE_FEATURE_RAG_CITATIONS=true npm run build` renders inline citations and collapsible Sources as before.