### PR TITLE
security: remove hardcoded capability-token dev secret fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -277,7 +277,13 @@ FORCE_TOOL_APPROVAL_GLOBALLY=false
 # APP_LOG_DIR defaults to <project_root>/logs when unset
 # APP_LOG_DIR=/path/to/logs
 
-CAPABILITY_TOKEN_SECRET=blablah
+# CAPABILITY_TOKEN_SECRET: HMAC secret for signing short-lived file-download
+# URLs embedded in tool arguments. Required in production — set this to a
+# random value of at least 32 characters (e.g. `openssl rand -hex 32`). If
+# unset, the server falls back to a cryptographically random per-process
+# secret and logs CRITICAL; tokens will then not survive process restarts.
+# NEVER reuse the placeholder value below in production.
+CAPABILITY_TOKEN_SECRET=replace-with-openssl-rand-hex-32
 
 #############################################
 # S3/MinIO Storage Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### PR #512 - 2026-04-12
 - **Security**: Removed the hardcoded `b"dev-capability-secret"` fallback used by `atlas/core/capabilities.py` when `CAPABILITY_TOKEN_SECRET` was unset. Previously, any attacker who knew this constant could forge HMAC capability tokens for any `{user, file_key}` pair and download any user's files via `/mcp/files/download/` (which intentionally bypasses header-based auth). The fallback now generates a cryptographically random 32-byte per-process secret via `secrets.token_bytes(32)`; tokens signed with it cannot be predicted or forged. A `CRITICAL` log entry is emitted in production (or `WARNING` in debug mode) the first time the ephemeral secret is used, instructing operators to set `CAPABILITY_TOKEN_SECRET` for durable, restart-stable tokens. Fail-closed: no hardcoded value is ever returned from `_get_secret()`.
+
+### PR #511 - 2026-04-12
 - **Security**: Tool approval requests are now bound to the authenticated user who created them. Any WebSocket approval response from a different user (or from an empty/missing user identity) is rejected and a security warning is logged. This prevents cross-user approval bypass (F-03) where a user who learned another user's pending `tool_call_id` could approve, reject, or inject edited arguments into that user's tool execution. The ownership check fails closed: once a request is bound to a `user_email`, the response must supply a matching one. Backward compatible: verification is skipped only for legacy requests where the request itself has no `user_email` (single-user deployments).
 
 ### PR #510 - 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### PR #511 - 2026-04-12
+### PR #512 - 2026-04-12
+- **Security**: Removed the hardcoded `b"dev-capability-secret"` fallback used by `atlas/core/capabilities.py` when `CAPABILITY_TOKEN_SECRET` was unset. Previously, any attacker who knew this constant could forge HMAC capability tokens for any `{user, file_key}` pair and download any user's files via `/mcp/files/download/` (which intentionally bypasses header-based auth). The fallback now generates a cryptographically random 32-byte per-process secret via `secrets.token_bytes(32)`; tokens signed with it cannot be predicted or forged. A `CRITICAL` log entry is emitted in production (or `WARNING` in debug mode) the first time the ephemeral secret is used, instructing operators to set `CAPABILITY_TOKEN_SECRET` for durable, restart-stable tokens. Fail-closed: no hardcoded value is ever returned from `_get_secret()`.
 - **Security**: Tool approval requests are now bound to the authenticated user who created them. Any WebSocket approval response from a different user (or from an empty/missing user identity) is rejected and a security warning is logged. This prevents cross-user approval bypass (F-03) where a user who learned another user's pending `tool_call_id` could approve, reject, or inject edited arguments into that user's tool execution. The ownership check fails closed: once a request is bound to a `user_email`, the response must supply a matching one. Backward compatible: verification is skipped only for legacy requests where the request itself has no `user_email` (single-user deployments).
 
 ### PR #510 - 2026-04-12

