### PR TITLE
docs(release): monthly release process + cut automation

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -47,16 +47,32 @@ jobs:
     # Guardrail: do not run scheduled cuts on forks. workflow_dispatch
     # is allowed on any repo so maintainers can dry-run from a fork.
     if: github.event_name != 'schedule' || github.repository == 'sandialabs/atlas-ui-3'
+    env:
+      # Prefer a PAT so the branch push and PR creation trigger
+      # downstream workflows (CI/CD Pipeline, Security Checks). PRs
+      # opened with the default GITHUB_TOKEN do not trigger other
+      # workflows, which would leave the release-PR checklist
+      # permanently blocking on missing required status checks. If
+      # RELEASE_PAT is unset we fall back to GITHUB_TOKEN and annotate
+      # the PR body so the release captain knows they must kick CI
+      # manually. See docs/developer/release-process.md → "Kicking CI
+      # on the release PR".
+      RELEASE_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+      HAS_RELEASE_PAT: ${{ secrets.RELEASE_PAT != '' && 'true' || 'false' }}
     steps:
+      - name: Warn if no PAT is configured
+        if: env.HAS_RELEASE_PAT != 'true'
+        run: |
+          echo "::warning::RELEASE_PAT secret is not configured; falling back to GITHUB_TOKEN."
+          echo "::warning::The release PR will open, but CI/CD Pipeline and Security Checks will NOT auto-run on it."
+          echo "::warning::The release captain must kick CI manually — see docs/developer/release-process.md."
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          # Use a PAT if you need the PR to trigger downstream
-          # workflows (GITHUB_TOKEN-created PRs do not). For now we
-          # rely on GITHUB_TOKEN; maintainers can re-run CI on the PR.
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ env.RELEASE_TOKEN }}
 
       - name: Compute release metadata
         id: meta
@@ -106,34 +122,43 @@ jobs:
             echo "release_branch=$release_branch"
             echo "commit_sha=$commit_sha"
             echo "commit_short=$commit_short"
-            echo "pr_title=release: ${new_version} (${year_month})"
           } >> "$GITHUB_OUTPUT"
 
           echo "::notice::Planning release ${current} -> ${new_version} on ${release_branch} from ${commit_short}"
 
-      - name: Check if release branch already exists
-        id: branch_check
+      - name: Check branch and PR state
+        id: state
         shell: bash
         env:
+          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
           BRANCH: ${{ steps.meta.outputs.release_branch }}
         run: |
           set -euo pipefail
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Branch $BRANCH already exists on origin. This run is a no-op."
+            echo "branch_exists=true" >> "$GITHUB_OUTPUT"
+            pr_count="$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')"
+            if [[ "$pr_count" == "0" ]]; then
+              echo "pr_exists=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::Release branch $BRANCH exists on origin but has no open PR — recovery path will open one."
+            else
+              echo "pr_exists=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::Release branch $BRANCH already exists and has an open PR. This run is a no-op."
+            fi
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "branch_exists=false" >> "$GITHUB_OUTPUT"
+            echo "pr_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Stop early if branch exists
-        if: steps.branch_check.outputs.exists == 'true'
+      - name: Stop early if nothing to do
+        if: steps.state.outputs.branch_exists == 'true' && steps.state.outputs.pr_exists == 'true'
         run: |
-          echo "Release branch ${{ steps.meta.outputs.release_branch }} already exists."
-          echo "This run exits cleanly without changing anything."
+          echo "Nothing to do: release branch and open PR already exist."
           exit 0
 
-      - name: Create release branch
-        if: steps.branch_check.outputs.exists == 'false'
+      # --- Fresh-cut path: branch does not exist ---
+
+      - name: Create release branch (fresh cut)
+        if: steps.state.outputs.branch_exists == 'false'
         env:
           BRANCH: ${{ steps.meta.outputs.release_branch }}
         run: |
@@ -141,7 +166,7 @@ jobs:
           git checkout -b "$BRANCH"
 
       - name: Bump atlas/version.py
