### PR TITLE
security: bind tool approval requests to owning user (F-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### PR #511 - 2026-04-12
-- **Security**: Tool approval requests are now bound to the authenticated user who created them. Any WebSocket approval response from a different user is rejected and a security warning is logged. This prevents cross-user approval bypass (F-03) where a user who learned another user's pending `tool_call_id` could approve, reject, or inject edited arguments into that user's tool execution. Backward compatible: verification is skipped when `user_email` is absent (single-user or legacy deployments).
+- **Security**: Tool approval requests are now bound to the authenticated user who created them. Any WebSocket approval response from a different user (or from an empty/missing user identity) is rejected and a security warning is logged. This prevents cross-user approval bypass (F-03) where a user who learned another user's pending `tool_call_id` could approve, reject, or inject edited arguments into that user's tool execution. The ownership check fails closed: once a request is bound to a `user_email`, the response must supply a matching one. Backward compatible: verification is skipped only for legacy requests where the request itself has no `user_email` (single-user deployments).
 
 ### PR #510 - 2026-04-12
 - **Security**: `get_current_user()` now raises HTTP 401 when `request.state.user_email` is unset, instead of silently falling back to `test@test.com`. Any request that bypasses auth middleware is now rejected rather than granted a default identity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #511 - 2026-04-12
+- **Security**: Tool approval requests are now bound to the authenticated user who created them. Any WebSocket approval response from a different user is rejected and a security warning is logged. This prevents cross-user approval bypass (F-03) where a user who learned another user's pending `tool_call_id` could approve, reject, or inject edited arguments into that user's tool execution. Backward compatible: verification is skipped when `user_email` is absent (single-user or legacy deployments).
+
 ### PR #510 - 2026-04-12
 - **Security**: `get_current_user()` now raises HTTP 401 when `request.state.user_email` is unset, instead of silently falling back to `test@test.com`. Any request that bypasses auth middleware is now rejected rather than granted a default identity.
 - **Security**: `is_user_in_group()` mock group memberships (which grant admin access to the test user) are now gated behind `debug_mode=True`. In production mode with no external auth endpoint, users receive only the default `users` group — no admin privileges are granted via mock.

--- a/atlas/application/chat/approval_manager.py
+++ b/atlas/application/chat/approval_manager.py
@@ -22,12 +22,14 @@ class ToolApprovalRequest:
         tool_call_id: str,
         tool_name: str,
         arguments: Dict[str, Any],
-        allow_edit: bool = True
+        allow_edit: bool = True,
+        user_email: str = "",
     ):
         self.tool_call_id = tool_call_id
         self.tool_name = tool_name
         self.arguments = arguments
         self.allow_edit = allow_edit
+        self.user_email = user_email
         self.future: asyncio.Future = asyncio.Future()
 
     async def wait_for_response(self, timeout: float = 300.0) -> Dict[str, Any]:
@@ -70,7 +72,8 @@ class ToolApprovalManager:
         tool_call_id: str,
         tool_name: str,
         arguments: Dict[str, Any],
-        allow_edit: bool = True
+        allow_edit: bool = True,
+        user_email: str = "",
     ) -> ToolApprovalRequest:
         """
         Create a new approval request.
@@ -80,11 +83,12 @@ class ToolApprovalManager:
             tool_name: Name of the tool being called
             arguments: Tool arguments
             allow_edit: Whether to allow editing of arguments
+            user_email: Authenticated email of the user who owns this request
 
         Returns:
             ToolApprovalRequest object
         """
-        request = ToolApprovalRequest(tool_call_id, tool_name, arguments, allow_edit)
+        request = ToolApprovalRequest(tool_call_id, tool_name, arguments, allow_edit, user_email=user_email)
         self._pending_requests[tool_call_id] = request
         logger.info(f"Created approval request for tool {sanitize_for_logging(tool_name)} (call_id: {sanitize_for_logging(tool_call_id)})")
         return request
@@ -94,7 +98,8 @@ class ToolApprovalManager:
         tool_call_id: str,
         approved: bool,
         arguments: Optional[Dict[str, Any]] = None,
