### PR TITLE
refactor(chat): remove deprecated self.sessions dict in ChatService

### DIFF
--- a/atlas/application/chat/service.py
+++ b/atlas/application/chat/service.py
@@ -98,10 +98,6 @@ class ChatService:
         # Track incognito sessions
         self._incognito_sessions: set = set()
 
-        # Legacy sessions dict - deprecated, use session_repository instead
-        # Kept temporarily for backward compatibility
-        self.sessions: Dict[UUID, Session] = {}
-
         # Initialize refactored services
         self.tool_authorization = ToolAuthorizationService(tool_manager=self.tool_manager)
         self.prompt_override = PromptOverrideService(tool_manager=self.tool_manager)
@@ -188,9 +184,6 @@ class ChatService:
     ) -> Session:
         """Create a new chat session."""
         session = Session(id=session_id, user_email=user_email)
-
-        # Store in both legacy dict and new repository
-        self.sessions[session_id] = session
         await self.session_repository.create(session)
 
         logger.info(f"Created session {sanitize_for_logging(str(session_id))} for user {sanitize_for_logging(user_email)}")
@@ -237,15 +230,9 @@ class ChatService:
             )
 
         # Get or create session
-        session = self.sessions.get(session_id)
+        session = await self.session_repository.get(session_id)
         if not session:
-            # Try session repository
-            session = await self.session_repository.get(session_id)
-            if not session:
-                await self.create_session(session_id, user_email)
-            else:
-                # Sync to legacy dict
-                self.sessions[session_id] = session
+            session = await self.create_session(session_id, user_email)
 
         # Check incognito mode
         _incognito_sentinel = object()
@@ -258,9 +245,7 @@ class ChatService:
         # Track conversation_id for continuing saved conversations
         conversation_id = kwargs.pop("conversation_id", None)
         if conversation_id:
-            session = self.sessions.get(session_id)
-            if session:
-                session.context["conversation_id"] = conversation_id
+            session.context["conversation_id"] = conversation_id
 
         try:
             # Delegate to orchestrator
@@ -288,10 +273,9 @@ class ChatService:
                 and user_email
             ):
                 try:
-                    self._save_conversation(session_id, user_email, model)
+                    self._save_conversation(session, user_email, model)
                     # Notify frontend of the conversation_id so it can track the active conversation
