### PR TITLE
feat(rag): align ATLAS RAG client + mock with OpenAPI v0.3.x (url_citation)

### DIFF
--- a/atlas/modules/config/config_manager.py
+++ b/atlas/modules/config/config_manager.py
@@ -202,8 +202,8 @@ class RAGSourceConfig(BaseModel):
     strip_domain: bool = False  # Strip @domain from username (e.g. user@corp.com -> user)
 
     # API endpoint customization (HTTP type)
-    discovery_endpoint: str = "/discover/datasources"
-    query_endpoint: str = "/rag/completions"
+    discovery_endpoint: str = "/api/v1/discover/datasources"
+    query_endpoint: str = "/api/v1/rag/completions"
 
     @model_validator(mode='after')
     def validate_type_specific_fields(self):

--- a/atlas/modules/rag/__init__.py
+++ b/atlas/modules/rag/__init__.py
@@ -7,7 +7,14 @@ This module provides:
 """
 
 from .atlas_rag_client import AtlasRAGClient, create_atlas_rag_client_from_config
-from .client import DataSource, DocumentMetadata, RAGClient, RAGMetadata, RAGResponse
+from .client import (
+    DataSource,
+    DocumentMetadata,
+    RAGClient,
+    RAGMetadata,
+    RAGResponse,
+    URLCitation,
+)
 
 __all__ = [
     "RAGClient",
@@ -17,4 +24,5 @@ __all__ = [
     "DocumentMetadata",
     "RAGMetadata",
     "RAGResponse",
+    "URLCitation",
 ]

--- a/atlas/modules/rag/atlas_rag_client.py
+++ b/atlas/modules/rag/atlas_rag_client.py
@@ -1,21 +1,30 @@
-"""ATLAS RAG Client for integrating with the ATLAS RAG API.
+"""ATLAS RAG Client for integrating with the ATLAS RAG API (OpenAPI v0.3.x).
 
-This client implements the same interface as RAGClient but translates
-requests to the ATLAS RAG API format.
+This client implements the same interface as ``RAGClient`` but speaks the
+ATLAS RAG API described at:
 
-ATLAS RAG API:
-- Discovery: GET /discover/datasources?as_user={user}
-- Query: POST /rag/completions?as_user={user}
+  - GET  /api/v1/discover/datasources?role=read|write&as_user={user}
+  - POST /api/v1/rag/completions?as_user={user}
+
+Responses follow the OpenAI ``chat.completion`` schema with an extra
+``rag_metadata`` block and per-message ``annotations`` (``url_citation``)
+that link character ranges in the assistant content to source documents.
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import HTTPException
 
 from atlas.core.log_sanitizer import sanitize_for_logging
-from atlas.modules.rag.client import DataSource, DocumentMetadata, RAGMetadata, RAGResponse
+from atlas.modules.rag.client import (
+    DataSource,
+    DocumentMetadata,
+    RAGMetadata,
+    RAGResponse,
+    URLCitation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +32,13 @@ logger = logging.getLogger(__name__)
 class AtlasRAGClient:
     """Client for communicating with external ATLAS RAG API.
 
-    Implements the same interface as RAGClient for seamless substitution.
-    Uses Bearer token authentication with user impersonation via as_user param.
+    Implements the same interface as ``RAGClient`` for seamless substitution.
+    Uses Bearer token authentication with user impersonation via the ``as_user``
+    query parameter.
     """
+
+    DEFAULT_DISCOVERY_PATH = "/api/v1/discover/datasources"
+    DEFAULT_QUERY_PATH = "/api/v1/rag/completions"
 
     def __init__(
         self,
@@ -35,6 +48,8 @@ class AtlasRAGClient:
         top_k: int = 4,
         timeout: float = 60.0,
         strip_domain: bool = False,
+        discovery_path: Optional[str] = None,
+        query_path: Optional[str] = None,
     ):
         """Initialize the external RAG client.
 
@@ -44,8 +59,12 @@ class AtlasRAGClient:
             default_model: Default model to use for RAG queries.
             top_k: Default number of documents to retrieve.
             timeout: Request timeout in seconds.
-            strip_domain: If True, strip @domain from usernames before sending
-                to the RAG API (e.g. user@corp.com -> user).
+            strip_domain: If True, strip ``@domain`` from usernames before
+                sending to the RAG API (``user@corp.com`` -> ``user``).
+            discovery_path: Override for the discovery endpoint path.
+                Defaults to ``/api/v1/discover/datasources``.
+            query_path: Override for the completions endpoint path.
+                Defaults to ``/api/v1/rag/completions``.
         """
         self.base_url = base_url.rstrip("/")
         self.bearer_token = bearer_token
@@ -53,23 +72,33 @@ class AtlasRAGClient:
         self.top_k = top_k
         self.timeout = timeout
         self.strip_domain = strip_domain
+        self.discovery_path = discovery_path or self.DEFAULT_DISCOVERY_PATH
+        self.query_path = query_path or self.DEFAULT_QUERY_PATH
 
         logger.info(
-            "AtlasRAGClient initialized: url=%s, model=%s, top_k=%d, strip_domain=%s",
+            "AtlasRAGClient initialized: url=%s, model=%s, top_k=%d, "
+            "strip_domain=%s, discovery=%s, query=%s",
             self.base_url,
             self.default_model,
             self.top_k,
             self.strip_domain,
+            self.discovery_path,
+            self.query_path,
         )
 
     def _resolve_username(self, user_name: str) -> str:
         """Resolve the username to send to the RAG API.
 
-        If strip_domain is enabled, strips the @domain portion from email addresses.
+        If ``strip_domain`` is enabled, strips the ``@domain`` portion from
+        email addresses.
         """
         if self.strip_domain and "@" in user_name:
             stripped = user_name.split("@", 1)[0]
-            logger.debug("Stripped domain from username: %s -> %s", sanitize_for_logging(user_name), sanitize_for_logging(stripped))
+            logger.debug(
+                "Stripped domain from username: %s -> %s",
+                sanitize_for_logging(user_name),
+                sanitize_for_logging(stripped),
+            )
             return stripped
         return user_name
 
@@ -80,31 +109,35 @@ class AtlasRAGClient:
             headers["Authorization"] = f"Bearer {self.bearer_token}"
         return headers
 
-    async def discover_data_sources(self, user_name: str) -> List[DataSource]:
+    async def discover_data_sources(
+        self,
+        user_name: str,
+        role: str = "read",
+    ) -> List[DataSource]:
         """Discover data sources accessible by a user.
 
