### PR TITLE
Fall back to sync call when MCP tool refuses task-augmented execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #TBD - 2026-04-16
+- **Fix**: Tool calls failed with `McpError: FunctionTool '...' does not support task-augmented execution` when the server advertised task capability but the individual tool declared `tasks.mode="forbidden"`. `MCPToolManager.call_tool` now catches that specific error, falls back to a synchronous (non-task) call, and caches the `(server, tool)` pair so subsequent invocations skip task mode directly. Unrelated errors still propagate unchanged.
+
 ### PR #533 - 2026-04-15
 - **Fix**: File delete (and download) from the File Library returned 404 in production. `AllFilesView` used `encodeURIComponent` on the full S3 key which encoded `/` to `%2F`, breaking path-based routing through reverse proxies. Now encodes each path segment individually. Also fixed `FilesPage` referencing the non-existent `file.s3_key` property (should be `file.key`). Added backend `unquote()` safety net on all `{file_key:path}` route handlers to handle residual percent-encoding from proxies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### PR #TBD - 2026-04-16
+### PR #534 - 2026-04-16
 - **Fix**: Tool calls failed with `McpError: FunctionTool '...' does not support task-augmented execution` when the server advertised task capability but the individual tool declared `tasks.mode="forbidden"`. `MCPToolManager.call_tool` now catches that specific error, falls back to a synchronous (non-task) call, and caches the `(server, tool)` pair so subsequent invocations skip task mode directly. Unrelated errors still propagate unchanged.
 
 ### PR #533 - 2026-04-15

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -27,6 +27,19 @@ logger = logging.getLogger(__name__)
 LogCallback = Callable[[str, str, str, Dict[str, Any]], Awaitable[None]]
 
 