-                    session = self.sessions.get(session_id)
-                    conv_id = session.context.get("conversation_id", str(session_id)) if session else str(session_id)
+                    conv_id = session.context.get("conversation_id", str(session_id))
                     if update_callback:
                         await update_callback({
                             "type": "conversation_saved",
@@ -334,33 +318,31 @@ class ChatService:
                 return {"type": "error", "error": "Conversation not found"}
 
         # Reset the session
-        self.end_session(session_id)
-        await self.create_session(session_id, user_email)
+        await self.end_session(session_id)
+        session = await self.create_session(session_id, user_email)
 
-        session = self.sessions.get(session_id)
-        if session:
-            # Store the conversation_id mapping and mark as restored
-            session.context["conversation_id"] = conversation_id
-            session.context["_restored"] = True
+        # Store the conversation_id mapping and mark as restored
+        session.context["conversation_id"] = conversation_id
+        session.context["_restored"] = True
 
-            # Load previous messages into session history for LLM context
-            for msg_data in messages:
-                role_value = msg_data.get("role", "user") or "user"
-                content = msg_data.get("content", "")
-                try:
-                    message_role = MessageRole(role_value)
-                except ValueError:
-                    logger.warning(
-                        "Skipping message with invalid role %s in conversation %s",
-                        sanitize_for_logging(str(role_value)),
-                        sanitize_for_logging(conversation_id),
-                    )
-                    continue
-                msg = Message(
-                    role=message_role,
-                    content=content,
+        # Load previous messages into session history for LLM context
+        for msg_data in messages:
+            role_value = msg_data.get("role", "user") or "user"
+            content = msg_data.get("content", "")
+            try:
+                message_role = MessageRole(role_value)
+            except ValueError:
+                logger.warning(
+                    "Skipping message with invalid role %s in conversation %s",
+                    sanitize_for_logging(str(role_value)),
+                    sanitize_for_logging(conversation_id),
                 )
-                session.history.add_message(msg)
+                continue
+            msg = Message(
+                role=message_role,
+                content=content,
+            )
+            session.history.add_message(msg)
 
         logger.info(
             "Restored conversation %s into session %s for user %s (%d messages)",
@@ -388,14 +370,12 @@ class ChatService:
         same for the lifetime of the WebSocket connection).
         """
         # End the current session
-        self.end_session(session_id)
+        await self.end_session(session_id)
 
         # Create a new session with a fresh conversation_id
-        await self.create_session(session_id, user_email)
-        session = self.sessions.get(session_id)
-        if session:
-            new_conv_id = str(uuid4())
-            session.context["conversation_id"] = new_conv_id
+        session = await self.create_session(session_id, user_email)
+        new_conv_id = str(uuid4())
+        session.context["conversation_id"] = new_conv_id
 
         logger.info(f"Reset session {sanitize_for_logging(str(session_id))} for user {sanitize_for_logging(user_email)}")
 
@@ -413,7 +393,7 @@ class ChatService:
         update_callback: Optional[UpdateCallback] = None
     ) -> Dict[str, Any]:
         """Attach a file from library to the current session."""
-        session = self.sessions.get(session_id)
+        session = await self.session_repository.get(session_id)
         if not session:
             session = await self.create_session(session_id, user_email)
 
@@ -492,7 +472,7 @@ class ChatService:
         user_email: Optional[str]
     ) -> Dict[str, Any]:
         """Download a file by original filename (within session context)."""
-        session = self.sessions.get(session_id)
+        session = await self.session_repository.get(session_id)
         if not session or not self.file_manager or not user_email:
             return {
                 "type": MessageType.FILE_DOWNLOAD.value,
@@ -563,9 +543,8 @@ class ChatService:
         except Exception as e:
             logger.error(f"Failed to update session from tool results: {e}", exc_info=True)
 
-    def _save_conversation(self, session_id: UUID, user_email: str, model: str) -> None:
-        """Persist the current session's conversation history to the database."""
-        session = self.sessions.get(session_id)
+    def _save_conversation(self, session: Session, user_email: str, model: str) -> None:
+        """Persist a session's conversation history to the database."""
         if not session or not session.history.messages:
             return
 
@@ -577,7 +556,7 @@ class ChatService:
             messages.append(msg_dict)
 
         # Use stored conversation_id if set, otherwise use session_id
-        conv_id = session.context.get("conversation_id", str(session_id))
+        conv_id = session.context.get("conversation_id", str(session.id))
 
         # Only generate title for new conversations (not restored ones)
         title = None
@@ -598,13 +577,16 @@ class ChatService:
             },
         )
 
-    def get_session(self, session_id: UUID) -> Optional[Session]:
+    async def get_session(self, session_id: UUID) -> Optional[Session]:
         """Get session by ID."""
-        return self.sessions.get(session_id)
+        return await self.session_repository.get(session_id)
 
-    def end_session(self, session_id: UUID) -> None:
+    async def end_session(self, session_id: UUID) -> None:
         """End a session."""
-        if session_id in self.sessions:
-            self.sessions[session_id].active = False
-            self._incognito_sessions.discard(session_id)
-            logger.info(f"Ended session {sanitize_for_logging(str(session_id))}")
+        session = await self.session_repository.get(session_id)
+        if session is None:
+            return
+        session.active = False
+        await self.session_repository.update(session)
+        self._incognito_sessions.discard(session_id)
+        logger.info(f"Ended session {sanitize_for_logging(str(session_id))}")

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -595,7 +595,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
             elif message_type == "restore_conversation":
                 # Release MCP sessions for the current conversation before restoring
-                session = chat_service.sessions.get(session_id)
+                session = await chat_service.session_repository.get(session_id)
                 if session:
                     old_conv_id = session.context.get("conversation_id")
                     if old_conv_id:
@@ -700,7 +700,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
     except WebSocketDisconnect:
         # Release MCP sessions for this conversation
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.session_repository.get(session_id)
         if session:
             conv_id = session.context.get("conversation_id", str(session_id))
             try:
@@ -708,7 +708,7 @@ async def websocket_endpoint(websocket: WebSocket):
                 await mcp_tool_manager.release_sessions(conv_id, user_email=user_email)
             except Exception as e:
                 logger.debug("Error releasing MCP sessions on disconnect: %s", e)
-        chat_service.end_session(session_id)
+        await chat_service.end_session(session_id)
         logger.info(f"WebSocket connection closed for session {session_id}")
 
 

--- a/atlas/tests/test_attach_file_flow.py
+++ b/atlas/tests/test_attach_file_flow.py
@@ -78,7 +78,7 @@ async def test_handle_attach_file_success_creates_session_and_emits_update(chat_
     ), "Expected a files_update intermediate update to be emitted"
 
     # Session context should include the file by filename
-    session = chat_service.sessions.get(session_id)
+    session = await chat_service.session_repository.get(session_id)
     assert session is not None
     assert filename in session.context.get("files", {})
     assert session.context["files"][filename]["key"] == s3_key
@@ -142,14 +142,14 @@ async def test_handle_reset_session_reinitializes(chat_service):
 
     # Create a session first
     await chat_service.create_session(session_id, user_email)
-    assert chat_service.sessions.get(session_id) is not None
+    assert await chat_service.session_repository.get(session_id) is not None
 
     # Reset the session
     resp = await chat_service.handle_reset_session(session_id=session_id, user_email=user_email)
 
     assert resp.get("type") == "session_reset"
     # After reset, a fresh active session should exist for the same id
-    new_session = chat_service.sessions.get(session_id)
+    new_session = await chat_service.session_repository.get(session_id)
     assert new_session is not None
     assert new_session.active is True
 
@@ -278,7 +278,7 @@ async def test_attach_file_with_spaces_end_to_end(chat_service, file_manager):
     assert " " not in s3_key
 
     # Verify the session stores the sanitized filename (no spaces)
-    session = chat_service.sessions.get(session_id)
+    session = await chat_service.session_repository.get(session_id)
     assert session is not None
     session_files = session.context.get("files", {})
     # The filename key in the session should have underscores, not spaces

--- a/atlas/tests/test_chat_history.py
+++ b/atlas/tests/test_chat_history.py
@@ -717,12 +717,12 @@ class TestSessionResetConversationIsolation:
         session_id = uuid4()
         await chat_service.create_session(session_id, "user@test.com")
 
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.session_repository.get(session_id)
         conv_id_before = session.context.get("conversation_id")
 
         await chat_service.handle_reset_session(session_id, "user@test.com")
 
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.session_repository.get(session_id)
         conv_id_after = session.context.get("conversation_id")
 
         assert conv_id_after is not None
@@ -742,10 +742,10 @@ class TestSessionResetConversationIsolation:
 
         # First conversation
         await chat_service.create_session(session_id, user)
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.session_repository.get(session_id)
         session.history.add_message(Message(role=MessageRole.USER, content="First question"))
         session.history.add_message(Message(role=MessageRole.ASSISTANT, content="First answer"))
-        chat_service._save_conversation(session_id, user, "gpt-4")
+        chat_service._save_conversation(session, user, "gpt-4")
 
         first_conv_id = session.context.get("conversation_id", str(session_id))
         first_conv = repo.get_conversation(first_conv_id, user)
@@ -754,13 +754,13 @@ class TestSessionResetConversationIsolation:
 
         # Reset and start second conversation
         await chat_service.handle_reset_session(session_id, user)
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.session_repository.get(session_id)
         second_conv_id = session.context.get("conversation_id")
         assert second_conv_id != first_conv_id
 
         session.history.add_message(Message(role=MessageRole.USER, content="Second question"))
         session.history.add_message(Message(role=MessageRole.ASSISTANT, content="Second answer"))
-        chat_service._save_conversation(session_id, user, "gpt-4")
+        chat_service._save_conversation(session, user, "gpt-4")
 
         # Verify both conversations exist independently
         first_after = repo.get_conversation(first_conv_id, user)
@@ -790,9 +790,9 @@ class TestSessionResetConversationIsolation:
             else:
                 await chat_service.handle_reset_session(session_id, user)
 
-            session = chat_service.sessions.get(session_id)
+            session = await chat_service.session_repository.get(session_id)
             session.history.add_message(Message(role=MessageRole.USER, content=f"Question {i}"))
-            chat_service._save_conversation(session_id, user, "gpt-4")
+            chat_service._save_conversation(session, user, "gpt-4")
             conv_ids.append(session.context.get("conversation_id", str(session_id)))
 
         # All conversation_ids should be unique
@@ -830,13 +830,13 @@ class TestSessionResetConversationIsolation:
 
         # Reset to start a new conversation
         await chat_service.handle_reset_session(session_id, user)
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.session_repository.get(session_id)
         new_conv_id = session.context.get("conversation_id")
         assert new_conv_id != "original-conv"
 
         # Save the new conversation
         session.history.add_message(Message(role=MessageRole.USER, content="New question"))
-        chat_service._save_conversation(session_id, user, "gpt-4")
+        chat_service._save_conversation(session, user, "gpt-4")
 
         # Original should still be intact
         original = repo.get_conversation("original-conv", user)
@@ -861,22 +861,19 @@ class TestConversationSavedEvent:
         )
         return service
 