-        Calls GET /discover/datasources?as_user={user_name}
+        Calls ``GET {discovery_path}?role={role}&as_user={user_name}``.
 
         Args:
             user_name: The username to discover data sources for.
+            role: Access role — ``"read"`` or ``"write"``.
 
         Returns:
             List of DataSource objects the user can access.
         """
         user_name = self._resolve_username(user_name)
-        logger.info("Discovering data sources for user: %s", user_name)
+        logger.info("Discovering data sources for user: %s (role=%s)", user_name, role)
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             try:
                 response = await client.get(
-                    f"{self.base_url}/discover/datasources",
+                    f"{self.base_url}{self.discovery_path}",
                     headers=self._get_headers(),
-                    params={"as_user": user_name},
+                    params={"role": role, "as_user": user_name},
                 )
                 response.raise_for_status()
                 data = response.json()
 
-                # Response format: {data_sources: [{id, label, compliance_level, description}]}
                 sources_list = data.get("data_sources", [])
                 data_sources = [DataSource(**src) for src in sources_list]
 
@@ -142,28 +175,37 @@ class AtlasRAGClient:
                 return []
 
     async def query_rag(
-        self, user_name: str, data_source: str, messages: List[Dict],
+        self,
+        user_name: str,
+        data_source: str,
+        messages: List[Dict],
         data_sources: Optional[List[str]] = None,
+        hybrid_search_kwargs: Optional[Dict[str, Any]] = None,
     ) -> RAGResponse:
         """Query RAG endpoint for a response with metadata.
 
-        Calls POST /rag/completions?as_user={user_name}
+        Calls ``POST {query_path}?as_user={user_name}`` with a ``RagRequest``
+        body matching the ATLAS RAG OpenAPI spec (v0.3.x).
 
         Args:
             user_name: The username making the query.
-            data_source: A single data source (corpus) to query. Ignored if data_sources is provided.
+            data_source: A single data source (corpus) to query. Ignored when
+                ``data_sources`` is provided.
             messages: List of message dictionaries with role and content.
-            data_sources: Multiple data sources (corpora) to query in a single request.
-                When provided, all sources are sent as one batched request instead of
-                requiring separate calls per source.
+            data_sources: Multiple data sources (corpora) to query in a single
+                request. When provided, all sources are sent as one batched
+                request via ``hybrid_search_kwargs.corpora``.
+            hybrid_search_kwargs: Additional search parameters forwarded to the
+                HybridSearch backend. ``top_k`` and ``corpora`` are injected
+                automatically when not present.
 
         Returns:
-            RAGResponse containing content and optional metadata.
+            RAGResponse containing content, metadata, and url_citation
+            annotations.
 
         Raises:
             HTTPException: On API errors (403, 404, 500).
         """
-        # Resolve corpora list: prefer explicit list, fall back to single source
         corpora = data_sources if data_sources else ([data_source] if data_source else None)
         user_name = self._resolve_username(user_name)
 
@@ -174,39 +216,39 @@ class AtlasRAGClient:
             len(messages),
         )
 
-        # Extract user query for logging
         user_query = ""
         for msg in reversed(messages):
             if msg.get("role") == "user":
-                user_query = msg.get("content", "")[:100]
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    user_query = content[:100]
                 break
-        logger.debug(
-            "[HTTP-RAG] Query preview: %s...",
-            user_query,
-        )
+        logger.debug("[HTTP-RAG] Query preview: %s...", user_query)
 
-        # Build request payload matching RagRequest format
+        merged_kwargs: Dict[str, Any] = {}
+        if hybrid_search_kwargs:
+            merged_kwargs.update(hybrid_search_kwargs)
+        merged_kwargs.setdefault("top_k", self.top_k)
+        if corpora is not None:
+            merged_kwargs["corpora"] = corpora
+
         payload = {
             "messages": messages,
             "stream": False,
             "model": self.default_model,
-            "top_k": self.top_k,
-            "corpora": corpora,
-            "threshold": None,
-            "expanded_window": [0, 0],
+            "hybrid_search_kwargs": merged_kwargs,
         }
 
         logger.debug(
-            "[HTTP-RAG] Request payload: model=%s, top_k=%d, corpora=%s",
+            "[HTTP-RAG] Request payload: model=%s, hybrid_search_kwargs=%s",
             payload["model"],
-            payload["top_k"],
-            payload["corpora"],
+            merged_kwargs,
         )
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             try:
                 response = await client.post(
-                    f"{self.base_url}/rag/completions",
+                    f"{self.base_url}{self.query_path}",
                     headers=self._get_headers(),
                     params={"as_user": user_name},
                     json=payload,
@@ -220,35 +262,36 @@ class AtlasRAGClient:
                     list(data.keys()),
                 )
 
-                # Check if this is a chat completion (already LLM-interpreted)
                 is_completion = data.get("object") == "chat.completion"
 
-                # Extract content from OpenAI ChatCompletion format
                 content = "No response from RAG system."
-                if "choices" in data and len(data["choices"]) > 0:
+                message: Dict[str, Any] = {}
+                if "choices" in data and data["choices"]:
                     choice = data["choices"][0]
-                    if "message" in choice and "content" in choice["message"]:
-                        content = choice["message"]["content"]
+                    message = choice.get("message", {}) or {}
+                    msg_content = message.get("content")
+                    if msg_content:
+                        content = msg_content
 
-                logger.debug(
-                    "[HTTP-RAG] Extracted content: length=%d, is_completion=%s, preview=%s...",
-                    len(content),
-                    is_completion,
-                    content[:300] if content else "(empty)",
-                )
-
-                # Map rag_metadata to RAGMetadata
-                metadata = self._parse_rag_metadata(data, data_source)
+                annotations = self._parse_annotations(message)
+                metadata = self._parse_rag_metadata(data, data_source, annotations)
 
                 logger.info(
-                    "[HTTP-RAG] query_rag complete: user=%s, source=%s, content_length=%d, has_metadata=%s, is_completion=%s",
+                    "[HTTP-RAG] query_rag complete: user=%s, source=%s, "
+                    "content_length=%d, has_metadata=%s, annotations=%d, is_completion=%s",
                     user_name,
                     data_source,
                     len(content),
                     metadata is not None,
+                    len(annotations),
                     is_completion,
                 )
-                return RAGResponse(content=content, metadata=metadata, is_completion=is_completion)
+                return RAGResponse(
+                    content=content,
+                    metadata=metadata,
+                    is_completion=is_completion,
+                    annotations=annotations,
+                )
 
             except httpx.HTTPStatusError as exc:
                 status_code = exc.response.status_code
@@ -258,7 +301,6 @@ class AtlasRAGClient:
                     exc.response.text,
                     status_code,
                 )
-
                 if status_code == 403:
                     raise HTTPException(
                         status_code=403, detail="Access denied to data source"
@@ -268,9 +310,7 @@ class AtlasRAGClient:
                         status_code=404, detail="Data source not found"
                     )
                 else:
-                    raise HTTPException(
-                        status_code=500, detail="RAG service error"
-                    )
+                    raise HTTPException(status_code=500, detail="RAG service error")
 
             except httpx.RequestError as exc:
                 logger.error(
@@ -283,7 +323,6 @@ class AtlasRAGClient:
                 )
 
             except HTTPException:
-                # Re-raise HTTPExceptions
                 raise
 
             except Exception as exc:
@@ -295,14 +334,52 @@ class AtlasRAGClient:
                 )
                 raise HTTPException(status_code=500, detail="Internal server error")
 
+    @staticmethod
+    def _parse_annotations(message: Dict[str, Any]) -> List[URLCitation]:
+        """Extract url_citation annotations from a ChatCompletionMessage.
+
+        Spec: ``message.annotations`` is an optional list of ``Annotation``
+        objects with ``type == "url_citation"`` and a ``url_citation`` payload.
+        Unknown types are ignored.
+        """
+        raw = message.get("annotations") or []
+        citations: List[URLCitation] = []
+        for ann in raw:
+            if not isinstance(ann, dict):
+                continue
+            if ann.get("type") != "url_citation":
+                continue
+            payload = ann.get("url_citation")
+            if not isinstance(payload, dict):
+                continue
+            try:
+                citations.append(URLCitation(**payload))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Skipping malformed url_citation annotation: %s",
+                    exc,
+                )
+        return citations
+
     def _parse_rag_metadata(
-        self, data: Dict, data_source: str
+        self,
+        data: Dict[str, Any],
+        data_source: str,
+        annotations: Optional[List[URLCitation]] = None,
     ) -> Optional[RAGMetadata]:
         """Parse rag_metadata from API response into RAGMetadata model.
 
