### PR TITLE
fix(mcp): seed task-forbidden cache from tools/list and detect immediate-error fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #557 - 2026-04-22
+- MCP task-augmented execution fixes: discovery-time seeding of task-forbidden
+  cache from per-tool execution.taskSupport metadata (SEP-1686), and runtime
+  fallback detection for immediate error results that don't raise exceptions.
+
 ### PR #555 - 2026-04-23
 - Monthly release process + cron automation: `docs/developer/release-process.md`
   runbook, `.github/workflows/release-cut.yml` scheduled cut (day 22, 14:00

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -1184,17 +1184,20 @@ class MCPToolManager:
                     'tools': tools,
                     'config': self.servers_config[server_name]
                 }
-                # Pre-seed the per-tool task-forbidden cache from the
-                # discovered metadata. The MCP spec (SEP-1686) lets each tool
-                # advertise execution.taskSupport in tools/list; when set to
-                # "forbidden" (or absent — "forbidden" is the spec default)
-                # we should never attempt task=True for it. This avoids the
-                # wasted round-trip + error-result that the runtime fallback
-                # handles. Only "optional" or "required" leaves us willing to
-                # try task mode for a given tool.
+                # Rebuild the per-tool task-forbidden cache for this server
+                # from the freshly discovered metadata. Drop any stale entries
+                # first so a server upgrade that flips a tool from "forbidden"
+                # to "optional"/"required" takes effect on next reload without
+                # a process restart. Per MCP SEP-1686, an absent taskSupport
+                # value defaults to "forbidden"; only "optional" or "required"
+                # leaves us willing to try task mode for a given tool.
+                self._tool_task_forbidden = {
+                    entry for entry in self._tool_task_forbidden
+                    if entry[0] != server_name
+                }
                 for tool in tools:
                     mode = self._discover_task_support_mode(tool)
-                    if mode not in ("optional", "required"):
+                    if mode in ("forbidden", None):
                         self._tool_task_forbidden.add((server_name, tool.name))
                 logger.debug("Stored %d tools for %s", len(tools), safe_server_name)
                 return server_data

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 LogCallback = Callable[[str, str, str, Dict[str, Any]], Awaitable[None]]
 
 
+_TASK_FORBIDDEN_MARKER = "does not support task-augmented execution"
+
+
 def _is_task_forbidden_error(exc: BaseException) -> bool:
     """Return True when an MCP call failed because the specific tool refuses
     task-augmented execution (fastmcp `tasks.mode="forbidden"`).
@@ -37,7 +40,28 @@ def _is_task_forbidden_error(exc: BaseException) -> bool:
     (see fastmcp/server/tasks/routing.py). We match on the message text
     because the concrete exception class varies across fastmcp versions.
     """
-    return "does not support task-augmented execution" in str(exc)
+    return _TASK_FORBIDDEN_MARKER in str(exc)
+
+
+def _is_task_forbidden_result(result: Any) -> bool:
+    """Return True when a CallToolResult-shaped object carries the
+    task-forbidden marker as an error.
+
+    fastmcp does not always raise on this condition: when the server-side
+    McpError is wrapped as a ToolError, the low-level MCP handler converts
+    it to a CallToolResult with isError=True instead of propagating an
+    exception. The client's _call_tool_as_task then returns a ToolTask whose
+    immediate_result is that error result, so the call site sees no
+    exception and our fallback never runs.
+    """
+    if not getattr(result, "is_error", False):
+        return False
+    content = getattr(result, "content", None) or []
+    for block in content:
+        text = getattr(block, "text", "") or ""
+        if _TASK_FORBIDDEN_MARKER in text:
+            return True
+    return False
 
 
 _SESSION_TERMINATED_MARKERS = ("session terminated", "session not found", "invalid session id")
@@ -1160,6 +1184,18 @@ class MCPToolManager:
                     'tools': tools,
                     'config': self.servers_config[server_name]
                 }
+                # Pre-seed the per-tool task-forbidden cache from the
+                # discovered metadata. The MCP spec (SEP-1686) lets each tool
+                # advertise execution.taskSupport in tools/list; when set to
+                # "forbidden" (or absent — "forbidden" is the spec default)
+                # we should never attempt task=True for it. This avoids the
+                # wasted round-trip + error-result that the runtime fallback
+                # handles. Only "optional" or "required" leaves us willing to
+                # try task mode for a given tool.
+                for tool in tools:
+                    mode = self._discover_task_support_mode(tool)
+                    if mode not in ("optional", "required"):
+                        self._tool_task_forbidden.add((server_name, tool.name))
                 logger.debug("Stored %d tools for %s", len(tools), safe_server_name)
                 return server_data
         except Exception as e:
@@ -1697,6 +1733,23 @@ class MCPToolManager:
 
         return routing
 
+    @staticmethod
+    def _discover_task_support_mode(tool: Any) -> Optional[str]:
+        """Read the per-tool taskSupport mode from a discovered MCP Tool.
+
+        Returns "required", "optional", "forbidden", or None when the tool
+        doesn't expose execution metadata. Per MCP SEP-1686, an absent value
+        defaults to "forbidden" — callers treat None the same as "forbidden"
+        for the purpose of skipping task-mode attempts.
+        """
+        execution = getattr(tool, "execution", None)
+        if execution is None:
+            return None
+        mode = getattr(execution, "taskSupport", None)
+        if mode is None:
+            return None
+        return getattr(mode, "value", mode)
+
     def _supports_tasks(self, server_name: str, client: Any) -> bool:
         """Check if a server supports background tasks (cached)."""
         if server_name in self._server_task_support:
@@ -1851,6 +1904,22 @@ class MCPToolManager:
             if use_tasks:
                 if tool_task.returned_immediately:
                     result = await tool_task.result()
+                    # fastmcp's graceful-degradation path does not raise when
+                    # the server refuses task mode mid-request: the McpError
+                    # is wrapped as a ToolError on the server, the low-level
+                    # handler converts it to CallToolResult(isError=True),
+                    # and _call_tool_as_task returns it as an immediate
+                    # result. Detect that here and fall back to sync.
+                    if _is_task_forbidden_result(result):
+                        logger.info(
+                            "Tool %s on %s returned task-forbidden as an "
+                            "immediate error result; falling back to "
+                            "synchronous call and caching the decision.",
+                            sanitize_for_logging(tool_name),
+                            sanitize_for_logging(server_name),
+                        )
+                        self._tool_task_forbidden.add((server_name, tool_name))
+                        use_tasks = False
                 else:
                     try:
                         await asyncio.wait_for(

--- a/atlas/tests/test_adaptive_task_polling.py
+++ b/atlas/tests/test_adaptive_task_polling.py
@@ -301,3 +301,144 @@ class TestTaskForbiddenFallback:
 
         # Did not poison the cache
         assert ("srv", "evaluate") not in manager._tool_task_forbidden
+
+    @pytest.mark.asyncio
+    async def test_task_forbidden_as_immediate_error_result_falls_back_to_sync(self, manager):
+        """fastmcp's real behavior: when a tool refuses task mode, the
+        server-side McpError is wrapped as ToolError and converted to a
+        CallToolResult(isError=True). _call_tool_as_task returns this as a
+        ToolTask with returned_immediately=True. The manager must detect
+        this, cache the decision, and retry without task mode."""
+        mock_client = AsyncMock()
+
+        caps = MagicMock()
+        caps.tasks = MagicMock()
+        init_result = MagicMock()
+        init_result.capabilities = caps
+        mock_client.initialize_result = init_result
+
+        # Immediate error result mirroring fastmcp's graceful-degradation path
+        forbidden_result = MagicMock()
+        forbidden_result.is_error = True
+        forbidden_result.content = [MagicMock(
+            type="text",
+            text=(
+                "Error calling tool 'evaluate': "
+                "FunctionTool 'tool:evaluate@' does not support task-augmented execution"
+            ),
+        )]
+
+        forbidden_task = MagicMock()
+        forbidden_task.returned_immediately = True
+        forbidden_task.result = AsyncMock(return_value=forbidden_result)
+
+        # Sync-mode result the fallback should return
+        sync_result = MagicMock()
+        sync_result.is_error = False
+        sync_result.content = [MagicMock(type="text", text="42")]
+        sync_result.structured_content = None
+        sync_result.data = None
+
+        call_history = []
+
+        async def fake_call_tool(tool_name, arguments, **kwargs):
+            call_history.append(kwargs)
+            if kwargs.get("task") is True:
+                return forbidden_task
+            return sync_result
+
+        mock_client.call_tool = AsyncMock(side_effect=fake_call_tool)
+
+        mock_session = MagicMock(spec=ManagedSession)
+        mock_session.client = mock_client
+        manager._session_manager.acquire = AsyncMock(return_value=mock_session)
+
+        manager.clients["srv"] = mock_client
+        manager.servers_config["srv"] = {}
+
+        result = await manager.call_tool(
+            "srv", "evaluate", {"x": 1},
+            conversation_id="conv-1",
+            meta={"tool_call_id": "tc-1"},
+        )
+
+        assert result is sync_result
+        assert call_history[0].get("task") is True
+        assert call_history[1].get("task") is not True
+        assert ("srv", "evaluate") in manager._tool_task_forbidden
+
+
+class TestTaskSupportDiscoverySeed:
+    """SEP-1686 lets tools advertise execution.taskSupport in tools/list.
+    The manager should pre-seed _tool_task_forbidden from that metadata so
+    forbidden tools never get a wasted task=True attempt at runtime."""
+
+    @pytest.mark.asyncio
+    async def test_discovery_seeds_forbidden_tools_and_skips_optional(self, manager):
+        # Three tools: forbidden, optional, and one with no execution metadata
+        # (per spec, absent → "forbidden")
+        forbidden_tool = MagicMock()
+        forbidden_tool.name = "fast_lookup"
+        forbidden_tool.execution = MagicMock(taskSupport="forbidden")
+
+        optional_tool = MagicMock()
+        optional_tool.name = "search_index"
+        optional_tool.execution = MagicMock(taskSupport="optional")
+
+        unspecified_tool = MagicMock()
+        unspecified_tool.name = "legacy_tool"
+        unspecified_tool.execution = None
+
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(
+            return_value=[forbidden_tool, optional_tool, unspecified_tool]
+        )
+
+        manager.servers_config["srv"] = {}
+        await manager._discover_tools_for_server("srv", mock_client)
+
+        assert ("srv", "fast_lookup") in manager._tool_task_forbidden
+        assert ("srv", "legacy_tool") in manager._tool_task_forbidden
+        assert ("srv", "search_index") not in manager._tool_task_forbidden
+
+    @pytest.mark.asyncio
+    async def test_seeded_forbidden_tool_skips_task_mode_at_call_time(self, manager):
+        """End-to-end: discovery marks a tool as forbidden, then call_tool
+        must take the sync path on the very first call."""
+        forbidden_tool = MagicMock()
+        forbidden_tool.name = "markdown_to_pptx"
+        forbidden_tool.execution = MagicMock(taskSupport="forbidden")
+
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=[forbidden_tool])
+
+        # Server *does* advertise overall task support — only this tool opts out
+        caps = MagicMock()
+        caps.tasks = MagicMock()
+        init_result = MagicMock()
+        init_result.capabilities = caps
+        mock_client.initialize_result = init_result
+
+        sync_result = MagicMock()
+        sync_result.is_error = False
+        sync_result.content = [MagicMock(type="text", text="ok")]
+        sync_result.structured_content = None
+        sync_result.data = None
+        mock_client.call_tool = AsyncMock(return_value=sync_result)
+
+        manager.servers_config["srv"] = {}
+        await manager._discover_tools_for_server("srv", mock_client)
+
+        mock_session = MagicMock(spec=ManagedSession)
+        mock_session.client = mock_client
+        manager._session_manager.acquire = AsyncMock(return_value=mock_session)
+        manager.clients["srv"] = mock_client
+
+        await manager.call_tool(
+            "srv", "markdown_to_pptx", {},
+            conversation_id="conv-1",
+        )
+
+        # Single call, sync mode — no wasted task=True round-trip
+        assert mock_client.call_tool.call_count == 1
+        assert mock_client.call_tool.call_args.kwargs.get("task") is not True