--- a/atlas/core/capabilities.py
+++ b/atlas/core/capabilities.py
@@ -9,6 +9,8 @@ import base64
 import hmac
 import json
 import logging
+import secrets
+import threading
 import time
 from hashlib import sha256
 from typing import Any, Dict, Optional
@@ -16,6 +18,15 @@ from typing import Any, Dict, Optional
 from atlas.modules.config import config_manager
 
 logger = logging.getLogger(__name__)
+
+# Ephemeral per-process secret used only when CAPABILITY_TOKEN_SECRET is not
+# configured. Generated on first use from a cryptographically secure RNG, so
+# it cannot be predicted or forged by an attacker. Tokens signed with an
+# ephemeral secret do not survive process restarts; operators must set
+# CAPABILITY_TOKEN_SECRET in production for durable tokens.
+_ephemeral_secret: Optional[bytes] = None
+_ephemeral_lock = threading.Lock()
+_ephemeral_warned: bool = False
 
 
 def _b64url_encode(data: bytes) -> str:
@@ -27,23 +38,67 @@ def _b64url_decode(data: str) -> bytes:
     return base64.urlsafe_b64decode((data + padding).encode("ascii"))
 
 
+def _get_ephemeral_secret() -> bytes:
+    """Return (and lazily create) the per-process ephemeral secret.
+
+    The first caller in the process allocates 32 random bytes; subsequent
+    callers receive the same value so mint/verify are consistent within
+    one process lifetime.
+    """
+    global _ephemeral_secret, _ephemeral_warned
+    with _ephemeral_lock:
+        if _ephemeral_secret is None:
+            _ephemeral_secret = secrets.token_bytes(32)
+        if not _ephemeral_warned:
+            _ephemeral_warned = True
+            # Elevate severity in production so this cannot be missed in logs.
+            try:
+                production = not bool(
+                    getattr(config_manager.app_settings, "debug_mode", False)
+                )
+            except Exception:
+                production = True
+            message = (
+                "CAPABILITY_TOKEN_SECRET is not configured; using an ephemeral "
+                "per-process secret for HMAC-signed file download tokens. "
+                "Tokens will not survive process restarts. Set "
+                "CAPABILITY_TOKEN_SECRET in the environment for production."
+            )
+            if production:
+                logger.critical(message)
+            else:
+                logger.warning(message)
+        return _ephemeral_secret
+
+
 def _get_secret() -> bytes:
     """Get the capability token secret as bytes.
 
     Order of precedence:
-    - App settings (config manager)
-    - Fallback development secret (unsafe for production)
+    - Configured CAPABILITY_TOKEN_SECRET from app settings
+    - Cryptographically random per-process ephemeral secret (fail-closed:
+      never falls back to a hardcoded value that an attacker could predict)
     """
     try:
         settings = config_manager.app_settings
-        if getattr(settings, "capability_token_secret", None):
-            return settings.capability_token_secret.encode("utf-8")
+        configured = getattr(settings, "capability_token_secret", None)
+        if configured:
+            return configured.encode("utf-8")
     except Exception:
-        # Config not ready; continue to fallback with a dev secret.
-        logger.debug("Capability token secret not available; using fallback dev secret.")
+        logger.debug("Capability token secret config not ready; using ephemeral secret.")
 
-    logger.warning("Using fallback dev capability token secret. Set CAPABILITY_TOKEN_SECRET for security.")
-    return b"dev-capability-secret"
+    return _get_ephemeral_secret()
+
+
+def _reset_ephemeral_secret_for_tests() -> None:
+    """Test helper: clear the cached ephemeral secret and warning flag.
+
+    Do not call from production code paths.
+    """
+    global _ephemeral_secret, _ephemeral_warned
+    with _ephemeral_lock:
+        _ephemeral_secret = None
+        _ephemeral_warned = False
 
 
 def _get_default_ttl_seconds() -> int:

--- a/atlas/tests/test_security_capability_tokens.py
+++ b/atlas/tests/test_security_capability_tokens.py
@@ -1,9 +1,17 @@
 import base64
