### PR TITLE
Fix Anthropic UnsupportedParamsError on history with tool_calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### PR #TBD - 2026-04-16
+### PR #534 - 2026-04-16
 - **Fix**: Anthropic calls failed with `litellm.UnsupportedParamsError: Anthropic doesn't support tool calling without tools= param specified` whenever the conversation history contained a prior assistant `tool_calls` block but the current call omitted `tools=` (e.g. title generation, plain replies, or follow-ups on a conversation that earlier used tools). Set `litellm.modify_params = True` at module load so litellm injects a benign `dummy_tool` schema for Anthropic in this case, matching litellm's documented workaround. Added a regression test asserting both `drop_params` and `modify_params` stay enabled.
 
 ### PR #533 - 2026-04-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #TBD - 2026-04-16
+- **Fix**: Anthropic calls failed with `litellm.UnsupportedParamsError: Anthropic doesn't support tool calling without tools= param specified` whenever the conversation history contained a prior assistant `tool_calls` block but the current call omitted `tools=` (e.g. title generation, plain replies, or follow-ups on a conversation that earlier used tools). Set `litellm.modify_params = True` at module load so litellm injects a benign `dummy_tool` schema for Anthropic in this case, matching litellm's documented workaround. Added a regression test asserting both `drop_params` and `modify_params` stay enabled.
+
 ### PR #533 - 2026-04-15
 - **Fix**: File delete (and download) from the File Library returned 404 in production. `AllFilesView` used `encodeURIComponent` on the full S3 key which encoded `/` to `%2F`, breaking path-based routing through reverse proxies. Now encodes each path segment individually. Also fixed `FilesPage` referencing the non-existent `file.s3_key` property (should be `file.key`). Added backend `unquote()` safety net on all `{file_key:path}` route handlers to handle residual percent-encoding from proxies.
 

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -52,6 +52,11 @@ logger = logging.getLogger(__name__)
 
 # Configure LiteLLM settings
 litellm.drop_params = True  # Drop unsupported params instead of erroring
+# Allow litellm to inject a dummy tool schema for Anthropic requests when the
+# message history contains tool_call blocks but the current call doesn't pass
+# tools= (e.g. title generation or plain replies on a conversation that earlier
+# used tools). Without this, Anthropic's transformer raises UnsupportedParamsError.
+litellm.modify_params = True
 
 # Retry configuration for transient LLM errors
 MAX_LLM_RETRIES = 3

--- a/atlas/tests/test_app_factory_smoke.py
+++ b/atlas/tests/test_app_factory_smoke.py
@@ -8,6 +8,7 @@ def _ensure_litellm_stub():
     m = types.ModuleType("litellm")
     # Attributes used at import time
     m.drop_params = True
+    m.modify_params = True
     def _set_verbose(*args, **kwargs):
         return None
     m.set_verbose = _set_verbose

--- a/atlas/tests/test_llm_anthropic_history.py
+++ b/atlas/tests/test_llm_anthropic_history.py
@@ -1,0 +1,28 @@
+"""Regression test: Anthropic requests must tolerate message history with tool_calls.
+
+Scenario: a conversation previously invoked tools (assistant message with
+tool_calls + tool-role result message), then the app calls plain LLM (no
+tools) — e.g. for title generation or a follow-up reply after the user
+switches models. Without `litellm.modify_params = True`, Anthropic's
+transformer raises `UnsupportedParamsError` because it refuses a request
+whose history references tool use but whose current call has no `tools=`.
+
+This test guards the module-level `litellm.modify_params` setting by
+confirming it is enabled at import time.
+"""
+
+import litellm
+
+from atlas.modules.llm import litellm_caller as caller_module  # noqa: F401
+
+
+def test_modify_params_enabled_for_anthropic_history_compat():
+    """modify_params must be True so litellm injects a dummy tool when
+    needed, instead of raising UnsupportedParamsError on Anthropic calls
+    whose message history contains tool_call blocks."""
+    assert litellm.modify_params is True
+
+
+def test_drop_params_still_enabled():
+    """Ensure the existing drop_params setting was not regressed."""
+    assert litellm.drop_params is True


### PR DESCRIPTION
## Summary
- Anthropic calls were failing with `litellm.UnsupportedParamsError: Anthropic doesn't support tool calling without 'tools=' param specified` whenever the conversation history contained a prior assistant `tool_calls` block but the current call omitted `tools=` (title generation, plain replies, follow-ups after switching models, etc.).
- Root cause confirmed in `litellm/llms/anthropic/chat/transformation.py:1345` — when `has_tool_call_blocks(messages)` is true but `tools` is not in params, litellm raises unless `litellm.modify_params` is set, in which case it injects a benign `dummy_tool` schema.
- Fix: set `litellm.modify_params = True` at module import in `atlas/modules/llm/litellm_caller.py` (next to the existing `drop_params = True`). This is the workaround litellm's own error message recommends.
- Added `test_llm_anthropic_history.py` to pin both flags, and updated the litellm stub in `test_app_factory_smoke.py`.

## Verification
- Replayed the exact failing scenario against `AnthropicConfig.transform_request` with a `user → assistant(tool_calls) → tool → user` history — before: `UnsupportedParamsError`; after: succeeds, `dummy_tool` injected.
- Toggled `modify_params=False` to confirm it is the controlling knob (original error reproduced).
- Full backend suite: **1218 passed, 17 skipped**. No regressions.

## Test plan
- [x] Unit test asserts `litellm.modify_params is True` and `litellm.drop_params is True`
- [x] Full backend pytest suite green
- [x] Manual repro of the failing scenario against the live `AnthropicConfig` transformer
- [ ] Smoke-test an Anthropic model in the running app on a conversation that already used tools