--- a/atlas/tests/test_adaptive_task_polling.py
+++ b/atlas/tests/test_adaptive_task_polling.py
@@ -374,9 +374,9 @@ class TestTaskSupportDiscoverySeed:
     forbidden tools never get a wasted task=True attempt at runtime."""
 
     @pytest.mark.asyncio
-    async def test_discovery_seeds_forbidden_tools_and_skips_optional(self, manager):
-        # Three tools: forbidden, optional, and one with no execution metadata
-        # (per spec, absent → "forbidden")
+    async def test_discovery_seeds_forbidden_tools_and_skips_task_capable(self, manager):
+        # Four tools: forbidden, optional, required, and one with no
+        # execution metadata (per spec, absent → "forbidden")
         forbidden_tool = MagicMock()
         forbidden_tool.name = "fast_lookup"
         forbidden_tool.execution = MagicMock(taskSupport="forbidden")
@@ -385,13 +385,17 @@ class TestTaskSupportDiscoverySeed:
         optional_tool.name = "search_index"
         optional_tool.execution = MagicMock(taskSupport="optional")
 
+        required_tool = MagicMock()
+        required_tool.name = "build_project"
+        required_tool.execution = MagicMock(taskSupport="required")
+
         unspecified_tool = MagicMock()
         unspecified_tool.name = "legacy_tool"
         unspecified_tool.execution = None
 
         mock_client = AsyncMock()
         mock_client.list_tools = AsyncMock(
-            return_value=[forbidden_tool, optional_tool, unspecified_tool]
+            return_value=[forbidden_tool, optional_tool, required_tool, unspecified_tool]
         )
 
         manager.servers_config["srv"] = {}
@@ -400,6 +404,36 @@ class TestTaskSupportDiscoverySeed:
         assert ("srv", "fast_lookup") in manager._tool_task_forbidden
         assert ("srv", "legacy_tool") in manager._tool_task_forbidden
         assert ("srv", "search_index") not in manager._tool_task_forbidden
+        assert ("srv", "build_project") not in manager._tool_task_forbidden
+
+    @pytest.mark.asyncio
+    async def test_rediscovery_drops_stale_forbidden_entries(self, manager):
+        """A server upgrade that flips a tool from forbidden → optional must
+        take effect on the next discovery — the stale forbidden entry is
+        dropped, not retained until process restart."""
+        v1_tool = MagicMock()
+        v1_tool.name = "evolving_tool"
+        v1_tool.execution = MagicMock(taskSupport="forbidden")
+
+        mock_client = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=[v1_tool])
+
+        manager.servers_config["srv"] = {}
+        await manager._discover_tools_for_server("srv", mock_client)
+        assert ("srv", "evolving_tool") in manager._tool_task_forbidden
+
+        # Seed a forbidden entry from a different server — must survive
+        manager._tool_task_forbidden.add(("other_srv", "other_tool"))
+
+        v2_tool = MagicMock()
+        v2_tool.name = "evolving_tool"
+        v2_tool.execution = MagicMock(taskSupport="optional")
+        mock_client.list_tools = AsyncMock(return_value=[v2_tool])
+
+        await manager._discover_tools_for_server("srv", mock_client)
+
+        assert ("srv", "evolving_tool") not in manager._tool_task_forbidden
+        assert ("other_srv", "other_tool") in manager._tool_task_forbidden
 
     @pytest.mark.asyncio
     async def test_seeded_forbidden_tool_skips_task_mode_at_call_time(self, manager):


### PR DESCRIPTION
## Summary

Fixes two bugs that caused tools declining task-augmented execution (e.g. `pptx_generator.markdown_to_pptx`) to return errors like `FunctionTool 'tool:markdown_to_pptx@' does not support task-augmented execution` straight to the LLM.

- **Discovery-time seeding**: Atlas only checked the *server-level* `capabilities.tasks` flag and assumed every tool on a task-capable server could accept `task=True`. Per MCP SEP-1686, each tool advertises `execution.taskSupport` (`required` / `optional` / `forbidden`, default `forbidden`) in `tools/list`. We now read it during `_discover_tools_for_server` and seed `_tool_task_forbidden` for anything not `optional` or `required`. Forbidden tools skip task mode on the very first call — no wasted round-trip.
- **Runtime fallback for graceful-degradation path**: the existing fallback only fired on a raised exception, but fastmcp wraps the server-side `McpError` as a `ToolError`, the low-level MCP handler converts it to `CallToolResult(isError=True)`, and `_call_tool_as_task` returns it as a `ToolTask`'s `immediate_result`. No exception was ever raised, so the fallback never triggered. Now we inspect the immediate result for the task-forbidden marker after `returned_immediately`, cache the decision, and fall through to the existing sync path.

The runtime check stays as a safety net for misbehaving servers that don't advertise per-tool metadata correctly.

## Test plan

- [x] `pytest atlas/tests/test_adaptive_task_polling.py` — 10 passing (4 new)
- [ ] Trigger `pptx_generator_markdown_to_pptx` through the chat UI and confirm the presentation generates successfully on the first call (no error result returned to the LLM)
- [ ] Confirm tools that *do* support tasks (`taskSupport=optional`/`required`) still go through the adaptive polling path