+        Spec notes: ``DocumentMetadata.data_source`` is a nested object and
+        ``text`` carries the snippet.  Title/URL are not on the document —
+        they live on the corresponding ``url_citation`` annotation (matched
+        by index order).  Back-compat fields (``corpus_id``, ``title``,
+        ``url``) are still read when present.
+
         Args:
             data: The full API response dictionary.
-            data_source: The data source used in the query.
+            data_source: The data source used in the query (fallback label).
+            annotations: Parsed url_citation annotations to enrich documents
+                with title/url by index pairing.
 
         Returns:
             RAGMetadata if present in response, None otherwise.
@@ -312,28 +389,36 @@ class AtlasRAGClient:
 
         try:
             rm = data["rag_metadata"]
+            citations = annotations or []
 
-            # Map documents_found to DocumentMetadata list
-            documents_found = []
-            for doc in rm.get("documents_found", []):
-                # data_source may be a nested dict {id, label, ...} or absent;
-                # corpus_id and title are the legacy flat-field equivalents.
+            documents_found: List[DocumentMetadata] = []
+            for i, doc in enumerate(rm.get("documents_found", [])):
                 ds = doc.get("data_source") if isinstance(doc.get("data_source"), dict) else {}
-                source = doc.get("corpus_id") or ds.get("id") or ""
-                title = doc.get("title") or ds.get("label") or None
+
+                source = ds.get("id") or doc.get("corpus_id") or ""
+
+                citation = citations[i] if i < len(citations) else None
+                title = (
+                    (citation.title if citation else None)
+                    or doc.get("title")
+                    or ds.get("label")
+                )
+                url = (
+                    (citation.url if citation and citation.url else None)
+                    or doc.get("url")
+                )
+
                 doc_metadata = DocumentMetadata(
                     source=source,
                     content_type=doc.get("content_type", "atlas-search"),
                     confidence_score=doc.get("confidence_score", 0.0),
-                    chunk_id=str(doc.get("id")) if doc.get("id") else None,
+                    chunk_id=(str(doc.get("id")) if doc.get("id") is not None else None),
                     last_modified=doc.get("last_modified"),
                     title=title,
-                    url=doc.get("url"),
+                    url=url,
                 )
                 documents_found.append(doc_metadata)
 
-            # Determine data source name from response or fallback.
-            # data_sources entries may be plain strings or dicts with id/label.
             data_sources_list = rm.get("data_sources", [])
             if data_sources_list:
                 first = data_sources_list[0]

--- a/atlas/modules/rag/client.py
+++ b/atlas/modules/rag/client.py
@@ -5,7 +5,7 @@ import re
 from typing import Dict, List, Optional
 
 from fastapi import HTTPException
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from atlas.core.http_client import create_rag_client
 
@@ -65,11 +65,25 @@ class RAGMetadata(BaseModel):
     query_embedding_time_ms: Optional[int] = None
 
 
+class URLCitation(BaseModel):
+    """A ``url_citation`` annotation returned by the RAG API.
+
+    Mirrors the ATLAS-RAG OpenAPI ``AnnotationURLCitation`` shape:
+    ``start_index``/``end_index`` are offsets into the assistant message
+    ``content`` identifying the span of text the citation supports.
+    """
+    start_index: int
+    end_index: int
+    title: str
+    url: str
+
+
 class RAGResponse(BaseModel):
     """Combined response from RAG system including content and metadata."""
     content: str
     metadata: Optional[RAGMetadata] = None
     is_completion: bool = False  # True if content is already LLM-interpreted (from /rag/completions)
+    annotations: List[URLCitation] = Field(default_factory=list)
 
 
 class RAGClient:

--- a/atlas/tests/test_atlas_rag_client.py
+++ b/atlas/tests/test_atlas_rag_client.py
@@ -108,8 +108,8 @@ class TestDiscoverDataSources:
         # Verify correct URL and params
         mock_instance.get.assert_called_once()
         call_args = mock_instance.get.call_args
-        assert call_args[0][0] == "https://rag-api.example.com/discover/datasources"
-        assert call_args[1]["params"] == {"as_user": "test-user"}
+        assert call_args[0][0] == "https://rag-api.example.com/api/v1/discover/datasources"
+        assert call_args[1]["params"] == {"role": "read", "as_user": "test-user"}
         assert call_args[1]["headers"]["Authorization"] == "Bearer test-token"
 
     @pytest.mark.asyncio