-        reason: Optional[str] = None
+        reason: Optional[str] = None,
+        user_email: str = "",
     ) -> bool:
         """
         Handle a user's response to an approval request.
@@ -104,6 +109,7 @@ class ToolApprovalManager:
             approved: Whether the user approved the call
             arguments: Potentially edited arguments (if allowed)
             reason: Optional reason for rejection
+            user_email: Authenticated email of the responding user
 
         Returns:
             True if request was found and handled, False otherwise
@@ -119,6 +125,18 @@ class ToolApprovalManager:
         if request is None:
             logger.warning(f"Received approval response for unknown tool call: {sanitize_for_logging(tool_call_id)}")
             logger.debug("Available pending requests: %s", list(self._pending_requests.keys()))
+            return False
+
+        # Security: verify the responding user owns this approval request.
+        # Prevents cross-user approval bypass where one user approves
+        # another user's pending tool call.
+        if request.user_email and user_email and request.user_email != user_email:
+            logger.warning(
+                "SECURITY: approval response rejected — user %s attempted to "
+                "approve tool call owned by a different user (call_id: %s)",
+                sanitize_for_logging(user_email),
+                sanitize_for_logging(tool_call_id),
+            )
             return False
 
         logger.debug("Found pending request for %s; setting response", sanitize_for_logging(tool_call_id))

--- a/atlas/application/chat/approval_manager.py
+++ b/atlas/application/chat/approval_manager.py
@@ -129,13 +129,23 @@ class ToolApprovalManager:
 
         # Security: verify the responding user owns this approval request.
         # Prevents cross-user approval bypass where one user approves
-        # another user's pending tool call.
-        if request.user_email and user_email and request.user_email != user_email:
+        # another user's pending tool call. Fail-closed: if the request has
+        # a user_email binding, the response MUST supply a matching one.
+        # Backward compat: only legacy requests (no user_email set) skip the
+        # check so single-user deployments continue to work.
+        if request.user_email and request.user_email != user_email:
+            # Inline sanitize for CodeQL py/log-injection: the query traces
+            # explicit CR/LF removal as a log-injection sanitizer, but does
+            # not recognize sanitize_for_logging() as one.
+            safe_user_email = str(user_email).replace("\r", "").replace("\n", "")
+            safe_tool_call_id = str(tool_call_id).replace("\r", "").replace("\n", "")
             logger.warning(
                 "SECURITY: approval response rejected — user %s attempted to "
-                "approve tool call owned by a different user (call_id: %s)",
-                sanitize_for_logging(user_email),
-                sanitize_for_logging(tool_call_id),
+                "respond to tool call owned by a different user "
+                "(call_id: %s, approved=%s)",
+                safe_user_email,
+                safe_tool_call_id,
+                approved,
             )
             return False
 

--- a/atlas/application/chat/utilities/tool_executor.py
+++ b/atlas/application/chat/utilities/tool_executor.py
@@ -392,7 +392,8 @@ async def execute_single_tool(
                 tool_call.id,
                 tool_call.function.name,
                 filtered_args,
-                allow_edit
+                allow_edit,
+                user_email=session_context.get("user_email", ""),
             )
 
             try:

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -655,7 +655,8 @@ async def websocket_endpoint(websocket: WebSocket):
                     tool_call_id=tool_call_id,
                     approved=approved,
                     arguments=arguments,
-                    reason=reason
+                    reason=reason,
+                    user_email=user_email,
                 )
 
                 logger.info(f"Approval response handled: result={sanitize_for_logging(result)}")

--- a/atlas/tests/test_approval_manager.py
+++ b/atlas/tests/test_approval_manager.py
@@ -17,12 +17,14 @@ class TestToolApprovalRequest:
             tool_call_id="test_123",
             tool_name="test_tool",
             arguments={"arg1": "value1"},
-            allow_edit=True
+            allow_edit=True,
+            user_email="alice@example.com",
         )
         assert request.tool_call_id == "test_123"
         assert request.tool_name == "test_tool"
         assert request.arguments == {"arg1": "value1"}
         assert request.allow_edit is True
+        assert request.user_email == "alice@example.com"
 
     @pytest.mark.asyncio
     async def test_set_response(self):
@@ -85,10 +87,12 @@ class TestToolApprovalManager:
             tool_call_id="test_123",
             tool_name="test_tool",
             arguments={"arg1": "value1"},
-            allow_edit=True
+            allow_edit=True,
+            user_email="alice@example.com",
         )
 
         assert request.tool_call_id == "test_123"
+        assert request.user_email == "alice@example.com"
         assert "test_123" in manager.get_pending_requests()
 
     @pytest.mark.asyncio
@@ -98,14 +102,16 @@ class TestToolApprovalManager:
         manager.create_approval_request(
             tool_call_id="test_123",
             tool_name="test_tool",
-            arguments={"arg1": "value1"}
+            arguments={"arg1": "value1"},
+            user_email="alice@example.com",
         )
 
-        # Handle approval response
+        # Handle approval response from the same user
         result = manager.handle_approval_response(
             tool_call_id="test_123",
             approved=True,
-            arguments={"arg1": "edited_value"}
+            arguments={"arg1": "edited_value"},
+            user_email="alice@example.com",
         )
 
         assert result is True
@@ -156,7 +162,8 @@ class TestToolApprovalManager:
             tool_call_id="test_123",
             tool_name="test_tool",
             arguments={"code": "print('test')"},
-            allow_edit=True
+            allow_edit=True,
+            user_email="alice@example.com",
         )
 
         # Simulate async approval (in a separate task)
@@ -165,7 +172,8 @@ class TestToolApprovalManager:
             manager.handle_approval_response(
                 tool_call_id="test_123",
                 approved=True,
-                arguments={"code": "print('edited test')"}
+                arguments={"code": "print('edited test')"},
+                user_email="alice@example.com",
             )
 
         # Start approval task
@@ -190,17 +198,20 @@ class TestToolApprovalManager:
         request1 = manager.create_approval_request(
             tool_call_id="test_1",
             tool_name="tool_a",
-            arguments={"arg": "value1"}
+            arguments={"arg": "value1"},
+            user_email="alice@example.com",
         )
         request2 = manager.create_approval_request(
             tool_call_id="test_2",
             tool_name="tool_b",
-            arguments={"arg": "value2"}
+            arguments={"arg": "value2"},
+            user_email="alice@example.com",
         )
         request3 = manager.create_approval_request(
             tool_call_id="test_3",
             tool_name="tool_c",
-            arguments={"arg": "value3"}
+            arguments={"arg": "value3"},
+            user_email="alice@example.com",
         )
 
         assert len(manager.get_pending_requests()) == 3
@@ -208,11 +219,11 @@ class TestToolApprovalManager:
         # Approve them in different order
         async def approve_requests():
             await asyncio.sleep(0.05)
-            manager.handle_approval_response("test_2", approved=True)
+            manager.handle_approval_response("test_2", approved=True, user_email="alice@example.com")
             await asyncio.sleep(0.05)
-            manager.handle_approval_response("test_1", approved=False, reason="Rejected")
+            manager.handle_approval_response("test_1", approved=False, reason="Rejected", user_email="alice@example.com")
             await asyncio.sleep(0.05)
-            manager.handle_approval_response("test_3", approved=True)
+            manager.handle_approval_response("test_3", approved=True, user_email="alice@example.com")
 
         asyncio.create_task(approve_requests())
 
@@ -236,7 +247,8 @@ class TestToolApprovalManager:
             tool_call_id="test_123",
             tool_name="test_tool",
             arguments=original_args,
-            allow_edit=True
+            allow_edit=True,
+            user_email="alice@example.com",
         )
 
         # Approve with same arguments
@@ -245,7 +257,8 @@ class TestToolApprovalManager:
             manager.handle_approval_response(
                 tool_call_id="test_123",
                 approved=True,
-                arguments={"code": "print('hello')"}  # Same as original
+                arguments={"code": "print('hello')"},  # Same as original
+                user_email="alice@example.com",
             )
 
         asyncio.create_task(approve())
@@ -282,14 +295,16 @@ class TestToolApprovalManager:
         request = manager.create_approval_request(
             tool_call_id="test_123",
             tool_name="test_tool",
-            arguments={"arg1": "value1"}
+            arguments={"arg1": "value1"},
+            user_email="alice@example.com",
         )
 
         async def reject():
             await asyncio.sleep(0.05)
             manager.handle_approval_response(
                 tool_call_id="test_123",
-                approved=False
+                approved=False,
+                user_email="alice@example.com",
                 # No reason provided
             )
 
@@ -363,7 +378,8 @@ class TestToolApprovalManager:
             tool_call_id="test_complex",
             tool_name="complex_tool",
             arguments=complex_args,
-            allow_edit=True
+            allow_edit=True,
+            user_email="alice@example.com",
         )
 
         # Modify nested structure
@@ -385,7 +401,8 @@ class TestToolApprovalManager:
             manager.handle_approval_response(
                 tool_call_id="test_complex",
                 approved=True,
-                arguments=edited_args
+                arguments=edited_args,
+                user_email="alice@example.com",
             )
 
         asyncio.create_task(approve())
@@ -404,12 +421,13 @@ class TestToolApprovalManager:
         request1 = manager.create_approval_request(
             tool_call_id="seq_1",
             tool_name="tool_1",
-            arguments={"step": 1}
+            arguments={"step": 1},
+            user_email="alice@example.com",
         )
 
         async def approve1():
             await asyncio.sleep(0.05)
-            manager.handle_approval_response("seq_1", approved=True)
+            manager.handle_approval_response("seq_1", approved=True, user_email="alice@example.com")
 
         task1 = asyncio.create_task(approve1())
         response1 = await request1.wait_for_response(timeout=1.0)
@@ -423,12 +441,13 @@ class TestToolApprovalManager:
         request2 = manager.create_approval_request(
             tool_call_id="seq_2",
             tool_name="tool_2",
-            arguments={"step": 2}
+            arguments={"step": 2},
+            user_email="alice@example.com",
         )
 
         async def approve2():
             await asyncio.sleep(0.05)
-            manager.handle_approval_response("seq_2", approved=True)
+            manager.handle_approval_response("seq_2", approved=True, user_email="alice@example.com")
 
         task2 = asyncio.create_task(approve2())
         response2 = await request2.wait_for_response(timeout=1.0)
@@ -437,3 +456,135 @@ class TestToolApprovalManager:
 
         assert response2["approved"] is True
         assert "seq_2" not in manager.get_pending_requests()
+
+
+class TestCrossUserApprovalPrevention:
+    """Test that cross-user tool approval bypass is prevented (F-03)."""
+
+    @pytest.mark.asyncio
+    async def test_different_user_cannot_approve(self):
+        """A different user's approval response must be rejected."""
+        manager = ToolApprovalManager()
+        manager.create_approval_request(
+            tool_call_id="call_alice",
+            tool_name="dangerous_tool",
+            arguments={"action": "delete_all"},
+            user_email="alice@example.com",
+        )
+
+        result = manager.handle_approval_response(
+            tool_call_id="call_alice",
+            approved=True,
+            user_email="bob@example.com",
+        )
+
+        assert result is False
+        # Request must still be pending (not resolved by the wrong user)
+        request = manager.get_pending_requests()["call_alice"]
+        assert not request.future.done()
+
+    @pytest.mark.asyncio
+    async def test_same_user_can_approve(self):
+        """The owning user's approval response must be accepted."""
+        manager = ToolApprovalManager()
+        manager.create_approval_request(
+            tool_call_id="call_alice",
+            tool_name="dangerous_tool",
+            arguments={"action": "delete_all"},
+            user_email="alice@example.com",
+        )
+
+        result = manager.handle_approval_response(
+            tool_call_id="call_alice",
+            approved=True,
+            user_email="alice@example.com",
+        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_different_user_cannot_reject(self):
+        """A different user must not be able to reject another user's request."""
+        manager = ToolApprovalManager()
+        manager.create_approval_request(
+            tool_call_id="call_alice",
+            tool_name="dangerous_tool",
+            arguments={"action": "delete_all"},
+            user_email="alice@example.com",
+        )
+
+        result = manager.handle_approval_response(
+            tool_call_id="call_alice",
+            approved=False,
+            reason="I don't like this",
+            user_email="bob@example.com",
+        )
+
+        assert result is False
+        request = manager.get_pending_requests()["call_alice"]
+        assert not request.future.done()
+
+    @pytest.mark.asyncio
+    async def test_different_user_cannot_edit_arguments(self):
+        """A different user must not be able to inject edited arguments."""
+        manager = ToolApprovalManager()
+        manager.create_approval_request(
+            tool_call_id="call_alice",
+            tool_name="filesystem_write",
+            arguments={"path": "/safe/file.txt", "content": "hello"},
+            user_email="alice@example.com",
+        )
+
+        result = manager.handle_approval_response(
+            tool_call_id="call_alice",
+            approved=True,
+            arguments={"path": "/etc/passwd", "content": "pwned"},
+            user_email="bob@example.com",
+        )
+
+        assert result is False
+        request = manager.get_pending_requests()["call_alice"]
+        assert not request.future.done()
+
+    @pytest.mark.asyncio
+    async def test_cross_user_rejection_leaves_request_resolvable(self):
+        """After a cross-user attempt is rejected, the real owner can still approve."""
+        manager = ToolApprovalManager()
+        request = manager.create_approval_request(
+            tool_call_id="call_alice",
+            tool_name="dangerous_tool",
+            arguments={"action": "safe_action"},
+            user_email="alice@example.com",
+        )
+
+        # Bob tries and fails
+        assert manager.handle_approval_response(
+            "call_alice", approved=True, user_email="bob@example.com"
+        ) is False
+
+        # Alice approves successfully
+        assert manager.handle_approval_response(
+            "call_alice", approved=True, user_email="alice@example.com"
+        ) is True
+
+        response = await request.wait_for_response(timeout=1.0)
+        assert response["approved"] is True
+
+    @pytest.mark.asyncio
+    async def test_legacy_no_user_email_still_works(self):
+        """Requests without user_email (backward compat) can be resolved by anyone."""
+        manager = ToolApprovalManager()
+        manager.create_approval_request(
+            tool_call_id="legacy_call",
+            tool_name="some_tool",
+            arguments={"arg": "val"},
+            # No user_email
+        )
+
+        result = manager.handle_approval_response(
+            tool_call_id="legacy_call",
+            approved=True,
+            # No user_email
+        )
+
+        assert result is True

--- a/atlas/tests/test_approval_manager.py
+++ b/atlas/tests/test_approval_manager.py
@@ -571,6 +571,33 @@ class TestCrossUserApprovalPrevention:
         assert response["approved"] is True
 
     @pytest.mark.asyncio
+    async def test_empty_user_email_cannot_approve_owned_request(self):
+        """An empty responder user_email must not approve a request owned by a specific user.
+
+        Regression test for fail-closed behavior: if the request is bound to
+        a user, the response MUST supply a matching user_email. An empty
+        user_email on the response side is NOT a free pass.
+        """
+        manager = ToolApprovalManager()
+        manager.create_approval_request(
+            tool_call_id="call_alice",
+            tool_name="dangerous_tool",
+            arguments={"action": "delete_all"},
+            user_email="alice@example.com",
+        )
+
+        result = manager.handle_approval_response(
+            tool_call_id="call_alice",
+            approved=True,
+            user_email="",
+        )
+
+        assert result is False
+        # Request must still be pending (not resolved by an empty user identity)
+        request = manager.get_pending_requests()["call_alice"]
+        assert not request.future.done()
+
+    @pytest.mark.asyncio
     async def test_legacy_no_user_email_still_works(self):
         """Requests without user_email (backward compat) can be resolved by anyone."""
         manager = ToolApprovalManager()

--- a/docs/admin/tool-approval.md
+++ b/docs/admin/tool-approval.md
@@ -31,6 +31,14 @@ FORCE_TOOL_APPROVAL_GLOBALLY=true
 
 This setting overrides all other user preferences and is a simple way to enforce maximum safety.
 
+## User-Binding and Cross-User Protection
+
+In multi-user deployments, each approval request is bound to the authenticated user who triggered it. When a user responds to an approval prompt, the system verifies that the responding user matches the request owner. If a different user attempts to approve, reject, or edit arguments for another user's pending tool call, the response is rejected and a security warning is logged.
+
+This prevents cross-user approval bypass where one user who learned another user's pending `tool_call_id` could hijack their tool execution.
+
+**Backward compatibility**: In single-user or legacy deployments where `user_email` is not set, the ownership check is skipped and approvals work as before.
+
 ## User-Controlled Auto-Approval
 
 For tools that are not mandated to require approval by an admin, users can choose to "auto-approve" them to streamline their workflow. This option is available in the user settings panel.

--- a/test/pr-validation/fixtures/pr511/.env
+++ b/test/pr-validation/fixtures/pr511/.env
@@ -1,0 +1,4 @@
+# PR #511 fixture: multi-user config for cross-user approval testing
+DEBUG_MODE=false
+USER_A=alice@example.com
+USER_B=bob@example.com

--- a/test/pr-validation/test_pr511_cross_user_tool_approval.sh
+++ b/test/pr-validation/test_pr511_cross_user_tool_approval.sh
@@ -149,9 +149,28 @@ print(result)
 print_result $? "Request still resolvable by owner after cross-user attempt (got: $RESULT)"
 
 # ==========================================
-# 6. Legacy requests (no user_email) still resolve
+# 6a. Empty user_email cannot bypass ownership check
 # ==========================================
-print_header "6. Legacy backward compatibility"
+print_header "6a. Empty user_email response blocked on bound request"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+mgr.create_approval_request('tc-6a', 'dangerous_tool', {'arg': 'val'}, user_email='$USER_A')
+# Attacker sends empty user_email; fail-closed must reject.
+result = mgr.handle_approval_response('tc-6a', approved=True, user_email='')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "False" ]
+print_result $? "Empty user_email cannot bypass owned request (got: $RESULT)"
+
+# ==========================================
+# 6b. Legacy requests (no user_email) still resolve
+# ==========================================
+print_header "6b. Legacy backward compatibility"
 
 RESULT=$(python3 -c "
 import logging; logging.disable(logging.CRITICAL)
@@ -174,7 +193,7 @@ print_header "7. Targeted test suite"
 
 cd "$ATLAS_DIR"
 python3 -m pytest tests/test_approval_manager.py -x -q 2>&1
-print_result $? "test_approval_manager.py passes (all 25 tests)"
+print_result $? "test_approval_manager.py passes (all 26 tests)"
 
 # ==========================================
 # Summary

--- a/test/pr-validation/test_pr511_cross_user_tool_approval.sh
+++ b/test/pr-validation/test_pr511_cross_user_tool_approval.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Test script for PR #511: Prevent cross-user tool approval bypass (F-03)
+#
+# Test plan:
+# - Verify cross-user approval is rejected
+# - Verify cross-user rejection is rejected
+# - Verify cross-user argument injection is rejected
+# - Verify same-user approval works
+# - Verify request remains pending after failed cross-user attempt
+# - Verify legacy requests (no user_email) still resolve
+# - Backend approval manager test suite passes
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ATLAS_DIR="$PROJECT_ROOT/atlas"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures/pr511"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+print_header() {
+    echo ""
+    echo "=========================================="
+    echo "$1"
+    echo "=========================================="
+}
+
+print_result() {
+    if [ $1 -eq 0 ]; then
+        echo -e "${GREEN}PASSED${NC}: $2"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "${RED}FAILED${NC}: $2"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+print_header "PR #511: Cross-User Tool Approval Prevention Tests"
+
+# Activate virtual environment
+if [ -f "$PROJECT_ROOT/.venv/bin/activate" ]; then
+    source "$PROJECT_ROOT/.venv/bin/activate"
+fi
+
+export PYTHONPATH="$PROJECT_ROOT"
+
+# Load fixture
+set -a
+source "$FIXTURES_DIR/.env"
+set +a
+
+# ==========================================
+# 1. Cross-user approval is rejected
+# ==========================================
+print_header "1. Cross-user approval is rejected"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+mgr.create_approval_request('tc-1', 'dangerous_tool', {'arg': 'val'}, user_email='$USER_A')
+result = mgr.handle_approval_response('tc-1', approved=True, user_email='$USER_B')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "False" ]
+print_result $? "Cross-user approval returns False (got: $RESULT)"
+
+# ==========================================
+# 2. Cross-user rejection is rejected
+# ==========================================
+print_header "2. Cross-user rejection is rejected"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+mgr.create_approval_request('tc-2', 'dangerous_tool', {'arg': 'val'}, user_email='$USER_A')
+result = mgr.handle_approval_response('tc-2', approved=False, reason='nope', user_email='$USER_B')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "False" ]
+print_result $? "Cross-user rejection returns False (got: $RESULT)"
+
+# ==========================================
+# 3. Cross-user argument injection is rejected
+# ==========================================
+print_header "3. Cross-user argument injection is rejected"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+mgr.create_approval_request('tc-3', 'dangerous_tool', {'arg': 'safe'}, user_email='$USER_A')
+result = mgr.handle_approval_response('tc-3', approved=True, arguments={'arg': 'INJECTED'}, user_email='$USER_B')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "False" ]
+print_result $? "Cross-user argument injection returns False (got: $RESULT)"
+
+# ==========================================
+# 4. Same-user approval works
+# ==========================================
+print_header "4. Same-user approval works"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+mgr.create_approval_request('tc-4', 'safe_tool', {'arg': 'val'}, user_email='$USER_A')
+result = mgr.handle_approval_response('tc-4', approved=True, user_email='$USER_A')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "True" ]
+print_result $? "Same-user approval returns True (got: $RESULT)"
+
+# ==========================================
+# 5. Request remains pending after failed cross-user attempt
+# ==========================================
+print_header "5. Request remains pending after cross-user failure"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+mgr.create_approval_request('tc-5', 'tool', {'a': '1'}, user_email='$USER_A')
+
+# Cross-user attempt should fail
+mgr.handle_approval_response('tc-5', approved=True, user_email='$USER_B')
+
+# Original user should still be able to respond
+result = mgr.handle_approval_response('tc-5', approved=True, user_email='$USER_A')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "True" ]
+print_result $? "Request still resolvable by owner after cross-user attempt (got: $RESULT)"
+
+# ==========================================
+# 6. Legacy requests (no user_email) still resolve
+# ==========================================
+print_header "6. Legacy backward compatibility"
+
+RESULT=$(python3 -c "
+import logging; logging.disable(logging.CRITICAL)
+from atlas.application.chat.approval_manager import ToolApprovalManager
+
+mgr = ToolApprovalManager()
+# No user_email on request (legacy)
+mgr.create_approval_request('tc-6', 'tool', {'a': '1'})
+result = mgr.handle_approval_response('tc-6', approved=True, user_email='anyone@example.com')
+print(result)
+" 2>&1 | tail -1)
+
+[ "$RESULT" = "True" ]
+print_result $? "Legacy request without user_email resolves normally (got: $RESULT)"
+
+# ==========================================
+# 7. Targeted test suite
+# ==========================================
+print_header "7. Targeted test suite"
+
+cd "$ATLAS_DIR"
+python3 -m pytest tests/test_approval_manager.py -x -q 2>&1
+print_result $? "test_approval_manager.py passes (all 25 tests)"
+
+# ==========================================
+# Summary
+# ==========================================
+print_header "SUMMARY"
+echo -e "Passed: ${GREEN}$PASSED${NC}"
+echo -e "Failed: ${RED}$FAILED${NC}"
+echo ""
+
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}SOME TESTS FAILED${NC}"
+    exit 1
+else
+    echo -e "${GREEN}ALL TESTS PASSED${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Fixes cross-user tool approval bypass (F-03) where any authenticated user who learned another user's pending `tool_call_id` could approve, reject, or inject edited arguments into that user's tool execution
- Adds `user_email` binding to `ToolApprovalRequest` and verifies the responding user matches the request owner in `handle_approval_response()`
- Backward compatible: verification is skipped when `user_email` is empty (single-user/legacy deployments)

## Changes
- `atlas/application/chat/approval_manager.py` — `user_email` field on `ToolApprovalRequest`, ownership check in `handle_approval_response()`
- `atlas/application/chat/utilities/tool_executor.py` — passes `session_context["user_email"]` when creating approval requests
- `atlas/main.py` — passes authenticated `user_email` from WebSocket connection when forwarding approval responses
- `atlas/tests/test_approval_manager.py` — 6 new tests in `TestCrossUserApprovalPrevention`: cross-user approve/reject/argument-injection blocked, same-user allowed, request remains resolvable after failed cross-user attempt, legacy backward compat

## Test plan
- [ ] All 25 approval manager tests pass (`pytest atlas/tests/test_approval_manager.py`)
- [ ] Cross-user approval correctly returns `False` and logs security warning
- [ ] Same-user approval continues to work as before
- [ ] Legacy requests without `user_email` still resolve (backward compat)
- [ ] Full CI/CD pipeline passes in both debug and production modes