-    def test_save_conversation_returns_conv_id(self, chat_service, repo):
+    @pytest.mark.asyncio
+    async def test_save_conversation_returns_conv_id(self, chat_service, repo):
         """After saving, the conversation_id should be retrievable from session context."""
-        import asyncio
         from uuid import uuid4
 
         from atlas.domain.messages.models import Message, MessageRole
 
         session_id = uuid4()
-        asyncio.get_event_loop().run_until_complete(
-            chat_service.create_session(session_id, "user@test.com")
-        )
-        session = chat_service.sessions.get(session_id)
+        session = await chat_service.create_session(session_id, "user@test.com")
         session.history.add_message(Message(role=MessageRole.USER, content="Hello"))
         session.history.add_message(Message(role=MessageRole.ASSISTANT, content="Hi"))
 
-        chat_service._save_conversation(session_id, "user@test.com", "gpt-4")
+        chat_service._save_conversation(session, "user@test.com", "gpt-4")
 
         conv_id = session.context.get("conversation_id", str(session_id))
         saved = repo.get_conversation(conv_id, "user@test.com")

--- a/atlas/tests/test_issue_access_denied_fix.py
+++ b/atlas/tests/test_issue_access_denied_fix.py
@@ -56,7 +56,8 @@ def mock_components():
             'success': True,
             'filename': 'mypdf.pdf'
         })