-        if: steps.branch_check.outputs.exists == 'false'
+        if: steps.state.outputs.branch_exists == 'false'
         env:
           OLD_VERSION: ${{ steps.meta.outputs.current_version }}
           NEW_VERSION: ${{ steps.meta.outputs.new_version }}
@@ -168,7 +193,7 @@ jobs:
           PY
 
       - name: Bump pyproject.toml
-        if: steps.branch_check.outputs.exists == 'false'
+        if: steps.state.outputs.branch_exists == 'false'
         env:
           OLD_VERSION: ${{ steps.meta.outputs.current_version }}
           NEW_VERSION: ${{ steps.meta.outputs.new_version }}
@@ -196,7 +221,7 @@ jobs:
           PY
 
       - name: Update CHANGELOG.md
-        if: steps.branch_check.outputs.exists == 'false'
+        if: steps.state.outputs.branch_exists == 'false'
         env:
           NEW_VERSION: ${{ steps.meta.outputs.new_version }}
           RELEASE_DATE: ${{ steps.meta.outputs.release_date }}
@@ -232,18 +257,18 @@ jobs:
           PY
 
       - name: Show diff
-        if: steps.branch_check.outputs.exists == 'false'
+        if: steps.state.outputs.branch_exists == 'false'
         run: |
           git --no-pager diff --stat
           git --no-pager diff
 
       - name: Dry run stops here
-        if: steps.branch_check.outputs.exists == 'false' && github.event.inputs.dry_run == 'true'
+        if: steps.state.outputs.branch_exists == 'false' && github.event.inputs.dry_run == 'true'
         run: |
           echo "::notice::dry_run=true — not committing, not pushing, not opening a PR."
 
       - name: Commit bump
-        if: steps.branch_check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+        if: steps.state.outputs.branch_exists == 'false' && github.event.inputs.dry_run != 'true'
         env:
           NEW_VERSION: ${{ steps.meta.outputs.new_version }}
           YEAR_MONTH: ${{ steps.meta.outputs.year_month }}
@@ -255,22 +280,116 @@ jobs:
           git commit -m "chore(release): cut ${YEAR_MONTH} at v${NEW_VERSION}"
 
       - name: Push release branch
-        if: steps.branch_check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+        if: steps.state.outputs.branch_exists == 'false' && github.event.inputs.dry_run != 'true'
         env:
           BRANCH: ${{ steps.meta.outputs.release_branch }}
         run: |
           set -euo pipefail
           git push --set-upstream origin "$BRANCH"
 