+def _is_task_forbidden_error(exc: BaseException) -> bool:
+    """Return True when an MCP call failed because the specific tool refuses
+    task-augmented execution (fastmcp `tasks.mode="forbidden"`).
+
+    A server may advertise task capability overall while individual tools
+    opt out. fastmcp surfaces that as an `McpError` whose message contains
+    "does not support task-augmented execution"
+    (see fastmcp/server/tasks/routing.py). We match on the message text
+    because the concrete exception class varies across fastmcp versions.
+    """
+    return "does not support task-augmented execution" in str(exc)
+
+
 class _ElicitationRoutingContext:
     def __init__(
         self,
@@ -171,6 +184,11 @@ class MCPToolManager:
 
         # Cache of which servers support background tasks
         self._server_task_support: Dict[str, bool] = {}
+        # Per-tool cache for tools that the server refused task-mode on (e.g.
+        # fastmcp tools declared with tasks.mode="forbidden"). A server may
+        # advertise task capability overall while individual tools opt out;
+        # we learn this on first failure and skip task mode thereafter.
+        self._tool_task_forbidden: set[tuple[str, str]] = set()
 
         # Task timeout: seconds before switching to background task polling
         app_settings = config_manager.app_settings
@@ -1783,12 +1801,32 @@ class MCPToolManager:
                     logger.info(f"Successfully called {sanitize_for_logging(tool_name)} on {sanitize_for_logging(server_name)}")
                     return result
 
-            # With persistent session, try adaptive task mode
-            use_tasks = self._supports_tasks(server_name, active_client)
+            # With persistent session, try adaptive task mode — unless this
+            # specific tool was already observed to refuse task mode
+            # (fastmcp tasks.mode="forbidden").
+            use_tasks = (
+                self._supports_tasks(server_name, active_client)
+                and (server_name, tool_name) not in self._tool_task_forbidden
+            )
+
+            tool_task = None
+            if use_tasks:
+                try:
+                    tool_task = await active_client.call_tool(tool_name, arguments, task=True, **kwargs)
+                except Exception as task_exc:
+                    if _is_task_forbidden_error(task_exc):
+                        logger.info(
+                            "Tool %s on %s does not support task-augmented execution; "
+                            "falling back to synchronous call and caching the decision.",
+                            sanitize_for_logging(tool_name),
+                            sanitize_for_logging(server_name),
+                        )
+                        self._tool_task_forbidden.add((server_name, tool_name))
+                        use_tasks = False
+                    else:
+                        raise
 
             if use_tasks:
-                tool_task = await active_client.call_tool(tool_name, arguments, task=True, **kwargs)
-
                 if tool_task.returned_immediately:
                     result = tool_task.result
                 else:
@@ -1842,7 +1880,8 @@ class MCPToolManager:
                     except asyncio.CancelledError:
                         await tool_task.cancel()
                         raise
-            else:
+
+            if not use_tasks:
                 result = await asyncio.wait_for(
                     active_client.call_tool(tool_name, arguments, **kwargs),
                     timeout=call_timeout,

--- a/atlas/tests/test_adaptive_task_polling.py
+++ b/atlas/tests/test_adaptive_task_polling.py
@@ -176,3 +176,124 @@ class TestAdaptiveTaskPolling:
 
         # Verify on_status_change was registered for progress
         mock_task.on_status_change.assert_called_once()
+
+
+class TestTaskForbiddenFallback:
+    """A server may advertise task support while individual tools refuse
+    task-augmented execution (fastmcp `tasks.mode="forbidden"`). The manager
+    must fall back to a synchronous call and cache the decision per tool."""
+
+    @pytest.mark.asyncio
+    async def test_task_forbidden_falls_back_to_sync_and_returns_result(self, manager):
+        """First call with task=True raises the forbidden McpError; manager
+        retries the same tool with a sync call and returns that result."""
+        mock_client = AsyncMock()
+
+        # Advertise task support at the server level
+        caps = MagicMock()
+        caps.tasks = MagicMock()
+        init_result = MagicMock()
+        init_result.capabilities = caps
+        mock_client.initialize_result = init_result
+
+        # Synchronous (non-task) result the fallback should return
+        sync_result = MagicMock()
+        sync_result.content = [MagicMock(type="text", text="42")]
+        sync_result.structured_content = None
+        sync_result.data = None
+
+        # First call (task=True) raises; second call (no task) returns sync_result
+        call_history = []
+
+        async def fake_call_tool(tool_name, arguments, **kwargs):
+            call_history.append(kwargs)
+            if kwargs.get("task") is True:
+                raise Exception(
+                    "FunctionTool 'tool:evaluate@' does not support task-augmented execution"
+                )
+            return sync_result
+
+        mock_client.call_tool = AsyncMock(side_effect=fake_call_tool)
+
+        mock_session = MagicMock(spec=ManagedSession)
+        mock_session.client = mock_client
+        manager._session_manager.acquire = AsyncMock(return_value=mock_session)
+
+        manager.clients["srv"] = mock_client
+        manager.servers_config["srv"] = {}
+
+        result = await manager.call_tool(
+            "srv", "evaluate", {"x": 1},
+            conversation_id="conv-1",
+            meta={"tool_call_id": "tc-1"},
+        )
+
+        assert result is sync_result
+        # First attempt used task=True, second attempt dropped it
+        assert call_history[0].get("task") is True
+        assert call_history[1].get("task") is not True
+        # Tool is now remembered as forbidden
+        assert ("srv", "evaluate") in manager._tool_task_forbidden
+
+    @pytest.mark.asyncio
+    async def test_forbidden_cache_skips_task_mode_on_subsequent_call(self, manager):
+        """After the cache is populated, the next call for that (server, tool)
+        must not attempt task mode at all."""
+        mock_client = AsyncMock()
+        caps = MagicMock()
+        caps.tasks = MagicMock()
+        init_result = MagicMock()
+        init_result.capabilities = caps
+        mock_client.initialize_result = init_result
+
+        sync_result = MagicMock()
+        sync_result.content = [MagicMock(type="text", text="ok")]
+        sync_result.structured_content = None
+        sync_result.data = None
+        mock_client.call_tool = AsyncMock(return_value=sync_result)
+
+        mock_session = MagicMock(spec=ManagedSession)
+        mock_session.client = mock_client
+        manager._session_manager.acquire = AsyncMock(return_value=mock_session)
+
+        manager.clients["srv"] = mock_client
+        manager.servers_config["srv"] = {}
+        # Pre-seed the forbidden cache as if a prior call had discovered it
+        manager._tool_task_forbidden.add(("srv", "evaluate"))
+
+        _result = await manager.call_tool(
+            "srv", "evaluate", {},
+            conversation_id="conv-1",
+        )
+
+        # Only one underlying call, and it was the sync (no task=True) path
+        assert mock_client.call_tool.call_count == 1
+        assert mock_client.call_tool.call_args.kwargs.get("task") is not True
+
+    @pytest.mark.asyncio
+    async def test_non_forbidden_error_is_not_swallowed(self, manager):
+        """Unrelated errors during task-mode call must still propagate."""
+        mock_client = AsyncMock()
+        caps = MagicMock()
+        caps.tasks = MagicMock()
+        init_result = MagicMock()
+        init_result.capabilities = caps
+        mock_client.initialize_result = init_result
+
+        mock_client.call_tool = AsyncMock(side_effect=RuntimeError("boom"))
+
+        mock_session = MagicMock(spec=ManagedSession)
+        mock_session.client = mock_client
+        manager._session_manager.acquire = AsyncMock(return_value=mock_session)
+
+        manager.clients["srv"] = mock_client
+        manager.servers_config["srv"] = {}
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await manager.call_tool(
+                "srv", "evaluate", {},
+                conversation_id="conv-1",
+            )
+
+        # Did not poison the cache
+        assert ("srv", "evaluate") not in manager._tool_task_forbidden


### PR DESCRIPTION
## Summary
- Tool calls were failing with `McpError: FunctionTool '...' does not support task-augmented execution` (`fastmcp/server/tasks/routing.py:63`) whenever the server advertised task capability at the capability-negotiation layer but the specific tool declared `tasks.mode="forbidden"`. The LLM saw no usable tool result and typically hallucinated around it ("I don't have a calculator…").
- Root cause: `MCPToolManager.call_tool` used server-level `_supports_tasks` as a blanket signal and sent `task=True` for every tool on a task-capable server.
- Fix (`atlas/modules/mcp_tools/client.py`): wrap the task-mode `call_tool` in a targeted try/except. On the forbidden-error message we record the `(server, tool)` pair in a new `_tool_task_forbidden` set and fall through to the existing synchronous call path. Subsequent invocations short-circuit to sync mode directly. Unrelated errors still propagate unchanged.
- Helper `_is_task_forbidden_error` matches on the documented fastmcp error message text (not the concrete exception class, since that varies across fastmcp versions).

## Why a string match?
`McpError`'s payload is an `ErrorData` with `code=METHOD_NOT_FOUND` — the same code fastmcp uses for "requires task-augmented execution" (the inverse mode). Discriminating by code alone would merge two distinct conditions. The message text is the narrow, stable signal.

## Test plan
- [x] `TestTaskForbiddenFallback::test_task_forbidden_falls_back_to_sync_and_returns_result` — first attempt uses `task=True`, raises; second attempt drops `task` and returns the sync result; cache populated.
- [x] `TestTaskForbiddenFallback::test_forbidden_cache_skips_task_mode_on_subsequent_call` — pre-seeded cache makes only one non-task call; no retry needed.
- [x] `TestTaskForbiddenFallback::test_non_forbidden_error_is_not_swallowed` — a `RuntimeError` in task-mode propagates; cache stays clean.
- [x] Existing `TestAdaptiveTaskPolling` tests still green (immediate, no-task-support, cancellation, timeout-then-poll).
- [x] Full backend suite: **1219 passed, 17 skipped**.
- [ ] Manual smoke: exercise the calculator `evaluate` tool from the app on a conversation and confirm the model now receives a real tool result.