@@ -233,14 +233,14 @@ class TestQueryRag:
         # Verify correct URL, params, and payload
         mock_instance.post.assert_called_once()
         call_args = mock_instance.post.call_args
-        assert call_args[0][0] == "https://rag-api.example.com/rag/completions"
+        assert call_args[0][0] == "https://rag-api.example.com/api/v1/rag/completions"
         assert call_args[1]["params"] == {"as_user": "test-user"}
         payload = call_args[1]["json"]
         assert payload["messages"] == messages
         assert payload["stream"] is False
         assert payload["model"] == "test-model"
-        assert payload["top_k"] == 4
-        assert payload["corpora"] == ["corpus1"]
+        assert payload["hybrid_search_kwargs"]["top_k"] == 4
+        assert payload["hybrid_search_kwargs"]["corpora"] == ["corpus1"]
 
     @pytest.mark.asyncio
     async def test_query_without_metadata(self, client):
@@ -523,8 +523,72 @@ class TestParseRagMetadata:
         assert result.documents_found[1].source == "atlas_team_data"
         assert result.documents_found[1].title == "Search Dataset | UUR: ATLAS Team Data"
 
-    def test_parse_documents_flat_corpus_id_takes_precedence(self, client):
-        """Flat corpus_id overrides nested data_source.id when both present."""
+    def test_annotations_enrich_documents_with_title_and_url(self, client):
+        """url_citation annotations pair with documents by index to supply title/url."""
+        from atlas.modules.rag.client import URLCitation
+
+        data = {
+            "rag_metadata": {
+                "query_processing_time_ms": 150,
+                "documents_found": [
+                    {
+                        "data_source": {"id": "corpus-1", "label": "Corpus 1"},
+                        "text": "Snippet one.",
+                        "content_type": "atlas-search",
+                        "confidence_score": 0.9,
+                    },
+                    {
+                        "data_source": {"id": "corpus-1", "label": "Corpus 1"},
+                        "text": "Snippet two.",
+                        "content_type": "atlas-search",
+                        "confidence_score": 0.8,
+                    },
+                ],
+                "data_sources": [
+                    {"id": "corpus-1", "label": "Corpus 1"},
+                ],
+                "retrieval_method": "similarity",
+            }
+        }
+        annotations = [
+            URLCitation(
+                start_index=0, end_index=12,
+                title="First Doc", url="https://example.com/doc1",
+            ),
+            URLCitation(
+                start_index=20, end_index=32,
+                title="Second Doc", url="https://example.com/doc2",
+            ),
+        ]
+
+        result = client._parse_rag_metadata(data, "fallback", annotations=annotations)
+
+        assert result is not None
+        assert result.documents_found[0].title == "First Doc"
+        assert result.documents_found[0].url == "https://example.com/doc1"
+        assert result.documents_found[1].title == "Second Doc"
+        assert result.documents_found[1].url == "https://example.com/doc2"
+
+    def test_parse_annotations_skips_unknown_types(self):
+        """_parse_annotations ignores non-url_citation annotations and malformed entries."""
+        message = {
+            "annotations": [
+                {"type": "url_citation", "url_citation": {
+                    "start_index": 0, "end_index": 5, "title": "T", "url": "https://x.y",
+                }},
+                {"type": "other_type", "url_citation": {
+                    "start_index": 0, "end_index": 5, "title": "T", "url": "https://x.y",
+                }},
+                {"type": "url_citation"},  # missing payload
+                "not-a-dict",
+            ]
+        }
+        result = AtlasRAGClient._parse_annotations(message)
+        assert len(result) == 1
+        assert result[0].title == "T"
+
+    def test_parse_documents_nested_data_source_takes_precedence(self, client):
+        """Nested data_source.id is primary per OpenAPI v0.3.x; corpus_id is legacy fallback."""
         data = {
             "rag_metadata": {
                 "query_processing_time_ms": 100,
@@ -532,6 +596,28 @@ class TestParseRagMetadata:
                     {
                         "corpus_id": "legacy-corpus",
                         "data_source": {"id": "nested-id", "label": "Nested Label"},
+                        "content_type": "atlas-search",
+                        "confidence_score": 0.9,
+                    },
+                ],
+                "data_sources": [],
+                "retrieval_method": "similarity",
+            }
+        }
+
+        result = client._parse_rag_metadata(data, "fallback-corpus")
+
+        assert result is not None
+        assert result.documents_found[0].source == "nested-id"
+
+    def test_parse_documents_legacy_corpus_id_when_no_nested(self, client):
+        """Legacy corpus_id still works when the nested data_source is absent."""
+        data = {
+            "rag_metadata": {
+                "query_processing_time_ms": 100,
+                "documents_found": [
+                    {
+                        "corpus_id": "legacy-corpus",
                         "content_type": "atlas-search",
                         "confidence_score": 0.9,
                     },
@@ -653,7 +739,7 @@ class TestQueryRagBatchCorpora:
 
         # Verify the corpora list in the payload uses data_sources, not single source
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["corpora"] == ["corpus1", "corpus2"]
+        assert payload["hybrid_search_kwargs"]["corpora"] == ["corpus1", "corpus2"]
 
     @pytest.mark.asyncio
     async def test_query_data_sources_overrides_single_source(self, client):
@@ -681,7 +767,7 @@ class TestQueryRagBatchCorpora:
             )
 
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["corpora"] == ["real-a", "real-b"]
+        assert payload["hybrid_search_kwargs"]["corpora"] == ["real-a", "real-b"]
 
     @pytest.mark.asyncio
     async def test_query_single_source_fallback(self, client):
@@ -706,4 +792,4 @@ class TestQueryRagBatchCorpora:
             await client.query_rag("test-user", "single-corpus", messages)
 
         payload = mock_instance.post.call_args[1]["json"]
-        assert payload["corpora"] == ["single-corpus"]
+        assert payload["hybrid_search_kwargs"]["corpora"] == ["single-corpus"]

--- a/atlas/tests/test_atlas_rag_integration.py
+++ b/atlas/tests/test_atlas_rag_integration.py
@@ -244,8 +244,8 @@ class TestAtlasRAGIntegration:
         # Check metadata
         assert response.metadata is not None
         assert response.metadata.query_processing_time_ms >= 0
-        assert response.metadata.data_source_name == "technical-docs"
-        assert response.metadata.retrieval_method == "keyword-search"
+        assert response.metadata.data_source_name  # populated from data_sources[0].label
+        assert response.metadata.retrieval_method == "similarity"
         assert len(response.metadata.documents_found) > 0
 
     @pytest.mark.asyncio

--- a/atlas/tests/test_config_manager.py
+++ b/atlas/tests/test_config_manager.py
@@ -518,8 +518,8 @@ class TestRAGSourceConfig:
         assert config.compliance_level is None
         assert config.top_k == 4
         assert config.timeout == 60.0
-        assert config.discovery_endpoint == "/discover/datasources"
-        assert config.query_endpoint == "/rag/completions"
+        assert config.discovery_endpoint == "/api/v1/discover/datasources"
+        assert config.query_endpoint == "/api/v1/rag/completions"
 
     def test_rag_source_with_all_fields(self):
         """RAGSourceConfig should accept all optional fields."""

--- a/mocks/atlas-rag-api-mock/main.py
+++ b/mocks/atlas-rag-api-mock/main.py
@@ -1,29 +1,34 @@
 #!/usr/bin/env python3
 """
-ATLAS RAG API Mock Service with Grep-Based Search
+ATLAS RAG API Mock Service (OpenAPI v0.3.x).
 
-Provides mock endpoints that simulate the external ATLAS RAG API:
-  - GET  /discover/datasources  - Discover accessible data sources
-  - POST /rag/completions       - Query RAG with grep-based search
+Implements the ATLAS RAG API shape described in the public OpenAPI spec:
 
-This mock searches through realistic text data using simple keyword matching.
-Mock data is loaded from mock_data.json in the same directory.
+  - GET  /api/v1/discover/datasources?role=read|write&as_user=<user>
+  - POST /api/v1/rag/completions?as_user=<user>
+
+Responses follow the OpenAI chat.completion schema, with an extra
+``rag_metadata`` field and per-message ``annotations`` (url_citation)
+that link specific character ranges in the assistant content to the
+source documents they were derived from.
+
+Mock data is loaded from mock_data.json next to this file.
 """
 
 import json
 import logging
 import os
-from pathlib import Path
 import re
 import time
 import uuid
 from datetime import datetime
-from typing import Dict, List, Optional, Any, Tuple
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
+import uvicorn
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-import uvicorn
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -47,13 +52,15 @@ def load_mock_data() -> Tuple[Dict[str, Any], Dict[str, List[str]]]:
     data_sources = data.get("data_sources", {})
     users_groups = data.get("users_groups", {})
 
-    logger.info("Loaded mock data: %d data sources, %d users",
-                len(data_sources), len(users_groups))
+    logger.info(
+        "Loaded mock data: %d data sources, %d users",
+        len(data_sources),
+        len(users_groups),
+    )
 
     return data_sources, users_groups
 
 
-# Load data at module level
 DATA_SOURCES, USERS_GROUPS_DB = load_mock_data()
 
 
@@ -70,10 +77,6 @@ class StaticTokenVerifier:
     def verify(self, token: str) -> Optional[Dict[str, Any]]:
         return self.tokens.get(token)
 
-
-# ------------------------------------------------------------------------------
-# Configuration
-# ------------------------------------------------------------------------------
 
 shared_key = (
     os.getenv("ATLAS_RAG_SHARED_KEY")
@@ -92,16 +95,14 @@ verifier = StaticTokenVerifier(
 )
 
 
-
-
 # ------------------------------------------------------------------------------
 # FastAPI App
 # ------------------------------------------------------------------------------
 
 app = FastAPI(
     title="ATLAS RAG API Mock",
-    description="Mock API with grep-based search over realistic data",
-    version="2.0.0",
+    description="Mock aligned with the ATLAS RAG OpenAPI v0.3.x spec",
+    version="0.3.0",
 )
 
 PUBLIC_PATHS = {"/", "/health", "/docs", "/redoc", "/openapi.json"}
@@ -114,7 +115,10 @@ async def verify_token_middleware(request, call_next):
 
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
-        return JSONResponse(status_code=401, content={"detail": "Missing or invalid Authorization header"})
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Missing or invalid Authorization header"},
+        )
 
     token = auth_header[7:]
     if verifier.verify(token) is None:
@@ -124,270 +128,395 @@ async def verify_token_middleware(request, call_next):
 
 
 # ------------------------------------------------------------------------------
-# Pydantic Models
+# Pydantic Models (OpenAPI v0.3.x)
 # ------------------------------------------------------------------------------
 
-class DataSourceInfo(BaseModel):
-    id: str
-    label: str
-    compliance_level: str = "CUI"
-    description: str = ""
+class DataSource(BaseModel):
+    id: str = Field(..., description="Unique identifier")
+    label: str = Field(..., description="Label")
+    compliance_level: str = Field("CUI", description="Compliance level of data source")
+    description: str = Field("", description="Description")
 
 
-class DataSourceDiscoveryResponse(BaseModel):
-    data_sources: List[DataSourceInfo]
+class DiscoverDataSourcesResponse(BaseModel):
+    data_sources: List[DataSource]
 
 
-class ChatMessage(BaseModel):
-    role: str
-    content: str
-
-
-class RagRequest(BaseModel):
-    messages: List[ChatMessage]
-    stream: bool = False
-    model: str = "gpt-4"
-    top_k: int = 4
-    corpora: Optional[List[str]] = None
-
-
-class DocumentFound(BaseModel):
-    id: str
-    corpus_id: str
+class AnnotationURLCitation(BaseModel):
+    end_index: int
+    start_index: int
     title: str
+    url: str
+
+
+class Annotation(BaseModel):
+    type: Literal["url_citation"] = "url_citation"
+    url_citation: AnnotationURLCitation
+
+
+class ChatCompletionMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: Optional[str] = None
+    refusal: Optional[str] = None
+    annotations: Optional[List[Annotation]] = None
+
+
+class Choice(BaseModel):
+    finish_reason: Literal[
+        "stop", "length", "tool_calls", "content_filter", "function_call"
+    ] = "stop"
+    index: int = 0
+    message: ChatCompletionMessage
+
+
+class DocumentMetadata(BaseModel):
+    data_source: DataSource
     text: str
+    id: Optional[int] = None
+    content_type: str = "atlas-search"
     confidence_score: float
-    content_type: str = "text"
     last_modified: Optional[str] = None
-    url: Optional[str] = None
 
 
 class RagMetadata(BaseModel):
     query_processing_time_ms: int
-    documents_found: List[DocumentFound]
-    data_sources: List[str]
-    retrieval_method: str = "keyword-search"
+    documents_found: List[DocumentMetadata]
+    data_sources: List[DataSource]
+    retrieval_method: str = "similarity"
 
 
-class RagResponseChoice(BaseModel):
-    index: int = 0
-    message: ChatMessage
-    finish_reason: str = "stop"
+class CompletionUsage(BaseModel):
+    completion_tokens: int
+    prompt_tokens: int
+    total_tokens: int
+
+
+class RagRequest(BaseModel):
+    messages: List[Dict[str, Any]] = Field(..., description="Message history")
+    stream: bool = Field(False, description="Stream response")
+    model: str = Field("openai/gpt-oss-120b", description="LLM used to generate response")
+    hybrid_search_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional arguments to be passed to HybridSearch",
+    )
+    shirty_api_key: Optional[str] = None
+    search_api_key: Optional[str] = None
+    as_user: Optional[str] = None
 
 
 class RagResponse(BaseModel):
     id: str = Field(default_factory=lambda: f"chatcmpl-{uuid.uuid4().hex[:12]}")
-    object: str = "chat.completion"
+    choices: List[Choice]
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
-    choices: List[RagResponseChoice]
-    rag_metadata: Optional[RagMetadata] = None
+    object: Literal["chat.completion"] = "chat.completion"
+    service_tier: Optional[str] = None
+    system_fingerprint: Optional[str] = None
+    usage: Optional[CompletionUsage] = None
+    rag_metadata: RagMetadata
 
 
 # ------------------------------------------------------------------------------
-# Search Functions
+# Search Helpers
 # ------------------------------------------------------------------------------
+
+STOP_WORDS = {
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "must", "shall", "can", "to", "of", "in",
+    "for", "on", "with", "at", "by", "from", "as", "into", "through",
+    "during", "before", "after", "above", "below", "between", "under",
+    "and", "or", "but", "if", "then", "else", "when", "where", "why",
+    "how", "what", "which", "who", "whom", "this", "that", "these",
+    "those", "it", "its", "i", "me", "my", "we", "our", "you", "your",
+}
+
 
 def grep_search(query: str, text: str, context_chars: int = 200) -> List[Tuple[str, float]]:
-    """
-    Search for query terms in text and return matching snippets with scores.
-    Returns list of (snippet, score) tuples.
-    """
+    """Return snippets in ``text`` that match any non-stopword token in ``query``."""
     if not query or not text:
         return []
 
-    # Tokenize query into words (ignore common stop words)
-    stop_words = {"the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
-                  "have", "has", "had", "do", "does", "did", "will", "would", "could",
-                  "should", "may", "might", "must", "shall", "can", "to", "of", "in",
-                  "for", "on", "with", "at", "by", "from", "as", "into", "through",
-                  "during", "before", "after", "above", "below", "between", "under",
-                  "and", "or", "but", "if", "then", "else", "when", "where", "why",
-                  "how", "what", "which", "who", "whom", "this", "that", "these",
-                  "those", "it", "its", "i", "me", "my", "we", "our", "you", "your"}
-
-    query_words = [w.lower() for w in re.findall(r'\w+', query) if w.lower() not in stop_words]
-
+    query_words = [
+        w.lower() for w in re.findall(r"\w+", query) if w.lower() not in STOP_WORDS
+    ]
     if not query_words:
         return []
 
-    results = []
-    lines = text.split('\n')
+    results: List[Tuple[str, float]] = []
+    lines = text.split("\n")
 
     for i, line in enumerate(lines):
         line_lower = line.lower()
-        matches = sum(1 for word in query_words if word in line_lower)
+        matches = sum(1 for w in query_words if w in line_lower)
+        if matches == 0:
+            continue
+        score = matches / len(query_words)
 
-        if matches > 0:
-            # Calculate score based on match ratio and position
-            score = matches / len(query_words)
+        start_line = max(0, i - 1)
+        end_line = min(len(lines), i + 2)
+        snippet = "\n".join(lines[start_line:end_line]).strip()
+        if len(snippet) > context_chars:
+            snippet = snippet[:context_chars] + "..."
+        results.append((snippet, score))
 
-            # Build context (include surrounding lines)
-            start_line = max(0, i - 1)
-            end_line = min(len(lines), i + 2)
-            snippet = '\n'.join(lines[start_line:end_line]).strip()
-
-            # Truncate if too long
-            if len(snippet) > context_chars:
-                snippet = snippet[:context_chars] + "..."
-
-            results.append((snippet, score))
-
-    # Sort by score and deduplicate
     results.sort(key=lambda x: -x[1])
+
     seen = set()
-    unique_results = []
+    unique: List[Tuple[str, float]] = []
     for snippet, score in results:
-        snippet_key = snippet[:50]  # Use first 50 chars as key
-        if snippet_key not in seen:
-            seen.add(snippet_key)
-            unique_results.append((snippet, score))
+        key = snippet[:50]
+        if key not in seen:
+            seen.add(key)
+            unique.append((snippet, score))
+    return unique[:5]
 
-    return unique_results[:5]  # Return top 5 matches
+
+def _make_data_source(corpus_id: str) -> DataSource:
+    corpus = DATA_SOURCES[corpus_id]
+    return DataSource(
+        id=corpus_id,
+        label=corpus.get("name", corpus_id),
+        compliance_level=corpus.get("compliance_level", "CUI"),
+        description=corpus.get("description", ""),
+    )
 
 
-def search_corpus(query: str, corpus_id: str, top_k: int = 4) -> List[DocumentFound]:
-    """Search a corpus for relevant documents."""
+def search_corpus(
+    query: str, corpus_id: str, top_k: int
+) -> List[Tuple[DocumentMetadata, Optional[str], Optional[str]]]:
+    """Return ``(DocumentMetadata, title, url)`` tuples for top matches in ``corpus_id``."""
     if corpus_id not in DATA_SOURCES:
         return []
 
     corpus = DATA_SOURCES[corpus_id]
-    all_results = []
+    data_source = _make_data_source(corpus_id)
 
+    scored: List[Tuple[DocumentMetadata, Optional[str], Optional[str], float]] = []
+    chunk_id = 1
     for doc in corpus["documents"]:
-        matches = grep_search(query, doc["content"])
-
-        for snippet, score in matches:
-            all_results.append(DocumentFound(
-                id=doc["id"],
-                corpus_id=corpus_id,
-                title=doc["title"],
+        for snippet, score in grep_search(query, doc["content"]):
+            metadata = DocumentMetadata(
+                data_source=data_source,
                 text=snippet,
-                confidence_score=round(score, 2),
-                content_type="text",
+                id=chunk_id,
+                content_type="atlas-search",
+                confidence_score=round(score, 4),
                 last_modified=doc.get("last_modified"),
-                url=doc.get("url"),
-            ))
+            )
+            scored.append((metadata, doc.get("title"), doc.get("url"), score))
+            chunk_id += 1
 
-    # Sort by confidence and return top_k
-    all_results.sort(key=lambda x: -x.confidence_score)
-    return all_results[:top_k]
+    scored.sort(key=lambda x: -x[3])
+    return [(m, t, u) for m, t, u, _ in scored[:top_k]]
 
 
 # ------------------------------------------------------------------------------
 # Authorization Helpers
 # ------------------------------------------------------------------------------
 
-def get_accessible_corpora(user_name: str) -> List[DataSourceInfo]:
-    """Get list of data sources accessible by a user."""
+def get_accessible_corpora(user_name: str) -> List[DataSource]:
+    """Return data sources accessible by ``user_name``."""
     user_groups = set(USERS_GROUPS_DB.get(user_name, []))
-    accessible = []
+    accessible: List[DataSource] = []
 
     for corpus_id, corpus in DATA_SOURCES.items():
         required = set(corpus.get("required_groups", []))
-
-        # Public if no required groups, or user has at least one required group
         if not required or (user_groups & required):
-            accessible.append(DataSourceInfo(
-                id=corpus_id,
-                label=corpus.get("name", corpus_id),
-                compliance_level=corpus.get("compliance_level", "CUI"),
-                description=corpus.get("description", ""),
-            ))
+            accessible.append(_make_data_source(corpus_id))
 
     return accessible
 
 
 def can_access_corpus(user_name: str, corpus_id: str) -> bool:
-    """Check if a user can access a corpus."""
     if corpus_id not in DATA_SOURCES:
         return False
-
     required = set(DATA_SOURCES[corpus_id].get("required_groups", []))
     if not required:
-        return True  # Public access
-
+        return True
     user_groups = set(USERS_GROUPS_DB.get(user_name, []))
     return bool(user_groups & required)
+
+
+# ------------------------------------------------------------------------------
+# Response Composition
+# ------------------------------------------------------------------------------
+
+def _compose_answer_with_citations(
+    corpora_searched: List[str],
+    docs_with_meta: List[Tuple[DocumentMetadata, Optional[str], Optional[str]]],
+    user_query: str,
+) -> Tuple[str, List[Annotation]]:
+    """Build assistant content and url_citation annotations pointing into it.
+
+    Each annotation's ``start_index``/``end_index`` bounds the exact characters
+    in the generated content that came from the referenced document.
+    """
+    if not docs_with_meta:
+        content = (
+            f"No results found for: \"{user_query}\"\n\n"
+            f"Searched in: {', '.join(corpora_searched)}\n"
+            "Try different keywords or check your data source access."
+        )
+        return content, []
+
+    parts: List[str] = []
+    annotations: List[Annotation] = []
+
+    intro = (
+        f"Based on searching {len(corpora_searched)} data source(s), "
+        f"I found {len(docs_with_meta)} relevant result(s):\n\n"
+    )
+    parts.append(intro)
+    cursor = len(intro)
+
+    for idx, (doc, title, url) in enumerate(docs_with_meta, start=1):
+        title_str = title or doc.data_source.label
+        header = f"[{idx}] {title_str}\n"
+        body = doc.text
+        citation_marker = f" [{idx}]"
+
+        parts.append(header)
+        cursor += len(header)
+
+        body_start = cursor
+        parts.append(body)
+        cursor += len(body)
+        body_end = cursor
+
+        parts.append(citation_marker)
+        cursor += len(citation_marker)
+        parts.append("\n\n")
+        cursor += 2
+
+        annotations.append(
+            Annotation(
+                type="url_citation",
+                url_citation=AnnotationURLCitation(
+                    start_index=body_start,
+                    end_index=body_end,
+                    title=title_str,
+                    url=url or "",
+                ),
+            )
+        )
+
+    footer = (
+        f"These results are from: "
+        f"{', '.join(sorted({d.data_source.id for d, _, _ in docs_with_meta}))}"
+    )
+    parts.append(footer)
+
+    return "".join(parts), annotations
 
 
 # ------------------------------------------------------------------------------
 # API Endpoints
 # ------------------------------------------------------------------------------
 
-@app.get("/discover/datasources", response_model=DataSourceDiscoveryResponse)
-async def discover_data_sources(as_user: str = Query(...)):
-    """Discover data sources accessible by a user."""
-    logger.info("Discovery request for user: %s", as_user)
+@app.get("/api/v1/discover/datasources", response_model=DiscoverDataSourcesResponse)
+async def discover_data_sources(
+    role: Literal["read", "write"] = Query("read"),
+    as_user: Optional[str] = Query(None, description="User ID to impersonate"),
+):
+    """Discover data sources accessible by a user.
 
-    accessible = get_accessible_corpora(as_user)
-    logger.info("User %s can access %d data sources", as_user, len(accessible))
-
-    return DataSourceDiscoveryResponse(
-        data_sources=accessible,
+    The mock treats ``read`` and ``write`` identically; a production impl would
+    filter further by role.
+    """
+    user = as_user or ""
+    logger.info("Discovery request: user=%s role=%s", user, role)
+    accessible = get_accessible_corpora(user)
+    logger.info(
+        "User %s can access %d data sources (role=%s)",
+        user,
+        len(accessible),
+        role,
     )
+    return DiscoverDataSourcesResponse(data_sources=accessible)
 
 
-@app.post("/rag/completions", response_model=RagResponse)
-async def rag_completions(request: RagRequest, as_user: str = Query(...)):
+@app.post("/api/v1/rag/completions", response_model=RagResponse)
+async def rag_completions(
+    request: RagRequest,
+    as_user: Optional[str] = Query(None, description="User ID to impersonate"),
+):
     """Query RAG with grep-based search."""
     start_time = time.time()
 
+    user = as_user or request.as_user or ""
     logger.info("---------- RAG query ----------")
-    logger.info("RAG query from user: %s, corpora: %s", as_user, request.corpora)
+    logger.info(
+        "RAG query user=%s model=%s hybrid_kwargs=%s",
+        user,
+        request.model,
+        request.hybrid_search_kwargs,
+    )
 
-    # Determine corpora to search
-    corpora_to_search = request.corpora or [c.id for c in get_accessible_corpora(as_user)]
+    top_k = int(request.hybrid_search_kwargs.get("top_k", 4))
+    requested_corpora = (
+        request.hybrid_search_kwargs.get("corpora")
+        or request.hybrid_search_kwargs.get("data_sources")
+    )
+    if requested_corpora is None:
+        corpora_to_search = [ds.id for ds in get_accessible_corpora(user)]
+    else:
+        corpora_to_search = list(requested_corpora)
 
-    # Validate access
     for corpus in corpora_to_search:
         if corpus not in DATA_SOURCES:
             raise HTTPException(status_code=404, detail=f"Corpus '{corpus}' not found")
-        if not can_access_corpus(as_user, corpus):
+        if not can_access_corpus(user, corpus):
             raise HTTPException(status_code=403, detail=f"Access denied to '{corpus}'")
 
-    # Extract user query
-    user_query = next((m.content for m in reversed(request.messages) if m.role == "user"), "")
-    logger.info("RAG user query (exact): %r", user_query)
+    user_query = ""
+    for m in reversed(request.messages):
+        if m.get("role") == "user":
+            c = m.get("content", "")
+            if isinstance(c, list):
+                user_query = " ".join(
+                    p.get("text", "")
+                    for p in c
+                    if isinstance(p, dict) and p.get("type") == "text"
+                )
+            else:
+                user_query = c or ""
+            break
+    logger.info("RAG user query: %r", user_query)
 
-    # Search each corpus
-    all_documents = []
+    docs_with_meta: List[Tuple[DocumentMetadata, Optional[str], Optional[str]]] = []
     for corpus in corpora_to_search:
-        docs = search_corpus(user_query, corpus, request.top_k)
-        all_documents.extend(docs)
+        docs_with_meta.extend(search_corpus(user_query, corpus, top_k))
 
-    # Sort by confidence and limit
-    all_documents.sort(key=lambda x: -x.confidence_score)
-    all_documents = all_documents[:request.top_k]
+    docs_with_meta.sort(key=lambda x: -x[0].confidence_score)
+    docs_with_meta = docs_with_meta[:top_k]
 
-    # Generate response
+    content, annotations = _compose_answer_with_citations(
+        corpora_to_search, docs_with_meta, user_query
+    )
+
     processing_time = int((time.time() - start_time) * 1000) + 20
-
-    if all_documents:
-        context_parts = [f"[{d.title}]\n{d.text}" for d in all_documents]
-        context = "\n\n---\n\n".join(context_parts)
-
-        response_content = (
-            f"Based on searching {len(corpora_to_search)} data source(s), "
-            f"I found {len(all_documents)} relevant result(s):\n\n"
-            f"{context}\n\n"
-            f"These results are from: {', '.join(set(d.corpus_id for d in all_documents))}"
-        )
-    else:
-        response_content = (
-            f"No results found for: \"{user_query}\"\n\n"
-            f"Searched in: {', '.join(corpora_to_search)}\n"
-            "Try different keywords or check your data source access."
-        )
 
     return RagResponse(
         model=request.model,
-        choices=[RagResponseChoice(message=ChatMessage(role="assistant", content=response_content))],
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content=content,
+                    annotations=annotations or None,
+                ),
+            )
+        ],
         rag_metadata=RagMetadata(
             query_processing_time_ms=processing_time,
-            documents_found=all_documents,
-            data_sources=corpora_to_search,
-            retrieval_method="keyword-search",
+            documents_found=[m for m, _, _ in docs_with_meta],
+            data_sources=[
+                _make_data_source(c) for c in corpora_to_search if c in DATA_SOURCES
+            ],
+            retrieval_method="similarity",
         ),
     )
 