+import hmac
+from hashlib import sha256
 
 from main import app
 from starlette.testclient import TestClient
 
-from atlas.core.capabilities import generate_file_token, verify_file_token
+from atlas.core import capabilities
+from atlas.core.capabilities import (
+    _b64url_encode,
+    _reset_ephemeral_secret_for_tests,
+    generate_file_token,
+    verify_file_token,
+)
 
 
 def test_capability_token_roundtrip_and_tamper(monkeypatch):
@@ -63,3 +71,111 @@ def test_download_rejects_invalid_or_expired_token(monkeypatch):
         headers={"X-User-Email": "ignored@example.com"},
     )
     assert resp2.status_code == 403
+
+
+class _EmptySecretSettings:
+    """Stand-in app settings object with no capability secret."""
+
+    capability_token_secret = ""
+    capability_token_ttl_seconds = 3600
+    debug_mode = False
+
+
+class _EmptySecretConfigManager:
+    app_settings = _EmptySecretSettings()
+
+
+def test_hardcoded_dev_secret_cannot_forge_tokens(monkeypatch, caplog):
+    """Fail-closed regression: forgeries signed with the old dev secret are rejected.
+
+    Prior to this fix, _get_secret() fell back to b"dev-capability-secret" when
+    CAPABILITY_TOKEN_SECRET was unset, letting any attacker mint tokens for any
+    (user, file_key) pair. Verify that a token crafted with that constant is now
+    refused and that an ephemeral secret has taken its place.
+    """
+    _reset_ephemeral_secret_for_tests()
+    monkeypatch.setattr(capabilities, "config_manager", _EmptySecretConfigManager())
+
+    # Forge a token using the previously hardcoded dev secret.
+    payload = b'{"u":"victim@example.com","k":"victim-file","e":9999999999}'
+    body = _b64url_encode(payload)
+    forged_sig = hmac.new(b"dev-capability-secret", body.encode("ascii"), sha256).digest()
+    forged_token = f"{body}.{_b64url_encode(forged_sig)}"
+
+    with caplog.at_level("WARNING"):
+        assert verify_file_token(forged_token) is None
+
+
+def test_ephemeral_secret_is_random_and_roundtrips(monkeypatch, caplog):
+    """When no secret is configured, an ephemeral random secret is used.
+
+    The secret must be consistent across calls inside one process (so mint and
+    verify agree) but cryptographically random (not predictable) across process
+    starts. We can only check within-process consistency here; length and
+    source of randomness are verified implicitly via secrets.token_bytes.
+    """
+    _reset_ephemeral_secret_for_tests()
+    monkeypatch.setattr(capabilities, "config_manager", _EmptySecretConfigManager())
+
+    with caplog.at_level("CRITICAL"):
+        token = generate_file_token("alice@example.com", "file-1", ttl_seconds=60)
+        claims = verify_file_token(token)
+
+    assert claims is not None
+    assert claims["u"] == "alice@example.com"
+    assert claims["k"] == "file-1"
+    # Production (debug_mode=False) must emit a CRITICAL warning exactly once.
+    critical_records = [r for r in caplog.records if r.levelname == "CRITICAL"]
+    assert any("CAPABILITY_TOKEN_SECRET" in r.getMessage() for r in critical_records)
+
+
+def test_ephemeral_secret_warn_is_warning_in_debug_mode(monkeypatch, caplog):
+    """Dev-mode deployments see a WARNING (not CRITICAL) to reduce log noise."""
+
+    class _DebugSettings:
+        capability_token_secret = ""
+        capability_token_ttl_seconds = 3600
+        debug_mode = True
+
+    class _DebugConfigManager:
+        app_settings = _DebugSettings()
+
+    _reset_ephemeral_secret_for_tests()
+    monkeypatch.setattr(capabilities, "config_manager", _DebugConfigManager())
+
+    with caplog.at_level("WARNING"):
+        _ = generate_file_token("alice@example.com", "file-1", ttl_seconds=60)
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("CAPABILITY_TOKEN_SECRET" in m for m in messages)
+    # No CRITICAL-level record in debug mode.
+    assert not any(r.levelname == "CRITICAL" for r in caplog.records)
+
+
+def test_ephemeral_secret_is_stable_within_process(monkeypatch):
+    """Repeated calls inside one process must return the same ephemeral secret."""
+    _reset_ephemeral_secret_for_tests()
+    monkeypatch.setattr(capabilities, "config_manager", _EmptySecretConfigManager())
+
+    first = capabilities._get_secret()
+    second = capabilities._get_secret()
+    assert first == second
+    assert len(first) == 32  # secrets.token_bytes(32)
+    assert first != b"dev-capability-secret"
+
+
+def test_configured_secret_preferred_over_ephemeral(monkeypatch):
+    """A configured CAPABILITY_TOKEN_SECRET must win over the ephemeral secret."""
+
+    class _ConfiguredSettings:
+        capability_token_secret = "configured-strong-secret-1234567890"
+        capability_token_ttl_seconds = 3600
+        debug_mode = False
+
+    class _ConfiguredConfigManager:
+        app_settings = _ConfiguredSettings()
+
+    _reset_ephemeral_secret_for_tests()
+    monkeypatch.setattr(capabilities, "config_manager", _ConfiguredConfigManager())
+
+    assert capabilities._get_secret() == b"configured-strong-secret-1234567890"