+      # --- Recovery path: branch already exists but no open PR ---
+
+      - name: Check out existing release branch (recovery)
+        if: steps.state.outputs.branch_exists == 'true' && steps.state.outputs.pr_exists == 'false'
+        env:
+          BRANCH: ${{ steps.meta.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BRANCH"
+          git checkout "$BRANCH"
+
+      - name: Recover metadata from existing branch
+        if: steps.state.outputs.branch_exists == 'true' && steps.state.outputs.pr_exists == 'false'
+        id: recover
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - >> "$GITHUB_OUTPUT" <<'PY'
+          import pathlib, re, subprocess
+
+          def sh(*cmd):
+              return subprocess.check_output(list(cmd), text=True).strip()
+
+          def read_version(blob):
+              for line in blob.splitlines():
+                  m = re.match(r'^VERSION\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"', line)
+                  if m:
+                      return m.group(1)
+              return ""
+
+          new_version = read_version(pathlib.Path("atlas/version.py").read_text())
+          if not new_version:
+              raise SystemExit("Could not read VERSION from release branch atlas/version.py")
+
+          # Best-effort: the tip of a freshly cut branch IS the bump
+          # commit, so HEAD~1 carries the pre-bump version.
+          try:
+              pre = sh("git", "show", "HEAD~1:atlas/version.py")
+              old_version = read_version(pre) or "unknown"
+          except subprocess.CalledProcessError:
+              old_version = "unknown"
+
+          release_date = sh("git", "show", "-s", "--format=%cs", "HEAD")
+          commit_sha = sh("git", "rev-parse", "HEAD")
+
+          print(f"new_version={new_version}")
+          print(f"current_version={old_version}")
+          print(f"release_date={release_date}")
+          print(f"commit_sha={commit_sha}")
+          PY
+
+      # --- Consolidate metadata for PR body / title ---
+
+      - name: Select final metadata
+        id: final
+        if: steps.state.outputs.pr_exists == 'false' && github.event.inputs.dry_run != 'true'
+        shell: bash
+        env:
+          BRANCH_EXISTS: ${{ steps.state.outputs.branch_exists }}
+          YEAR_MONTH: ${{ steps.meta.outputs.year_month }}
+          FRESH_VERSION: ${{ steps.meta.outputs.new_version }}
+          FRESH_OLD: ${{ steps.meta.outputs.current_version }}
+          FRESH_DATE: ${{ steps.meta.outputs.release_date }}
+          FRESH_SHA: ${{ steps.meta.outputs.commit_sha }}
+          REC_VERSION: ${{ steps.recover.outputs.new_version }}
+          REC_OLD: ${{ steps.recover.outputs.current_version }}
+          REC_DATE: ${{ steps.recover.outputs.release_date }}
+          REC_SHA: ${{ steps.recover.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$BRANCH_EXISTS" == "true" ]]; then
+            version="$REC_VERSION"
+            old_version="$REC_OLD"
+            release_date="$REC_DATE"
+            commit_sha="$REC_SHA"
+            is_recovery="true"
+          else
+            version="$FRESH_VERSION"
+            old_version="$FRESH_OLD"
+            release_date="$FRESH_DATE"
+            commit_sha="$FRESH_SHA"
+            is_recovery="false"
+          fi
+          {
+            echo "version=$version"
+            echo "old_version=$old_version"
+            echo "release_date=$release_date"
+            echo "commit_sha=$commit_sha"
+            echo "is_recovery=$is_recovery"
+            echo "pr_title=release: ${version} (${YEAR_MONTH})"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build PR body from checklist template
-        if: steps.branch_check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+        if: steps.state.outputs.pr_exists == 'false' && github.event.inputs.dry_run != 'true'
         id: pr_body
         env:
-          VERSION: ${{ steps.meta.outputs.new_version }}
-          OLD_VERSION: ${{ steps.meta.outputs.current_version }}
+          VERSION: ${{ steps.final.outputs.version }}
+          OLD_VERSION: ${{ steps.final.outputs.old_version }}
           YEAR_MONTH: ${{ steps.meta.outputs.year_month }}
-          RELEASE_DATE: ${{ steps.meta.outputs.release_date }}
-          COMMIT_SHA: ${{ steps.meta.outputs.commit_sha }}
+          RELEASE_DATE: ${{ steps.final.outputs.release_date }}
+          COMMIT_SHA: ${{ steps.final.outputs.commit_sha }}
+          IS_RECOVERY: ${{ steps.final.outputs.is_recovery }}
+          HAS_PAT: ${{ env.HAS_RELEASE_PAT }}
         shell: bash
         run: |
           set -euo pipefail
@@ -286,15 +405,59 @@ jobs:
           }
           for k, v in subs.items():
               body = body.replace(k, v)
+
+          banners = []
+          if os.environ.get("IS_RECOVERY") == "true":
+              banners.append(
+                  "> **Recovery open**: the release branch already existed "
+                  "on origin but no open PR tracked it — this PR was opened "
+                  "by the `release-cut` workflow's recovery path. Verify the "
+                  "version and commit metadata above against the branch "
+                  "contents before tagging."
+              )
+          if os.environ.get("HAS_PAT") != "true":
+              banners.append(
+                  "> **CI kick required**: this PR was opened with the "
+                  "default `GITHUB_TOKEN`, which does not trigger "
+                  "`pull_request` workflows. To satisfy the checklist's "
+                  "`CI/CD Pipeline` and `Security Checks` gates, the "
+                  "release captain must either (a) close this PR and "
+                  "immediately reopen it, or (b) push any commit to this "
+                  "branch from a personal account. See "
+                  "`docs/developer/release-process.md` → \"Kicking CI on "
+                  "the release PR\"."
+              )
+          if banners:
+              body = "\n\n".join(banners) + "\n\n---\n\n" + body
+
           pathlib.Path("release-pr-body.md").write_text(body)
           PY
           echo "body_file=release-pr-body.md" >> "$GITHUB_OUTPUT"
 
-      - name: Open draft release PR
-        if: steps.branch_check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+      - name: Ensure 'release' label exists
+        if: steps.state.outputs.pr_exists == 'false' && github.event.inputs.dry_run != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TITLE: ${{ steps.meta.outputs.pr_title }}
+          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Idempotent label create. gh exits non-zero if the label
+          # already exists; swallow that specific case only.
+          if ! gh label create "release" \
+               --description "Monthly release cut PR" \
+               --color "0e8a16" 2>/tmp/label-err; then
+            if grep -qi "already exists" /tmp/label-err; then
+              echo "Label 'release' already exists — continuing."
+            else
+              cat /tmp/label-err
+              exit 1
+            fi
+          fi
+
+      - name: Open draft release PR
+        if: steps.state.outputs.pr_exists == 'false' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ env.RELEASE_TOKEN }}
+          TITLE: ${{ steps.final.outputs.pr_title }}
           HEAD: ${{ steps.meta.outputs.release_branch }}
           BODY_FILE: ${{ steps.pr_body.outputs.body_file }}
         run: |
@@ -305,40 +468,40 @@ jobs:
             --head "$HEAD" \
             --title "$TITLE" \
             --body-file "$BODY_FILE" \
-            --label "release" \
-            || {
-              echo "::warning::gh pr create failed (label may not exist). Retrying without label."
-              gh pr create \
-                --draft \
-                --base main \
-                --head "$HEAD" \
-                --title "$TITLE" \
-                --body-file "$BODY_FILE"
-            }
+            --label "release"
 
       - name: Summary
         if: always()
         env:
-          EXISTS: ${{ steps.branch_check.outputs.exists }}
+          BRANCH_EXISTS: ${{ steps.state.outputs.branch_exists }}
+          PR_EXISTS: ${{ steps.state.outputs.pr_exists }}
           BRANCH: ${{ steps.meta.outputs.release_branch }}
           OLD: ${{ steps.meta.outputs.current_version }}
           NEW: ${{ steps.meta.outputs.new_version }}
           DRY: ${{ github.event.inputs.dry_run }}
+          HAS_PAT: ${{ env.HAS_RELEASE_PAT }}
         run: |
           {
             echo "## Release cut summary"
             echo ""
             echo "- Branch: \`$BRANCH\`"
             echo "- Version: \`$OLD\` → \`$NEW\`"
-            echo "- Pre-existing branch: \`$EXISTS\`"
+            echo "- Pre-existing branch: \`$BRANCH_EXISTS\`"
+            echo "- Pre-existing PR: \`$PR_EXISTS\`"
             echo "- Dry run: \`${DRY:-false}\`"
+            echo "- RELEASE_PAT configured: \`$HAS_PAT\`"
             echo ""
-            if [[ "$EXISTS" == "true" ]]; then
-              echo "No changes made — release branch already exists."
+            if [[ "$BRANCH_EXISTS" == "true" && "$PR_EXISTS" == "true" ]]; then
+              echo "No changes made — release branch and PR already exist."
             elif [[ "$DRY" == "true" ]]; then
               echo "No changes pushed — dry run only."
+            elif [[ "$BRANCH_EXISTS" == "true" && "$PR_EXISTS" == "false" ]]; then
+              echo "Recovery path: existing release branch had no open PR. Opened a new draft PR."
             else
-              echo "Draft release PR opened. Next step: a maintainer"
-              echo "claims it and follows the checklist in the PR body."
+              echo "Draft release PR opened. Next step: a maintainer claims it and follows the checklist in the PR body."
+            fi
+            if [[ "$HAS_PAT" != "true" ]]; then
+              echo ""
+              echo "> RELEASE_PAT not set → CI/Security workflows will not auto-run on the PR. See docs/developer/release-process.md for the kick-CI recipe."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #555 - 2026-04-23
+- Monthly release process + cron automation: `docs/developer/release-process.md`
+  runbook, `.github/workflows/release-cut.yml` scheduled cut (day 22, 14:00
+  UTC) that creates `release/YYYY.MM`, bumps versions, reshapes CHANGELOG,
+  and opens a draft release PR from `.github/release-checklist.md`. Workflow
+  uses an optional `RELEASE_PAT` secret so the PR triggers `CI/CD Pipeline`
+  and `Security Checks`, falls back to `GITHUB_TOKEN` with a visible
+  kick-CI banner, and includes a recovery path that opens a PR when a prior
+  run stranded a pushed branch without one. No publish paths change.
+
 ### PR #552 - 2026-04-20
 - New Chat stops in-flight generation: clicking "New Chat" while a reply is
   streaming no longer lets orphaned tokens bleed into the fresh session.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ We have created a set of comprehensive guides to help you get the most out of At
 
 ## Releases
 
-Atlas UI 3 ships on a **monthly cadence**. During the last week of each calendar month the `release-cut` workflow opens a draft release PR from a new `release/YYYY.MM` branch, bumps `atlas/version.py` and `pyproject.toml`, and finalizes the `CHANGELOG.md` section for that release. A maintainer (the release captain) runs the smoke test, pushes a `vX.Y.Z` tag, and publishes — automation never publishes by itself.
+Atlas UI 3 ships on a **monthly cadence**. During the last week of each calendar month the `release-cut` workflow opens a draft release PR from a new `release/YYYY.MM` branch, bumps `atlas/version.py` and `pyproject.toml`, and finalizes the `CHANGELOG.md` section for that release. A maintainer (the release captain) runs the smoke test, pushes a `vX.Y.Z` tag, and publishes — the `release-cut` workflow itself never tags or publishes.
 
 The full runbook — branch strategy, versioning (SemVer), stabilization window, hotfix flow, rollback — lives in **[docs/developer/release-process.md](./docs/developer/release-process.md)**. Published versions land on [PyPI](https://pypi.org/project/atlas-chat/) and as container images on Quay.io.
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -1,6 +1,6 @@
 # Release Process
 
-Last updated: 2026-04-22
+Last updated: 2026-04-23
 
 This document is the canonical runbook for cutting a release of Atlas UI 3.
 It covers both the **monthly release cadence** and **hotfix releases**. If
@@ -22,13 +22,32 @@ The model is small and deliberately boring:
 - **`release/YYYY.MM`** is cut from `main` during the last week of each
   month. It is the stabilization branch for that month's release. The
   release branch is frozen to bug fixes only until the tag is pushed.
-- **`vX.Y.Z`** is the tag that ships. Pushing a `v*.*.*` tag triggers
-  `pypi-publish.yml` (on GitHub Release) and `quay-publish.yml` (on tag
-  push). There is no other way to publish.
+- **`vX.Y.Z`** is the tag that ships. Publishing a GitHub Release (created
+  from a `v*.*.*` tag) triggers `pypi-publish.yml`; pushing a `v*.*.*` tag
+  triggers `quay-publish.yml`. This is the intended release path.
 
 Automation handles the mechanical parts of cutting the branch; humans
 make the go/no-go call, run the smoke tests, and push the tag. See
 [Guardrails](#guardrails) for what automation will and will not do.
+
+### Other publish paths (non-release)
+
+Two publish paths exist outside the tag-driven release flow. Both are
+preserved deliberately, but they should not be used to ship a version
+to end users:
+
+- **`quay-publish.yml` also fires on `push` to `main`, `develop`, and
+  `quay`.** Every merge to `main` builds and pushes a container image
+  tagged with the branch name and commit SHA. Those images are for
+  continuous smoke-testing, not for external consumption. The
+  `X.Y.Z` and `X.Y` semver tags only appear on a `v*.*.*` tag push.
+- **`pypi-publish.yml` exposes a `workflow_dispatch` with a `target`
+  input** (`testpypi` or `pypi`). This is an emergency escape hatch to
+  re-publish the current `main` build if the tag-driven run failed and
+  the tag cannot be recreated. Using `target: pypi` publishes to
+  production PyPI immediately — only maintainers should run it, and only
+  as a last resort. Prefer cutting a patch release via the hotfix flow
+  over reaching for this lever.
 
 ### Versioning
 
@@ -92,6 +111,13 @@ run), use **Actions → Release: cut monthly branch → Run workflow**.
 You can override the computed version with the `version` input, and
 `dry_run: true` prints the plan without pushing anything.
 
+If the release branch was pushed but the PR creation failed (network
+blip, permission hiccup), rerun the workflow. It detects the existing
+branch, sees no open PR, and takes the **recovery path**: it opens a
+draft PR against the existing branch without touching any files. The
+recovery PR body is flagged with a banner so the captain knows to
+verify the inferred metadata.
+
 #### 2. Release captain takes ownership
 
 A maintainer claims the draft PR (self-assign) and becomes the
@@ -124,7 +150,35 @@ git push
 Add the cherry-pick under the current release's CHANGELOG section on
 the release branch.
 
-#### 4. Pre-tag checklist
+#### 4. Kicking CI on the release PR
+
+The release captain must confirm `CI/CD Pipeline` and `Security Checks`
+are green on the release PR before tagging. Which path produces those
+checks depends on how the PR was opened:
+
+- **`RELEASE_PAT` is configured** (recommended). The `release-cut`
+  workflow uses the PAT to push the branch and open the PR, so the
+  `pull_request` event fires normally and both workflows run without
+  any manual kick.
+- **`RELEASE_PAT` is not configured.** The workflow falls back to the
+  default `GITHUB_TOKEN`. GitHub deliberately suppresses workflow
+  triggers for actions taken with `GITHUB_TOKEN`, so the release PR
+  opens with no CI runs attached. The captain must kick CI manually:
+  1. Close and immediately reopen the PR (simplest), **or**
+  2. Push any commit to the release branch from a personal account
+     (e.g., an empty `git commit --allow-empty -m "ci: kick"` then
+     `git push`). The resulting `synchronize` event triggers both
+     workflows.
+
+  The release PR body is pre-populated with a `CI kick required`
+  banner when this fallback is in effect.
+
+> **One-time setup**: to enable the PAT path, a maintainer creates a
+> GitHub PAT (classic, scope `repo` + `workflow`) or a fine-grained
+> token with `Contents: write`, `Pull requests: write`, and `Actions:
+> write`, then stores it as the `RELEASE_PAT` repository secret.
+
+#### 5. Pre-tag checklist
 
 Before tagging, the release captain completes every item on the
 checklist embedded in the release PR (see
@@ -138,7 +192,7 @@ The critical items:
       [Smoke test](#smoke-test) below).
 - [ ] No known P0/P1 bugs filed against the release branch.
 
-#### 5. Tag and publish
+#### 6. Tag and publish
 
 When the checklist is green:
 
@@ -151,13 +205,34 @@ git tag -a vX.Y.Z -m "Atlas UI 3 vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-Then create a GitHub Release from that tag using the web UI or:
+Then create a GitHub Release from that tag. The easiest path is the
+web UI (**Releases → Draft a new release → pick the tag → paste the
+`## [X.Y.Z] - YYYY-MM-DD` section of `CHANGELOG.md` as the body**).
+
+To do it from the CLI, extract the current release's CHANGELOG section
+into a scratch file first — do not try to inline it with process
+substitution, it is fragile and does not handle the first-ever release
+(which has no following `## [` to delimit the section):
 
 ```bash
-gh release create vX.Y.Z \
-  --title "vX.Y.Z" \
-  --notes-file <(awk '/^## \[X\.Y\.Z\]/,/^## \[/' CHANGELOG.md | sed '$d') \
-  --target release/YYYY.MM
+# Set V to the bare version once, and let the script do the extraction.
+V=X.Y.Z
+python3 - "$V" > /tmp/release-notes.md <<'PY'
+import re, sys, pathlib
+version = sys.argv[1]
+text = pathlib.Path("CHANGELOG.md").read_text()
+# Grab the block starting at `## [<version>]` up to the next `## [` or EOF.
+m = re.search(rf'(^## \[{re.escape(version)}\][^\n]*\n.*?)(?=^## \[|\Z)',
+              text, flags=re.MULTILINE | re.DOTALL)
+if not m:
+    sys.exit(f"No `## [{version}]` section in CHANGELOG.md")
+sys.stdout.write(m.group(1).rstrip() + "\n")
+PY
+
+gh release create "v$V" \
+  --title "v$V" \
+  --notes-file /tmp/release-notes.md \
+  --target "release/$(date -u +%Y.%m)"
 ```
 
 Publishing a GitHub Release triggers `pypi-publish.yml`. Pushing the
@@ -167,7 +242,7 @@ Actions tab and confirm:
 - `atlas-chat X.Y.Z` is visible on <https://pypi.org/project/atlas-chat/>.
 - `quay.io/<namespace>/atlas-ui-3:X.Y.Z` and `:X.Y` tags exist.
 
-#### 6. Carry the bump back to main
+#### 7. Carry the bump back to main
 
 Open a PR merging `release/YYYY.MM` into `main`. This carries the
 version bump commit and any hotfix cherry-picks that did not originate
@@ -262,8 +337,8 @@ image, build locally from the release branch using `podman build`.
 
 PyPI releases cannot be overwritten. If a release is broken:
 
-1. **Yank** the bad version from PyPI with `twine upload --skip-existing`
-   cannot help here; use the PyPI web UI → project → Manage → Yank.
+1. **Yank the bad version from PyPI.** There is no CLI yank — `twine`
+   only uploads. Use the PyPI web UI → project → Manage → Yank.
    Yanking keeps existing installs working but hides the version from
    `pip install atlas-chat` resolution.
 2. Cut a patch release (`X.Y.(Z+1)`) using the hotfix flow above. This
@@ -295,6 +370,15 @@ The `release-cut.yml` workflow will **never**:
 What automation *does* do: cuts the branch, bumps version files,
 reshapes `CHANGELOG.md`, and opens a draft PR with the checklist. Every
 step from "run smoke tests" forward is manual and requires a human.
+
+The workflow is idempotent with a recovery path:
+
+- If `release/YYYY.MM` exists **with** an open PR, the run is a no-op.
+- If `release/YYYY.MM` exists **without** an open PR (e.g., a prior run
+  pushed the branch but `gh pr create` failed), the next run takes the
+  recovery path: it reads version metadata from the branch tip, builds
+  the PR body, and opens a draft PR. It does not rewrite the branch.
+- If the branch does not exist, the run does the full cut.
 
 If you need to override automation (off-cycle release, custom version,
 etc.), use the workflow's `workflow_dispatch` inputs. Use `dry_run:
@@ -332,8 +416,8 @@ when one is made.
 ## Related files
 
 - [.github/workflows/release-cut.yml](../../.github/workflows/release-cut.yml) — the cron automation
-- [.github/workflows/pypi-publish.yml](../../.github/workflows/pypi-publish.yml) — triggers on GitHub Release
-- [.github/workflows/quay-publish.yml](../../.github/workflows/quay-publish.yml) — triggers on `v*.*.*` tag push
+- [.github/workflows/pypi-publish.yml](../../.github/workflows/pypi-publish.yml) — publishes on GitHub Release; also has a `workflow_dispatch` escape hatch
+- [.github/workflows/quay-publish.yml](../../.github/workflows/quay-publish.yml) — publishes semver-tagged images on `v*.*.*` tag push, and branch-named images on push to `main`/`develop`/`quay`
 - [.github/release-checklist.md](../../.github/release-checklist.md) — PR body used by automation
 - [CHANGELOG.md](../../CHANGELOG.md) — format contract for release notes
 - [AGENTS.md](../../AGENTS.md) — version-bump and changelog conventions for contributors


### PR DESCRIPTION
## Summary

Adds a practical, low-ceremony monthly release process for Atlas UI 3 — both the docs humans read and the GitHub Actions cron that does the mechanical cut work.

- **Runbook** at `docs/developer/release-process.md`: cadence, branch strategy (`release/YYYY.MM`), SemVer policy, stabilization window, hotfix flow, smoke test, rollback, and open policy questions for maintainer decision.
- **Automation** at `.github/workflows/release-cut.yml`: cron fires on day 22 at 14:00 UTC. It creates `release/YYYY.MM` from `main`, bumps `atlas/version.py` + `pyproject.toml` (minor by default), rewrites `CHANGELOG.md` (`[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` + fresh empty Unreleased), and opens a **draft** PR populated from the reusable checklist. Idempotent (no-op if the branch exists). Has `workflow_dispatch` with `version` override and `dry_run`. Guardrailed so scheduled runs only fire on the canonical repo and the workflow never pushes tags, never creates non-draft PRs, and never publishes.
- **Checklist template** at `.github/release-checklist.md`: the PR body used by the workflow — one checklist per release with the smoke-test + publish + post-publish gates spelled out.
- README gets a short Releases section pointing to the runbook; AGENTS.md gets a note that changelog entries go under `[Unreleased]` and that the monthly automation owns the renaming; developer docs index picks up the new page.

Does not change any publish workflows (`pypi-publish.yml`, `quay-publish.yml`) — both continue to trigger on tag push / GitHub Release as they do today. A human pushing `vX.Y.Z` is the only thing that publishes.

## Open policy questions (documented in the runbook)

Tagged in `docs/developer/release-process.md` under "Open policy decisions" so a maintainer can file follow-up PRs:

1. SemVer vs CalVer (recommendation: keep SemVer until 1.0).
2. Release captain rotation mechanism.
3. Branch protection rules on `release/*`.
4. Announcement channel for new releases.
5. Supported-versions / security-patch policy.

## Further recommendations (not in this PR)

Practical additions that would strengthen the process once the core flow lands; happy to do any of these in follow-ups:

- **PR validation**: a small CI check that any PR touching `atlas/`, `frontend/src/`, or `docs/` also adds a line under `## [Unreleased]` in `CHANGELOG.md`. Prevents empty monthly releases.
- **Branch protection**: require `CI/CD Pipeline` + `Security Checks` green + 1 review on merges into `release/*` and `main`. Repo settings, not code.
- **Auto-generated release notes**: call `gh release create --generate-notes` as a starting point and diff against the CHANGELOG section so the captain notices drift.
- **Release retrospective doc template** under `docs/planning/` for tracking what went sideways each month.
- **Dependabot alignment**: the release branch should not accept Dependabot updates during stabilization — either adjust `dependabot.yml` or let branch protection handle it.

## Test plan

- [x] YAML parses (`yaml.safe_load`).
- [x] Dry-run the version-bump Python against the real `atlas/version.py`, `pyproject.toml`, and `CHANGELOG.md` on `main`. `0.1.5 → 0.2.0` produces the expected diffs and preserves the blank line between the new heading and the first entry.
- [x] PR body template substitutes with no leftover `{{...}}` placeholders.
- [ ] Run the workflow via `workflow_dispatch` with `dry_run: true` once merged (or cherry-picked to a throwaway branch first) to validate CI surface area.
- [ ] Run a real cut on day 22 and walk the release captain through the checklist end-to-end.

## Guardrails

- Workflow is `draft` PR only — no tag push, no publish.
- Scheduled runs gated on `github.repository == 'sandialabs/atlas-ui-3'` (won't fire on forks).
- Idempotent: if `release/YYYY.MM` already exists on origin, the run is a no-op.
- `dry_run: true` prints the plan and stops before committing or opening a PR.

## What still needs a human

- Tagging `vX.Y.Z` on the release branch (manual — triggers `pypi-publish.yml` + `quay-publish.yml`).
- Smoke test before tagging.
- Merging the release PR back to `main` after publishing.
- The open policy questions above.