@@ -401,13 +530,15 @@ async def health_check():
 async def root():
     return {
         "service": "ATLAS RAG API Mock",
-        "version": "2.0.0",
-        "search_method": "grep-based keyword search",
+        "version": "0.3.0",
+        "openapi": "v0.3.x",
         "data_sources": list(DATA_SOURCES.keys()),
         "test_users": list(USERS_GROUPS_DB.keys()),
         "endpoints": {
-            "GET /discover/datasources?as_user=<email>": "List accessible data sources",
-            "POST /rag/completions?as_user=<email>": "Search and query",
+            "GET /api/v1/discover/datasources?role=read|write&as_user=<user>":
+                "List accessible data sources",
+            "POST /api/v1/rag/completions?as_user=<user>":
+                "Search and query",
             "GET /health": "Health check",
         },
     }


### PR DESCRIPTION
## Summary

Aligns ATLAS's RAG integration with the ATLAS-RAG OpenAPI v0.3.x spec. The main payoff is that **citations now work reliably**: URLs and titles flow directly from the API's `url_citation` annotations into our `DocumentMetadata`, instead of being guessed from legacy flat fields that weren't in the spec.

- **Endpoints** — `AtlasRAGClient` now hits `/api/v1/discover/datasources` (with `role=read|write`) and `/api/v1/rag/completions`.
- **Request shape** — `top_k` and `corpora` are nested inside `hybrid_search_kwargs` per the spec; legacy flat fields removed.
- **Response shape** — parses `choices[0].message.annotations` (`type=url_citation`) into a new `URLCitation` model and enriches `DocumentMetadata.title`/`url` by pairing annotations with documents in order. Accepts nested `data_source` and `data_sources: List[DataSource]` in `rag_metadata`; back-compat parsing of flat `corpus_id`/`title`/`url`/string `data_sources` preserved for older servers.
- **Mock** (`mocks/atlas-rag-api-mock/main.py`) — rewritten to match: OpenAI `chat.completion` envelope, per-message `url_citation` annotations whose `start_index`/`end_index` bound the cited span in `content`, and `rag_metadata` with nested `DataSource` objects.
- **Config defaults** — `RAGSourceConfig.discovery_endpoint`/`query_endpoint` bumped to `/api/v1/...`.

The existing citation-rendering pipeline (`_build_citation_instructions`, `_format_rag_references`, frontend `ragCitations.js`) needed no changes — it was already consuming `DocumentMetadata.title`/`url`, which now come from real annotations.

## Test plan

- [x] `atlas/tests/` — 1233 passed, 8 skipped (includes 14 live-mock integration tests under `RUN_RAG_INTEGRATION=1`)
- [x] `frontend/` vitest — 372 passed across 32 files
- [x] Added unit tests for `_parse_annotations`, index-order annotation/document pairing, and nested-data_source precedence
- [x] Manual end-to-end against the rewritten mock: `annotations[0]` at `[91:134]` correctly bounds `"Remote Work Policy - Effective January 2024"`; rendered References section links titles to the corresponding URLs