--- a/docs/admin/troubleshooting-file-access.md
+++ b/docs/admin/troubleshooting-file-access.md
@@ -1,6 +1,6 @@
 # Troubleshooting File Access for MCP Servers
 
-Last updated: 2026-03-11
+Last updated: 2026-04-12
 
 This guide helps resolve issues with MCP servers accessing attached files in Atlas UI.
 
@@ -60,7 +60,39 @@ Local servers can resolve relative URLs or use `localhost`, but remote servers n
    curl https://atlas-ui.example.com/api/health
    ```
 
-### Issue 3: Token Expiration Errors
+### Issue 3: `CAPABILITY_TOKEN_SECRET` Not Configured (Ephemeral Secret Warning)
+
+**Symptoms:**
+- Logs contain `CRITICAL` or `WARNING` entries mentioning
+  `CAPABILITY_TOKEN_SECRET is not configured; using an ephemeral per-process secret`
+- File download links stop working after a backend restart
+- Tokens minted by one worker cannot be verified by another in multi-worker
+  deployments
+
+**Cause:**
+`CAPABILITY_TOKEN_SECRET` is unset or empty. As of PR #512 the backend no
+longer falls back to a hardcoded development secret; instead it generates a
+cryptographically random 32-byte secret at first use. This secret is safe
+against forgery, but does not persist across process restarts or multiple
+worker processes.
+
+**Solution:**
+Set a strong, stable value in production:
+
+```bash
+# Generate a random secret once, then store it in your secrets manager / .env
+openssl rand -hex 32
+```
+
+Add to `.env`:
+```bash
+CAPABILITY_TOKEN_SECRET=<paste-the-64-char-hex-output-here>
+```
+
+Restart the backend. The warning should stop appearing and tokens will
+survive restarts and be verifiable across workers.
+
+### Issue 4: Token Expiration Errors
 
 **Symptoms:**
 - File download initially works but fails after some time
@@ -82,7 +114,7 @@ Increase the token TTL in your configuration:
 
 3. For very large files or slow operations, consider implementing chunked downloads or streaming in your MCP server
 
-### Issue 4: Files Work in Development But Not Production
+### Issue 5: Files Work in Development But Not Production
 
 **Symptoms:**
 - File access works when testing locally
@@ -106,7 +138,7 @@ Increase the token TTL in your configuration:
 
 3. Ensure load balancer or reverse proxy properly forwards requests to the backend
 
-### Issue 5: SSL/TLS Certificate Errors
+### Issue 6: SSL/TLS Certificate Errors
 
 **Symptoms:**
 - MCP server reports SSL certificate verification errors
@@ -134,7 +166,7 @@ The remote MCP server cannot verify the SSL certificate of the Atlas UI backend.
 
 2. Or install the self-signed certificate in the MCP server's trust store
 
-### Issue 6: Network Isolation / Firewall Blocks
+### Issue 7: Network Isolation / Firewall Blocks
 
 **Symptoms:**
 - Connection timeout errors
@@ -214,7 +246,7 @@ BACKEND_PUBLIC_URL=https://atlas.company.com
 
 Both local and remote servers work because the backend generates absolute URLs.
 
-### Issue 7: File Upload Fails for Filenames with Spaces
+### Issue 8: File Upload Fails for Filenames with Spaces
 
 **Symptoms:**
 - Uploading a file whose name contains spaces fails silently or produces an error

--- a/test/pr-validation/fixtures/pr512/.env.configured
+++ b/test/pr-validation/fixtures/pr512/.env.configured
@@ -1,0 +1,4 @@
+# PR #512 fixture: deployment with a configured CAPABILITY_TOKEN_SECRET.
+# Verifies the configured value is preferred over the ephemeral secret.
+DEBUG_MODE=false
+CAPABILITY_TOKEN_SECRET=pr512-configured-strong-secret-0123456789abcdef

--- a/test/pr-validation/fixtures/pr512/.env.unset
+++ b/test/pr-validation/fixtures/pr512/.env.unset
@@ -1,0 +1,12 @@
+# PR #512 fixture: simulates a deployment where CAPABILITY_TOKEN_SECRET was
+# forgotten (or set to an empty string). The capabilities module must NOT
+# fall back to the old hardcoded b"dev-capability-secret" constant; it must
+# generate an ephemeral random secret instead.
+#
+# Explicit empty value overrides the project root `.env` (which ships with a
+# placeholder) so pydantic-settings loads an empty string for this field.
+DEBUG_MODE=false
+# Disable proxy-secret fail-closed so the end-to-end test exercises the
+# capability-token fix path rather than the PR #510 proxy-secret path.
+FEATURE_PROXY_SECRET_ENABLED=false
+CAPABILITY_TOKEN_SECRET=

--- a/test/pr-validation/test_pr512_capability_token_fail_closed.sh
+++ b/test/pr-validation/test_pr512_capability_token_fail_closed.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+# Test script for PR #512: Remove hardcoded capability-token dev secret (fail-closed).
+#
+# Test plan:
+# - With the unset fixture (CAPABILITY_TOKEN_SECRET=""), a forged token
+#   signed with the legacy b"dev-capability-secret" constant is rejected.
+# - With the unset fixture, mint/verify still roundtrip inside one process
+#   via the ephemeral per-process secret.
+# - With the unset fixture, _get_secret() returns a 32-byte stable random
+#   value that is NOT the legacy constant.
+# - With the configured fixture, the configured CAPABILITY_TOKEN_SECRET is
+#   preferred over the ephemeral secret.
+# - End-to-end HTTP: /api/files/download/<key>?token=<forged> returns 403
+#   even when the legacy dev secret was used to sign the forgery.
+# - Backend capability-token security test suite passes.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ATLAS_DIR="$PROJECT_ROOT/atlas"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures/pr512"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+print_header() {
+    echo ""
+    echo "=========================================="
+    echo "$1"
+    echo "=========================================="
+}
+
+print_result() {
+    if [ $1 -eq 0 ]; then
+        echo -e "${GREEN}PASSED${NC}: $2"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "${RED}FAILED${NC}: $2"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+print_header "PR #512: Capability-token fail-closed validation"
+
+# Activate virtual environment
+if [ -f "$PROJECT_ROOT/.venv/bin/activate" ]; then
+    source "$PROJECT_ROOT/.venv/bin/activate"
+fi
+
+export PYTHONPATH="$PROJECT_ROOT"
+
+run_with_fixture() {
+    local fixture="$1"
+    local script="$2"
+    (
+        set -a
+        # shellcheck disable=SC1090
+        source "$fixture"
+        set +a
+        python3 -c "$script"
+    )
+}
+
+# ==========================================
+# 1. Legacy forged token is rejected (unset fixture)
+# ==========================================
+print_header "1. Legacy forged token rejected (CAPABILITY_TOKEN_SECRET unset)"
+
+RESULT=$(run_with_fixture "$FIXTURES_DIR/.env.unset" '
+import hmac, logging
+logging.disable(logging.CRITICAL)
+from hashlib import sha256
+from atlas.core.capabilities import (
+    _b64url_encode,
+    _reset_ephemeral_secret_for_tests,
+    verify_file_token,
+)
+
+_reset_ephemeral_secret_for_tests()
+
+payload = b"{\"u\":\"victim@example.com\",\"k\":\"victim-file\",\"e\":9999999999}"
+body = _b64url_encode(payload)
+sig = hmac.new(b"dev-capability-secret", body.encode("ascii"), sha256).digest()
+token = f"{body}.{_b64url_encode(sig)}"
+print("FORGED_ACCEPTED" if verify_file_token(token) is not None else "REJECTED")
+' 2>&1 | tail -1)
+
+[ "$RESULT" = "REJECTED" ]
+print_result $? "Forged token with legacy dev secret rejected (got: $RESULT)"
+
+# ==========================================
+# 2. Ephemeral secret mint/verify roundtrips (unset fixture)
+# ==========================================
+print_header "2. Ephemeral secret mint/verify roundtrip"
+
+RESULT=$(run_with_fixture "$FIXTURES_DIR/.env.unset" '
+import logging
+logging.disable(logging.CRITICAL)
+from atlas.core.capabilities import (
+    _reset_ephemeral_secret_for_tests,
+    generate_file_token,
+    verify_file_token,
+)
+
+_reset_ephemeral_secret_for_tests()
+token = generate_file_token("alice@example.com", "pr512-key", ttl_seconds=60)
+claims = verify_file_token(token)
+if claims and claims["u"] == "alice@example.com" and claims["k"] == "pr512-key":
+    print("OK")
+else:
+    print("BAD")
+' 2>&1 | tail -1)
+
+[ "$RESULT" = "OK" ]
+print_result $? "Ephemeral mint/verify roundtrip (got: $RESULT)"
+
+# ==========================================
+# 3. Ephemeral secret properties (unset fixture)
+# ==========================================
+print_header "3. Ephemeral secret is 32 random bytes, stable, not legacy"
+
+RESULT=$(run_with_fixture "$FIXTURES_DIR/.env.unset" '
+import logging
+logging.disable(logging.CRITICAL)
+from atlas.core.capabilities import _get_secret, _reset_ephemeral_secret_for_tests
+
+_reset_ephemeral_secret_for_tests()
+first = _get_secret()
+second = _get_secret()
+legacy = b"dev-capability-secret"
+if len(first) == 32 and first == second and first != legacy:
+    print("OK")
+else:
+    print("BAD len=" + str(len(first)) + " stable=" + str(first == second) + " legacy=" + str(first == legacy))
+' 2>&1 | tail -1)
+
+[ "$RESULT" = "OK" ]
+print_result $? "Ephemeral secret is 32 random bytes, stable, not legacy (got: $RESULT)"
+
+# ==========================================
+# 4. Configured CAPABILITY_TOKEN_SECRET wins (configured fixture)
+# ==========================================
+print_header "4. Configured CAPABILITY_TOKEN_SECRET preferred over ephemeral"
+
+RESULT=$(run_with_fixture "$FIXTURES_DIR/.env.configured" '
+import logging
+logging.disable(logging.CRITICAL)
+from atlas.core.capabilities import _get_secret, _reset_ephemeral_secret_for_tests
+
+_reset_ephemeral_secret_for_tests()
+secret = _get_secret()
+if secret == b"pr512-configured-strong-secret-0123456789abcdef":
+    print("OK")
+else:
+    print(f"BAD secret={secret!r}")
+' 2>&1 | tail -1)
+
+[ "$RESULT" = "OK" ]
+print_result $? "Configured secret wins (got: $RESULT)"
+
+# ==========================================
+# 5. End-to-end: forged token download attempt returns 403
+# ==========================================
+print_header "5. End-to-end forged download attempt returns 403"
+
+RESULT=$(ATLAS_DIR="$ATLAS_DIR" run_with_fixture "$FIXTURES_DIR/.env.unset" '
+import base64, hmac, logging, os, sys, types
+logging.disable(logging.CRITICAL)
+
+# atlas/main.py needs to be importable as "main".
+sys.path.insert(0, os.environ["ATLAS_DIR"])
+
+# Stub LiteLLM to avoid external deps (mirrors test_capability_tokens_and_injection.py).
+fake = types.ModuleType("atlas.modules.llm.litellm_caller")
+
+class _FakeLLM:
+    def __init__(self, *args, **kwargs):
+        pass
+    async def call_plain(self, *args, **kwargs):
+        return "ok"
+
+fake.LiteLLMCaller = _FakeLLM
+sys.modules["atlas.modules.llm.litellm_caller"] = fake
+
+from hashlib import sha256
+from main import app
+from starlette.testclient import TestClient
+
+from atlas.core.capabilities import _b64url_encode, _reset_ephemeral_secret_for_tests
+from atlas.infrastructure import app_factory as af
+
+_reset_ephemeral_secret_for_tests()
+
+class _FakeS3:
+    endpoint_url = "mock://s3"
+    bucket_name = "test-bucket"
+    async def get_file(self, user, key):
+        return {
+            "key": key,
+            "filename": "leak.txt",
+            "content_base64": base64.b64encode(b"secret").decode(),
+            "content_type": "text/plain",
+            "size": 6,
+            "last_modified": "",
+            "etag": "",
+            "tags": {},
+            "user_email": user,
+        }
+
+original = af.get_file_storage
+af.get_file_storage = lambda: _FakeS3()
+try:
+    payload = b"{\"u\":\"victim@example.com\",\"k\":\"victim-file\",\"e\":9999999999}"
+    body = _b64url_encode(payload)
+    sig = hmac.new(b"dev-capability-secret", body.encode("ascii"), sha256).digest()
+    forged = f"{body}.{_b64url_encode(sig)}"
+
+    client = TestClient(app)
+    resp = client.get(
+        "/api/files/download/victim-file",
+        params={"token": forged},
+        headers={"X-User-Email": "attacker@example.com"},
+    )
+    print(f"STATUS={resp.status_code}")
+finally:
+    af.get_file_storage = original
+' 2>&1 | tail -1)
+
+# The forged token must be rejected with 403 by the download route's
+# verify_file_token check. 401 would also indicate rejection upstream.
+# 200 would mean the forgery succeeded (the vulnerability still exists).
+[[ "$RESULT" == "STATUS=403" || "$RESULT" == "STATUS=401" ]]
+print_result $? "Forged download rejected with 401/403 (got: $RESULT)"
+
+# ==========================================
+# 6. Backend capability-token security suite
+# ==========================================
+print_header "6. Backend capability-token security suite"
+
+# Run pytest in a clean environment so the fixture sources above cannot leak
+# DEBUG_MODE=false or empty CAPABILITY_TOKEN_SECRET into the suite.
+cd "$ATLAS_DIR"
+env -u DEBUG_MODE -u CAPABILITY_TOKEN_SECRET \
+    PYTHONPATH="$PROJECT_ROOT" \
+    python3 -m pytest tests/test_security_capability_tokens.py -x -q 2>&1
+print_result $? "test_security_capability_tokens.py passes"
+
+# ==========================================
+# Summary
+# ==========================================
+print_header "SUMMARY"
+echo -e "Passed: ${GREEN}$PASSED${NC}"
+echo -e "Failed: ${RED}$FAILED${NC}"
+echo ""
+
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}SOME TESTS FAILED${NC}"
+    exit 1
+else
+    echo -e "${GREEN}ALL TESTS PASSED${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- `atlas/core/capabilities.py` no longer falls back to `b"dev-capability-secret"` when `CAPABILITY_TOKEN_SECRET` is unset. Previously, any attacker who knew that constant could forge HMAC capability tokens for any `{user, file_key}` pair and read arbitrary users' files via `/mcp/files/download/` (which intentionally bypasses header-based auth).
- The new fallback generates a cryptographically random 32-byte per-process secret via `secrets.token_bytes(32)`. Tokens signed with it cannot be predicted or forged. Fail-closed: `_get_secret()` never returns a hardcoded value.
- A `CRITICAL` log entry is emitted in production (or `WARNING` in debug mode) the first time the ephemeral secret is used, instructing operators to set `CAPABILITY_TOKEN_SECRET` for durable, restart-stable tokens.

## Vulnerability fixed

> Capability-token HMAC falls back to a hardcoded dev secret `b"dev-capability-secret"`. `atlas/core/capabilities.py:30-46`. Default `capability_token_secret = ""` (`config_manager.py:557`). If an operator forgets to set it, any attacker can forge file-download tokens for any `{user, file_key}` and read any user's files via `/mcp/files/download/` (which bypasses header auth entirely).

## Changes

- **`atlas/core/capabilities.py`**: removed the `b"dev-capability-secret"` constant; introduced a lock-protected `_get_ephemeral_secret()` that lazily allocates 32 random bytes on first use and logs a loud warning. `_reset_ephemeral_secret_for_tests()` is exposed purely for test isolation.
- **`atlas/tests/test_security_capability_tokens.py`**: 5 new tests asserting the legacy forgery is rejected, ephemeral mint/verify roundtrips, ephemeral secret properties (32 bytes, stable, not the legacy constant), configured-secret precedence, and warning severity by mode.
- **`.env.example`**: replaced placeholder `blablah` with an explicit `replace-with-openssl-rand-hex-32` and an explanatory comment describing production requirements and the ephemeral fallback.
- **`docs/admin/troubleshooting-file-access.md`**: added a new Issue 3 describing the `CRITICAL` log line and the `openssl rand -hex 32` remediation.
- **`CHANGELOG.md`**: new PR #512 entry under `[Unreleased]`.
- **`test/pr-validation/test_pr512_capability_token_fail_closed.sh`** + fixtures `pr512/.env.unset` and `pr512/.env.configured`: end-to-end validation script with 6 checks including a `TestClient` HTTP probe that verifies a forged token on `/api/files/download/` returns 403 under the unset fixture.

## Test plan

- [x] `ruff check atlas/` passes
- [x] `python -m pytest atlas/tests/` passes (1183 passed, 17 skipped)
- [x] New `test_security_capability_tokens.py` tests pass (8/8)
- [x] `bash test/run_pr_validation.sh 512` passes (6/6 checks)
- [x] End-to-end `TestClient` check confirms that a token forged with the legacy `b"dev-capability-secret"` constant returns HTTP 403 on `/api/files/download/<key>` under the unset fixture (proxy-secret disabled so the capability-token path is exercised, not the PR #510 fail-closed path)
- [ ] Reviewer: manually confirm the `CRITICAL` log line appears once on first use when `CAPABILITY_TOKEN_SECRET` is unset in a prod-mode start