-        mock_chat_service.end_session = MagicMock()
+        mock_chat_service.end_session = AsyncMock()
+        mock_chat_service.session_repository.get = AsyncMock(return_value=None)
         mock_factory.create_chat_service.return_value = mock_chat_service
 
         yield {
@@ -112,7 +113,8 @@ def test_issue_scenario_would_fail_without_header():
 
         # Mock chat service
         mock_chat_service = MagicMock()
-        mock_chat_service.end_session = MagicMock()
+        mock_chat_service.end_session = AsyncMock()
+        mock_chat_service.session_repository.get = AsyncMock(return_value=None)
         mock_factory.create_chat_service.return_value = mock_chat_service
 
         client = TestClient(app)

--- a/atlas/tests/test_websocket_auth_header.py
+++ b/atlas/tests/test_websocket_auth_header.py
@@ -32,7 +32,8 @@ def mock_app_factory():
         mock_chat_service = MagicMock()
         mock_chat_service.handle_chat_message = AsyncMock(return_value={})
         mock_chat_service.handle_attach_file = AsyncMock(return_value={'type': 'file_attach', 'success': True})
-        mock_chat_service.end_session = MagicMock()
+        mock_chat_service.end_session = AsyncMock()
+        mock_chat_service.session_repository.get = AsyncMock(return_value=None)
         mock_factory.create_chat_service.return_value = mock_chat_service
 
         yield mock_factory
@@ -108,7 +109,8 @@ def mock_app_factory_debug_mode():
         mock_chat_service = MagicMock()
         mock_chat_service.handle_chat_message = AsyncMock(return_value={})
         mock_chat_service.handle_attach_file = AsyncMock(return_value={'type': 'file_attach', 'success': True})
-        mock_chat_service.end_session = MagicMock()
+        mock_chat_service.end_session = AsyncMock()
+        mock_chat_service.session_repository.get = AsyncMock(return_value=None)
         mock_factory.create_chat_service.return_value = mock_chat_service
 
         yield mock_factory


### PR DESCRIPTION
## Summary

Follows the 2026-04-18 cleanup audit's bounded refactor #1: `ChatService` kept a legacy `self.sessions` dict alongside the injected `SessionRepository`, mirroring every write to both stores. This PR rips out the dict and routes all session access through the repository.

- Drop `self.sessions` field and all 14 read/write call sites.
- Make `get_session()` and `end_session()` async (they delegate to the repository); `end_session` persists `active=False` via `repository.update()` instead of mutating the dict.
- `_save_conversation` now takes a `Session` directly — the caller already has one, so re-fetching was pointless.
- `handle_chat_message` session bootstrap drops from five branches to two.
- `main.py` and four tests updated to the new async shape (`await chat_service.session_repository.get(...)`, `AsyncMock` for `end_session`).

Net -17 lines; no behaviour change.

## What remains (not in this PR)

The audit lists several other backend simplifications that are deliberately out of scope for this slice:

- Agent loop base class (#2 in the audit) — consolidating the four strategies' shared plumbing.
- `UnifiedRAGService` vs `RAGMCPService` merge (#3).
- Flattening `chat/modes|policies|preprocessors|utilities` into fewer subdirs (#4).
- Stale `/backend/...` path comments (e.g. `atlas/modules/mcp_tools/client.py:792`).

Each of those is its own PR.

## Test plan

- [x] `PYTHONPATH=. python -m pytest atlas/tests/ --ignore=atlas/tests/integration` — 1213 passed, 17 skipped.
- [x] `ruff check` passes on all touched files.
- [ ] Smoke: WebSocket disconnect path (now `await chat_service.end_session(...)`) exercised by `test_websocket_auth_header.py` suite.