### PR TITLE
fix(mcp): scope per-user HTTP clients per conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #559 - 2026-04-25
+- MCP cross-conversation isolation: cache FastMCP HTTP `Client` instances by
+  `(user_email, server_name, conversation_id)` so each conversation gets its
+  own MCP session ID and FastMCP nesting counter. Fixes the
+  "nesting counter should be 0" reconnect failure that surfaced after a
+  shared client's session task died, and isolates stateful HTTP servers
+  (e.g. the per-session `PrinterService`) across the same user's conversations.
+- `handle_reset_session` now releases the previous conversation's MCP
+  sessions and per-conversation HTTP clients before generating a new
+  `conversation_id` — previously each "New chat" click orphaned the old
+  `(user, server, old_conv_id)` cache entries and `MCPSessionManager` sessions.
+- `get_prompt` now mirrors `call_tool`'s auth routing on HTTP MCP servers
+  with `auth_type` of oauth/jwt/bearer/api_key: requests go through the
+  user's stored token instead of the admin/server-default token, and missing
+  tokens raise `AuthenticationRequiredException` with the OAuth start URL.
+- `_get_or_create_user_http_client` now requires a non-empty
+  `conversation_id` (a `None` value would alias every caller into one
+  shared cache slot, recreating the bug this cache exists to prevent).
+- Added integration-style tests using a faithful `FakeFastMCPClient` that
+  drives the real `MCPSessionManager` and reproduces the pre-fix nesting
+  counter failure mode, plus unit coverage for `release_sessions`'s
+  per-conversation eviction.
+
 ### PR #557 - 2026-04-22
 - MCP task-augmented execution fixes: discovery-time seeding of task-forbidden
   cache from per-tool execution.taskSupport metadata (SEP-1686), and runtime

--- a/atlas/application/chat/preprocessors/prompt_override_service.py
+++ b/atlas/application/chat/preprocessors/prompt_override_service.py
@@ -65,7 +65,11 @@ class PromptOverrideService:
                     meta["conversation_id"] = conversation_id
 
                 prompt_obj = await self.tool_manager.get_prompt(
-                    server, prompt_name, meta=meta if meta else None
+                    server,
+                    prompt_name,
+                    meta=meta if meta else None,
+                    user_email=user_email,
+                    conversation_id=conversation_id,
                 )
                 prompt_text = self._extract_prompt_text(prompt_obj)
 

--- a/atlas/application/chat/service.py
+++ b/atlas/application/chat/service.py
@@ -392,8 +392,25 @@ class ChatService:
         does not overwrite the previous one (session_id stays the
         same for the lifetime of the WebSocket connection).
         """
+        # Capture the old conversation_id before tearing down the session
+        # so we can release any MCP sessions/clients scoped to it.
+        old_session = await self.session_repository.get(session_id)
+        old_conv_id = old_session.context.get("conversation_id") if old_session else None
+
         # End the current session
         await self.end_session(session_id)
+
+        # Release MCP sessions and per-conversation clients for the old
+        # conversation. Without this, each reset orphans the
+        # (user, server, old_conv_id) entries in MCPSessionManager and
+        # MCPToolManager._user_clients (cache keys are per-conversation).
+        if old_conv_id:
+            release_sessions = getattr(self.tool_manager, "release_sessions", None)
+            if release_sessions is not None:
+                try:
+                    await release_sessions(old_conv_id, user_email=user_email)
+                except Exception as e:
+                    logger.debug("Error releasing MCP sessions on reset: %s", e)
 
         # Create a new session with a fresh conversation_id
         session = await self.create_session(session_id, user_email)

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -627,7 +627,9 @@ async def websocket_endpoint(websocket: WebSocket):
                     logger.info("Cancelling active chat task (reset_session)")
                     task.cancel()
 
-                # Handle session reset (use authenticated user from connection)
+                # Handle session reset (use authenticated user from connection).
+                # handle_reset_session itself releases the old conversation's
+                # MCP sessions before generating a new conversation_id.
                 response = await chat_service.handle_reset_session(
                     session_id=session_id,
                     user_email=user_email

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -2040,8 +2040,44 @@ class MCPToolManager:
         meta: Optional[Dict[str, Any]] = None,
         conversation_id: Optional[str] = None,
     ) -> Any:
-        """Get a specific prompt from an MCP server."""
-        if self._is_http_server(server_name) and user_email:
+        """Get a specific prompt from an MCP server.
+
+        Mirrors ``call_tool``'s auth routing: servers that declare an
+        ``auth_type`` of oauth/jwt/bearer/api_key route through
+        ``_get_user_client`` so the request is sent under the user's
+        stored token. Other HTTP servers fall through to the
+        per-conversation plain HTTP client.
+        """
+        if self._requires_user_auth(server_name):
+            if not user_email:
+                server_config = self.servers_config.get(server_name, {})
+                auth_type = server_config.get("auth_type", "oauth")
+                raise AuthenticationRequiredException(
+                    server_name=server_name,
+                    auth_type=auth_type,
+                    message=(
+                        f"Server '{server_name}' requires authentication "
+                        "but no user context."
+                    ),
+                    oauth_start_url=(
+                        f"/api/mcp/auth/{server_name}/oauth/start"
+                        if auth_type == "oauth" else None
+                    ),
+                )
+            client = await self._get_user_client(server_name, user_email, conversation_id)
+            if client is None:
+                server_config = self.servers_config.get(server_name, {})
+                auth_type = server_config.get("auth_type", "oauth")
+                raise AuthenticationRequiredException(
+                    server_name=server_name,
+                    auth_type=auth_type,
+                    message=f"Server '{server_name}' requires authentication.",
+                    oauth_start_url=(
+                        f"/api/mcp/auth/{server_name}/oauth/start"
+                        if auth_type == "oauth" else None
+                    ),
+                )
+        elif self._is_http_server(server_name) and user_email:
             client = await self._get_or_create_user_http_client(
                 server_name, user_email, conversation_id
             )

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -209,8 +209,17 @@ class MCPToolManager:
         # Get configured log level for filtering
         self._min_log_level = self._get_min_log_level()
 
-        # Per-user client cache for servers requiring user-specific authentication
-        # Key: (user_email, server_name), Value: FastMCP Client instance
+        # Per-user/per-conversation client cache.
+        #
+        # Key: (user_email_lower, server_name, conversation_id), Value: FastMCP Client.
+        #
+        # Keying by conversation_id (not just user) is required because the
+        # session manager opens persistent contexts per (conversation_id,
+        # server) and each open() increments FastMCP's internal nesting
+        # counter on the client. Sharing one client across conversations
+        # accumulates the counter; if the underlying session_task dies,
+        # FastMCP refuses to reconnect ("nesting counter should be 0 when
+        # starting new session, got N").
         self._user_clients: Dict[tuple, Client] = {}
         self._user_clients_lock = asyncio.Lock()
 
@@ -1521,12 +1530,17 @@ class MCPToolManager:
         self,
         server_name: str,
         user_email: str,
+        conversation_id: Optional[str] = None,
     ) -> Optional[Client]:
         """Get or create a user-specific client for servers requiring per-user auth.
 
         Args:
             server_name: Name of the MCP server
             user_email: User's email address
+            conversation_id: Conversation scope for the cached client. Each
+                conversation gets its own FastMCP Client so that persistent
+                MCP sessions opened by ``MCPSessionManager`` don't share
+                FastMCP's reentrant nesting counter across conversations.
 
         Returns:
             FastMCP Client configured with user's token, or None if no token available
@@ -1534,7 +1548,7 @@ class MCPToolManager:
         from atlas.modules.mcp_tools.token_storage import get_token_storage
 
         token_storage = get_token_storage()
-        cache_key = (user_email.lower(), server_name)
+        cache_key = (user_email.lower(), server_name, conversation_id)
 
         # Check cache first, but validate token is still valid
         async with self._user_clients_lock:
@@ -1625,32 +1639,48 @@ class MCPToolManager:
             return None
 
     async def _invalidate_user_client(self, user_email: str, server_name: str) -> None:
-        """Remove a user's cached client (e.g., when token is revoked)."""
-        cache_key = (user_email.lower(), server_name)
+        """Remove all cached clients for a user/server (e.g., when token is revoked).
+
+        Removes every entry matching ``(user_email, server_name, *)`` across
+        all conversations, since the cache key now includes conversation_id.
+        """
+        user_lc = user_email.lower()
         async with self._user_clients_lock:
-            if cache_key in self._user_clients:
-                del self._user_clients[cache_key]
-                logger.debug(f"Invalidated user client cache for server '{server_name}'")
+            keys_to_remove = [
+                k for k in self._user_clients
+                if k[0] == user_lc and k[1] == server_name
+            ]
+            for k in keys_to_remove:
+                del self._user_clients[k]
+            if keys_to_remove:
+                logger.debug(
+                    "Invalidated %d user client cache entry(s) for server '%s'",
+                    len(keys_to_remove), server_name,
+                )
 
     async def _get_or_create_user_http_client(
         self,
         server_name: str,
         user_email: str,
+        conversation_id: Optional[str] = None,
     ) -> Client:
-        """Get or create a per-user HTTP client for session isolation.
+        """Get or create a per-user/per-conversation HTTP client for session isolation.
 
         Unlike _get_user_client (which requires auth tokens), this creates
-        plain HTTP clients keyed by (user_email, server_name). Each user gets
-        their own MCP session ID, ensuring state isolation.
+        plain HTTP clients. Each (user, server, conversation) gets its own
+        FastMCP Client and therefore its own MCP session ID.
 
         Args:
             server_name: Name of the MCP server
             user_email: User's email address
+            conversation_id: Conversation scope for the client. Required to
+                avoid sharing one Client across multiple conversations of
+                the same user — see the comment on ``_user_clients`` for why.
 
         Returns:
-            FastMCP Client instance for this user+server pair
+            FastMCP Client instance for this (user, server, conversation) tuple
         """
-        cache_key = (user_email.lower(), server_name)
+        cache_key = (user_email.lower(), server_name, conversation_id)
 
         async with self._user_clients_lock:
             if cache_key in self._user_clients:
@@ -1686,23 +1716,28 @@ class MCPToolManager:
         """Release all MCP sessions for a conversation.
 
         Call this on WebSocket disconnect or conversation restore to clean up
-        persistent sessions held by the session manager. Also evicts per-user
-        HTTP clients for this user to prevent unbounded cache growth.
+        persistent sessions held by the session manager. Also evicts cached
+        FastMCP clients scoped to this (user, conversation) so the next
+        conversation on the same user gets fresh clients.
         """
         await self._session_manager.release_all(conversation_id)
 
-        # Evict per-user HTTP clients for this user to prevent unbounded growth
+        # Evict cached clients scoped to this conversation. With the new
+        # per-conversation cache key, only the current conversation's
+        # entries are removed; other conversations for the same user
+        # keep their clients alive.
         if user_email:
+            user_lc = user_email.lower()
             async with self._user_clients_lock:
                 keys_to_remove = [
                     k for k in self._user_clients
-                    if k[0] == user_email.lower()
+                    if k[0] == user_lc and k[2] == conversation_id
                 ]
                 for k in keys_to_remove:
                     del self._user_clients[k]
                 if keys_to_remove:
                     logger.debug(
-                        "Evicted %d per-user HTTP client(s) for conversation=%s",
+                        "Evicted %d per-conversation HTTP client(s) for conversation=%s",
                         len(keys_to_remove), conversation_id,
                     )
 
@@ -1813,7 +1848,7 @@ class MCPToolManager:
         if self._requires_user_auth(server_name):
             logger.debug(f"Server '{server_name}' requires user auth, user_email={user_email}")
             if user_email:
-                client = await self._get_user_client(server_name, user_email)
+                client = await self._get_user_client(server_name, user_email, conversation_id)
                 logger.debug(f"_get_user_client for '{server_name}' returned client: {client is not None}")
                 if client is None:
                     # Get auth type and build OAuth URL if applicable
@@ -1839,8 +1874,11 @@ class MCPToolManager:
                     oauth_start_url=f"/api/mcp/auth/{server_name}/oauth/start" if auth_type == "oauth" else None,
                 )
         elif self._is_http_server(server_name) and user_email:
-            # HTTP servers get per-user clients for session state isolation
-            client = await self._get_or_create_user_http_client(server_name, user_email)
+            # HTTP servers get per-user/per-conversation clients for session
+            # state isolation and to avoid FastMCP nesting-counter leaks.
+            client = await self._get_or_create_user_http_client(
+                server_name, user_email, conversation_id
+            )
         else:
             # STDIO servers use shared client (safe: BlockedStateStore prevents state use)
             if server_name not in self.clients:
@@ -2000,10 +2038,13 @@ class MCPToolManager:
         *,
         user_email: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
+        conversation_id: Optional[str] = None,
     ) -> Any:
         """Get a specific prompt from an MCP server."""
         if self._is_http_server(server_name) and user_email:
-            client = await self._get_or_create_user_http_client(server_name, user_email)
+            client = await self._get_or_create_user_http_client(
+                server_name, user_email, conversation_id
+            )
         elif server_name not in self.clients:
             raise ValueError(f"No client available for server: {server_name}")
         else:

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -1662,7 +1662,7 @@ class MCPToolManager:
         self,
         server_name: str,
         user_email: str,
-        conversation_id: Optional[str] = None,
+        conversation_id: str,
     ) -> Client:
         """Get or create a per-user/per-conversation HTTP client for session isolation.
 
@@ -1673,13 +1673,20 @@ class MCPToolManager:
         Args:
             server_name: Name of the MCP server
             user_email: User's email address
-            conversation_id: Conversation scope for the client. Required to
-                avoid sharing one Client across multiple conversations of
-                the same user — see the comment on ``_user_clients`` for why.
+            conversation_id: Conversation scope for the client. Required:
+                a None value would collapse every caller for the same
+                (user, server) into a single shared cache slot, recreating
+                the cross-conversation aliasing bug this caching layer
+                exists to prevent.
 
         Returns:
             FastMCP Client instance for this (user, server, conversation) tuple
         """
+        if not conversation_id:
+            raise ValueError(
+                "conversation_id is required for per-user HTTP client cache "
+                "(falsy values would alias unrelated conversations together)"
+            )
         cache_key = (user_email.lower(), server_name, conversation_id)
 
         async with self._user_clients_lock:

--- a/atlas/tests/test_chat_history.py
+++ b/atlas/tests/test_chat_history.py
@@ -880,6 +880,76 @@ class TestConversationSavedEvent:
         assert saved is not None
         assert len(saved["messages"]) == 2
 
+    @pytest.mark.asyncio
+    async def test_reset_releases_old_conversation_mcp_sessions(self, repo):
+        """Reset must release the OLD conversation_id's MCP sessions before
+        generating a new one. With per-conversation cache keys, skipping this
+        leaks (user, server, old_conv_id) entries on every "new chat" click.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+        from uuid import uuid4
+
+        from atlas.application.chat.service import ChatService
+
+        tool_manager = MagicMock()
+        tool_manager.release_sessions = AsyncMock()
+
+        service = ChatService(
+            llm=MagicMock(),
+            tool_manager=tool_manager,
+            conversation_repository=repo,
+        )
+
+        session_id = uuid4()
+        await service.create_session(session_id, "user@test.com")
+        session = await service.session_repository.get(session_id)
+        conv_id_before = session.context.get("conversation_id")
+        if not conv_id_before:
+            conv_id_before = "seeded-conv-1"
+            session.context["conversation_id"] = conv_id_before
+            await service.session_repository.update(session)
+
+        await service.handle_reset_session(session_id, "user@test.com")
+
+        tool_manager.release_sessions.assert_awaited_once_with(
+            conv_id_before, user_email="user@test.com"
+        )
+
+        # And the new session should have a fresh conversation_id distinct
+        # from the old one we just released.
+        session_after = await service.session_repository.get(session_id)
+        assert session_after.context.get("conversation_id") != conv_id_before
+
+    @pytest.mark.asyncio
+    async def test_reset_swallows_release_sessions_errors(self, repo):
+        """If release_sessions raises, reset still proceeds — cleanup is
+        best-effort, and a leak is preferable to a broken reset.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+        from uuid import uuid4
+
+        from atlas.application.chat.service import ChatService
+
+        tool_manager = MagicMock()
+        tool_manager.release_sessions = AsyncMock(side_effect=RuntimeError("boom"))
+
+        service = ChatService(
+            llm=MagicMock(),
+            tool_manager=tool_manager,
+            conversation_repository=repo,
+        )
+
+        session_id = uuid4()
+        await service.create_session(session_id, "user@test.com")
+        session = await service.session_repository.get(session_id)
+        if not session.context.get("conversation_id"):
+            session.context["conversation_id"] = "seeded-conv-2"
+            await service.session_repository.update(session)
+
+        # Must not raise even though release_sessions did.
+        result = await service.handle_reset_session(session_id, "user@test.com")
+        assert result["type"] == "session_reset"
+
 
 class TestConversationRoutes:
     """Test the REST API routes for conversation history."""

--- a/atlas/tests/test_mcp_client_auth.py
+++ b/atlas/tests/test_mcp_client_auth.py
@@ -280,16 +280,16 @@ class TestGetUserClient:
 
             # First call - token valid
             mock_token_storage.get_valid_token.return_value = mock_token
-            result1 = await manager._get_user_client("test-server", "user@example.com")
+            result1 = await manager._get_user_client("test-server", "user@example.com", "conv-1")
             assert result1 is mock_client
 
             # Second call - token expired (returns None)
             mock_token_storage.get_valid_token.return_value = None
-            result2 = await manager._get_user_client("test-server", "user@example.com")
+            result2 = await manager._get_user_client("test-server", "user@example.com", "conv-1")
 
             # Should return None and cache should be invalidated
             assert result2 is None
-            cache_key = ("user@example.com", "test-server")
+            cache_key = ("user@example.com", "test-server", "conv-1")
             assert cache_key not in manager._user_clients
 
 
@@ -305,16 +305,19 @@ class TestInvalidateUserClient:
 
         manager = MCPToolManager.__new__(MCPToolManager)
         manager._user_clients = {
-            ("user@example.com", "test-server"): MagicMock(),
-            ("other@example.com", "test-server"): MagicMock(),
+            ("user@example.com", "test-server", "conv-1"): MagicMock(),
+            ("user@example.com", "test-server", "conv-2"): MagicMock(),
+            ("other@example.com", "test-server", "conv-1"): MagicMock(),
         }
         manager._user_clients_lock = asyncio.Lock()
 
         await manager._invalidate_user_client("user@example.com", "test-server")
 
-        assert ("user@example.com", "test-server") not in manager._user_clients
+        # All conversation entries for the target user/server are removed
+        assert ("user@example.com", "test-server", "conv-1") not in manager._user_clients
+        assert ("user@example.com", "test-server", "conv-2") not in manager._user_clients
         # Other user's client should remain
-        assert ("other@example.com", "test-server") in manager._user_clients
+        assert ("other@example.com", "test-server", "conv-1") in manager._user_clients
 
     @pytest.mark.asyncio
     async def test_handles_missing_cache_entry(self):

--- a/atlas/tests/test_mcp_client_auth.py
+++ b/atlas/tests/test_mcp_client_auth.py
@@ -332,3 +332,156 @@ class TestInvalidateUserClient:
 
         # Should not raise
         await manager._invalidate_user_client("user@example.com", "test-server")
+
+
+class TestGetPromptAuthRouting:
+    """Tests that get_prompt mirrors call_tool's auth routing.
+
+    Pre-fix, get_prompt only checked _is_http_server and routed every HTTP
+    server through _get_or_create_user_http_client (admin/server-default
+    token). For servers with auth_type=oauth/jwt/bearer/api_key this caused
+    prompt fetches to run unauthenticated even though tool calls on the
+    same server ran as the user.
+    """
+
+    def _make_manager_for_auth_server(self, auth_type: str = "bearer"):
+        import asyncio
+
+        from atlas.modules.mcp_tools.client import MCPToolManager
+
+        manager = MCPToolManager.__new__(MCPToolManager)
+        manager.servers_config = {
+            "auth-server": {
+                "auth_type": auth_type,
+                "url": "http://auth-server.local",
+            },
+        }
+        manager.clients = {}
+        manager._user_clients = {}
+        manager._user_clients_lock = asyncio.Lock()
+        manager._create_log_handler = MagicMock(return_value=None)
+        manager._create_elicitation_handler = MagicMock(return_value=None)
+        manager._create_sampling_handler = MagicMock(return_value=None)
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_uses_user_client_for_auth_server(self):
+        """get_prompt on an auth-required HTTP server must go through
+        _get_user_client, not _get_or_create_user_http_client.
+        """
+        from unittest.mock import AsyncMock
+
+        manager = self._make_manager_for_auth_server("bearer")
+
+        user_client = MagicMock()
+        user_client.__aenter__ = AsyncMock(return_value=user_client)
+        user_client.__aexit__ = AsyncMock(return_value=None)
+        user_client.get_prompt = AsyncMock(return_value="prompt-text")
+
+        manager._get_user_client = AsyncMock(return_value=user_client)
+        manager._get_or_create_user_http_client = AsyncMock(
+            side_effect=AssertionError(
+                "auth-required server must not fall through to admin-token client"
+            )
+        )
+
+        result = await manager.get_prompt(
+            "auth-server",
+            "my_prompt",
+            user_email="alice@example.com",
+            conversation_id="conv-1",
+        )
+
+        assert result == "prompt-text"
+        manager._get_user_client.assert_awaited_once_with(
+            "auth-server", "alice@example.com", "conv-1",
+        )
+        manager._get_or_create_user_http_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_raises_when_no_user_token(self):
+        """Auth-required server with no stored token must raise
+        AuthenticationRequiredException, not silently fall back to admin auth.
+        """
+        from unittest.mock import AsyncMock
+
+        from atlas.modules.mcp_tools.token_storage import (
+            AuthenticationRequiredException,
+        )
+
+        manager = self._make_manager_for_auth_server("oauth")
+        manager._get_user_client = AsyncMock(return_value=None)
+        manager._get_or_create_user_http_client = AsyncMock(
+            side_effect=AssertionError("must not fall through on missing token")
+        )
+
+        with pytest.raises(AuthenticationRequiredException) as exc_info:
+            await manager.get_prompt(
+                "auth-server",
+                "my_prompt",
+                user_email="bob@example.com",
+                conversation_id="conv-2",
+            )
+
+        assert exc_info.value.server_name == "auth-server"
+        assert exc_info.value.auth_type == "oauth"
+        assert "/api/mcp/auth/auth-server/oauth/start" in (
+            exc_info.value.oauth_start_url or ""
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_raises_when_no_user_email(self):
+        """Auth-required server invoked without user_email must raise."""
+        from atlas.modules.mcp_tools.token_storage import (
+            AuthenticationRequiredException,
+        )
+
+        manager = self._make_manager_for_auth_server("jwt")
+
+        with pytest.raises(AuthenticationRequiredException):
+            await manager.get_prompt(
+                "auth-server",
+                "my_prompt",
+                user_email=None,
+                conversation_id="conv-3",
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_prompt_uses_http_client_for_unauthed_server(self):
+        """Plain HTTP server (no auth_type) with a user_email still routes
+        through the per-conversation HTTP client — unchanged behavior.
+        """
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        from atlas.modules.mcp_tools.client import MCPToolManager
+
+        manager = MCPToolManager.__new__(MCPToolManager)
+        manager.servers_config = {
+            "plain-http": {"url": "http://plain.local"},
+        }
+        manager.clients = {}
+        manager._user_clients = {}
+        manager._user_clients_lock = asyncio.Lock()
+        manager._create_log_handler = MagicMock(return_value=None)
+        manager._create_elicitation_handler = MagicMock(return_value=None)
+        manager._create_sampling_handler = MagicMock(return_value=None)
+
+        plain_client = MagicMock()
+        plain_client.__aenter__ = AsyncMock(return_value=plain_client)
+        plain_client.__aexit__ = AsyncMock(return_value=None)
+        plain_client.get_prompt = AsyncMock(return_value="ok")
+
+        manager._get_or_create_user_http_client = AsyncMock(return_value=plain_client)
+        manager._get_user_client = AsyncMock(
+            side_effect=AssertionError("non-auth server must not call _get_user_client")
+        )
+
+        result = await manager.get_prompt(
+            "plain-http",
+            "p",
+            user_email="alice@example.com",
+            conversation_id="conv-x",
+        )
+        assert result == "ok"
+        manager._get_or_create_user_http_client.assert_awaited_once()

--- a/atlas/tests/test_mcp_per_user_http_clients.py
+++ b/atlas/tests/test_mcp_per_user_http_clients.py
@@ -121,3 +121,82 @@ async def test_get_or_create_user_http_client_isolates_conversations(manager):
         )
         assert c1 is not c2
         assert MockClient.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_http_client_rejects_missing_conversation_id(manager):
+    """A falsy conversation_id would alias every caller for (user, server)
+    into one cache slot — exactly the cross-conversation aliasing bug this
+    cache exists to prevent. Surface that as an error rather than silently
+    sharing one Client.
+    """
+    manager.servers_config["state_server"] = {
+        "url": "http://127.0.0.1:8010/mcp",
+        "transport": "http",
+    }
+    for bad_value in (None, ""):
+        with pytest.raises(ValueError, match="conversation_id is required"):
+            await manager._get_or_create_user_http_client(
+                "state_server", "alice@test.com", bad_value
+            )
+
+
+# --- release_sessions tests ---
+
+
+@pytest.mark.asyncio
+async def test_release_sessions_evicts_only_target_conversation(manager):
+    """release_sessions must evict only entries scoped to the target
+    conversation_id, leaving other conversations for the same user
+    (and other users) intact.
+    """
+    other_user_client = MagicMock()
+    alice_conv1 = MagicMock()
+    alice_conv2 = MagicMock()
+    manager._user_clients = {
+        ("alice@test.com", "state_server", "conv-1"): alice_conv1,
+        ("alice@test.com", "state_server", "conv-2"): alice_conv2,
+        ("bob@test.com", "state_server", "conv-1"): other_user_client,
+    }
+
+    session_manager_release = MagicMock()
+
+    async def _async_release(_):
+        session_manager_release()
+
+    manager._session_manager = MagicMock()
+    manager._session_manager.release_all = _async_release
+
+    await manager.release_sessions("conv-1", user_email="alice@test.com")
+
+    # Alice's conv-1 evicted; her conv-2 and Bob's conv-1 survive.
+    assert ("alice@test.com", "state_server", "conv-1") not in manager._user_clients
+    assert ("alice@test.com", "state_server", "conv-2") in manager._user_clients
+    assert ("bob@test.com", "state_server", "conv-1") in manager._user_clients
+    session_manager_release.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_release_sessions_without_user_email_only_releases_session_manager(manager):
+    """Without user_email we cannot scope cache eviction safely, so we only
+    release the session manager entries for the conversation. The HTTP
+    client cache is left untouched (eviction will happen via the next
+    call's reuse, or when the user reconnects).
+    """
+    alice_conv1 = MagicMock()
+    manager._user_clients = {
+        ("alice@test.com", "state_server", "conv-1"): alice_conv1,
+    }
+    release_called_with = {}
+
+    async def _async_release(conv_id):
+        release_called_with["arg"] = conv_id
+
+    manager._session_manager = MagicMock()
+    manager._session_manager.release_all = _async_release
+
+    await manager.release_sessions("conv-1", user_email=None)
+
+    assert release_called_with["arg"] == "conv-1"
+    # Cache entry survives because we cannot scope to user safely.
+    assert ("alice@test.com", "state_server", "conv-1") in manager._user_clients

--- a/atlas/tests/test_mcp_per_user_http_clients.py
+++ b/atlas/tests/test_mcp_per_user_http_clients.py
@@ -61,7 +61,9 @@ async def test_get_or_create_user_http_client_creates_client(manager):
     with patch("atlas.modules.mcp_tools.client.Client") as MockClient:
         mock_instance = MagicMock()
         MockClient.return_value = mock_instance
-        client = await manager._get_or_create_user_http_client("state_server", "alice@test.com")
+        client = await manager._get_or_create_user_http_client(
+            "state_server", "alice@test.com", "conv-1"
+        )
         assert client is mock_instance
 
 
@@ -74,10 +76,14 @@ async def test_get_or_create_user_http_client_caches(manager):
     with patch("atlas.modules.mcp_tools.client.Client") as MockClient:
         mock_instance = MagicMock()
         MockClient.return_value = mock_instance
-        c1 = await manager._get_or_create_user_http_client("state_server", "alice@test.com")
-        c2 = await manager._get_or_create_user_http_client("state_server", "alice@test.com")
+        c1 = await manager._get_or_create_user_http_client(
+            "state_server", "alice@test.com", "conv-1"
+        )
+        c2 = await manager._get_or_create_user_http_client(
+            "state_server", "alice@test.com", "conv-1"
+        )
         assert c1 is c2
-        assert MockClient.call_count == 1  # Only created once
+        assert MockClient.call_count == 1  # Only created once for the same conversation
 
 
 @pytest.mark.asyncio
@@ -88,7 +94,30 @@ async def test_get_or_create_user_http_client_isolates_users(manager):
     }
     with patch("atlas.modules.mcp_tools.client.Client") as MockClient:
         MockClient.side_effect = [MagicMock(), MagicMock()]
-        c1 = await manager._get_or_create_user_http_client("state_server", "alice@test.com")
-        c2 = await manager._get_or_create_user_http_client("state_server", "bob@test.com")
+        c1 = await manager._get_or_create_user_http_client(
+            "state_server", "alice@test.com", "conv-1"
+        )
+        c2 = await manager._get_or_create_user_http_client(
+            "state_server", "bob@test.com", "conv-1"
+        )
+        assert c1 is not c2
+        assert MockClient.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_user_http_client_isolates_conversations(manager):
+    """Each conversation gets its own Client to keep FastMCP nesting counters separate."""
+    manager.servers_config["state_server"] = {
+        "url": "http://127.0.0.1:8010/mcp",
+        "transport": "http",
+    }
+    with patch("atlas.modules.mcp_tools.client.Client") as MockClient:
+        MockClient.side_effect = [MagicMock(), MagicMock()]
+        c1 = await manager._get_or_create_user_http_client(
+            "state_server", "alice@test.com", "conv-1"
+        )
+        c2 = await manager._get_or_create_user_http_client(
+            "state_server", "alice@test.com", "conv-2"
+        )
         assert c1 is not c2
         assert MockClient.call_count == 2

--- a/atlas/tests/test_mcp_session_isolation_integration.py
+++ b/atlas/tests/test_mcp_session_isolation_integration.py
@@ -1,0 +1,264 @@
+"""Integration-style tests for cross-conversation MCP session isolation.
+
+These tests use a FakeFastMCPClient that mimics the real ``fastmcp.Client``
+shape — supporting ``__aenter__`` / ``__aexit__`` and tracking a nesting
+counter the way FastMCP does internally — to exercise the actual
+``MCPSessionManager.acquire`` path that the production code goes through.
+
+The earlier mocked tests (``test_mcp_per_user_http_clients.py``) only assert
+that the cache key shape returns distinct ``MagicMock`` objects per
+conversation. They don't catch the original failure mode: that two
+conversations sharing one Client accumulate FastMCP's reentrant nesting
+counter, so when one conversation's session task dies the other can no
+longer reconnect.
+"""
+import asyncio
+
+import pytest
+
+from atlas.modules.mcp_tools.client import MCPToolManager
+from atlas.modules.mcp_tools.session_manager import MCPSessionManager
+
+
+class _NestingCounterError(RuntimeError):
+    """Mirrors the real FastMCP error on stale reentry."""
+
+
+class FakeFastMCPClient:
+    """A test double that approximates the lifecycle of fastmcp.Client.
+
+    Tracks an internal ``nesting`` counter that increments on
+    ``__aenter__`` and decrements on ``__aexit__``. If the underlying
+    transport has been killed (``simulate_disconnect``) and a caller
+    enters again without first exiting cleanly, we raise the same
+    error class FastMCP raises — that's the failure mode this PR fixes.
+    """
+
+    def __init__(self, label: str):
+        self.label = label
+        self.nesting = 0
+        self.max_nesting = 0
+        self._connected = True
+        self._disconnected_inside_session = False
+
+    async def __aenter__(self):
+        if self._disconnected_inside_session and self.nesting > 0:
+            raise _NestingCounterError(
+                f"nesting counter should be 0 when starting new session, "
+                f"got {self.nesting}"
+            )
+        self.nesting += 1
+        self.max_nesting = max(self.max_nesting, self.nesting)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.nesting = max(0, self.nesting - 1)
+        if self.nesting == 0:
+            # A clean full exit clears the simulated stale state.
+            self._disconnected_inside_session = False
+        return False
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def simulate_disconnect(self) -> None:
+        """Simulate the server-side session task dying mid-flight.
+
+        Clears the connection flag but leaves the nesting counter at
+        whatever its current value is — FastMCP's real behavior.
+        """
+        if self.nesting > 0:
+            self._disconnected_inside_session = True
+        self._connected = False
+
+    def simulate_recover(self) -> None:
+        """After the dead session is closed and a fresh one opens, the
+        underlying transport reconnects. Our fake just re-flips the flag."""
+        self._connected = True
+
+
+def _make_manager(client_factory) -> MCPToolManager:
+    """Build a minimal MCPToolManager wired to inject the given fake clients.
+
+    Patches _get_or_create_user_http_client to return clients produced by
+    the supplied factory, while leaving the real MCPSessionManager and the
+    real per-user-clients dict in place so we exercise actual behavior.
+    """
+    mgr = MCPToolManager.__new__(MCPToolManager)
+    mgr.servers_config = {
+        "state_server": {
+            "url": "http://state-server.local/mcp",
+            "transport": "http",
+        }
+    }
+    mgr.clients = {}
+    mgr._user_clients = {}
+    mgr._user_clients_lock = asyncio.Lock()
+    mgr._session_manager = MCPSessionManager()
+
+    async def fake_get_or_create(server_name, user_email, conversation_id):
+        if not conversation_id:
+            raise ValueError("conversation_id required")
+        cache_key = (user_email.lower(), server_name, conversation_id)
+        async with mgr._user_clients_lock:
+            existing = mgr._user_clients.get(cache_key)
+            if existing is not None:
+                return existing
+            new_client = client_factory(cache_key)
+            mgr._user_clients[cache_key] = new_client
+            return new_client
+
+    mgr._get_or_create_user_http_client = fake_get_or_create
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_two_conversations_get_independent_session_lifecycles():
+    """Each conversation acquires its own Client + ManagedSession; opening
+    a session for conv-2 must not bump conv-1's nesting counter (the bug
+    pre-fix was that a single shared Client's counter accumulated across
+    conversations).
+    """
+    created: dict = {}
+
+    def factory(key):
+        client = FakeFastMCPClient(label=str(key))
+        created[key] = client
+        return client
+
+    mgr = _make_manager(factory)
+
+    client_a = await mgr._get_or_create_user_http_client(
+        "state_server", "alice@test.com", "conv-1"
+    )
+    client_b = await mgr._get_or_create_user_http_client(
+        "state_server", "alice@test.com", "conv-2"
+    )
+
+    # Distinct Client instances per conversation.
+    assert client_a is not client_b
+
+    sess_a = await mgr._session_manager.acquire(
+        "conv-1", "state_server", client_a
+    )
+    sess_b = await mgr._session_manager.acquire(
+        "conv-2", "state_server", client_b
+    )
+
+    # Each Client's nesting counter is its own — neither exceeds 1.
+    assert client_a.nesting == 1
+    assert client_b.nesting == 1
+    assert client_a.max_nesting == 1
+    assert client_b.max_nesting == 1
+    assert sess_a is not sess_b
+
+
+@pytest.mark.asyncio
+async def test_dead_session_in_one_conversation_does_not_break_another():
+    """Killing conv-1's session task must leave conv-2 healthy.
+
+    Pre-fix this was the symptom: conv-1's dead session left FastMCP's
+    counter > 0 on the *shared* client, so conv-2's next acquire on the
+    same shared client raised the nesting-counter error.
+
+    Post-fix conv-1 and conv-2 hold distinct Clients, so conv-1's dead
+    state is contained and conv-2 keeps working.
+    """
+    def factory(key):
+        return FakeFastMCPClient(label=str(key))
+
+    mgr = _make_manager(factory)
+
+    client_a = await mgr._get_or_create_user_http_client(
+        "state_server", "alice@test.com", "conv-1"
+    )
+    client_b = await mgr._get_or_create_user_http_client(
+        "state_server", "alice@test.com", "conv-2"
+    )
+
+    await mgr._session_manager.acquire("conv-1", "state_server", client_a)
+    await mgr._session_manager.acquire("conv-2", "state_server", client_b)
+
+    # Simulate conv-1's session dying server-side.
+    client_a.simulate_disconnect()
+
+    # Conv-2 must remain usable: it can still be acquired (cache hit on
+    # the live session) and a tool call against client_b would not raise
+    # the nesting-counter error because client_b is independent.
+    sess_b_again = await mgr._session_manager.acquire(
+        "conv-2", "state_server", client_b
+    )
+    assert sess_b_again.is_open is True
+    assert client_b.nesting == 1  # unchanged by conv-1's disaster
+
+    # Conv-1 can recover by closing the dead session and opening fresh.
+    # The session manager detects is_connected() == False, evicts, and
+    # we open a new one. Allow recovery on the underlying client.
+    client_a.simulate_recover()
+    sess_a_new = await mgr._session_manager.acquire(
+        "conv-1", "state_server", client_a
+    )
+    assert sess_a_new.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_release_sessions_only_closes_target_conversation():
+    """release_sessions("conv-1", user_email=...) must close conv-1's
+    ManagedSession AND evict conv-1's cached Client without touching
+    conv-2's session or cache.
+    """
+    def factory(key):
+        return FakeFastMCPClient(label=str(key))
+
+    mgr = _make_manager(factory)
+
+    client_a = await mgr._get_or_create_user_http_client(
+        "state_server", "alice@test.com", "conv-1"
+    )
+    client_b = await mgr._get_or_create_user_http_client(
+        "state_server", "alice@test.com", "conv-2"
+    )
+    await mgr._session_manager.acquire("conv-1", "state_server", client_a)
+    await mgr._session_manager.acquire("conv-2", "state_server", client_b)
+
+    await mgr.release_sessions("conv-1", user_email="alice@test.com")
+
+    # Conv-1's Client cache entry is gone.
+    assert ("alice@test.com", "state_server", "conv-1") not in mgr._user_clients
+    # Conv-2's cache entry survives.
+    assert ("alice@test.com", "state_server", "conv-2") in mgr._user_clients
+
+    # Conv-1's session is closed (counter back to 0); conv-2's still open.
+    assert client_a.nesting == 0
+    assert client_b.nesting == 1
+
+    # MCPSessionManager state mirrors the cache.
+    assert ("conv-1", "state_server") not in mgr._session_manager._sessions
+    assert ("conv-2", "state_server") in mgr._session_manager._sessions
+
+
+@pytest.mark.asyncio
+async def test_pre_fix_failure_mode_documented():
+    """If two conversations had been forced to share one Client (the
+    pre-fix bug), simulate_disconnect on that shared Client + retry
+    raises ``_NestingCounterError`` — proving our fake reproduces the
+    real failure shape FastMCP exhibits.
+    """
+    shared = FakeFastMCPClient(label="shared")
+
+    # First conversation opens a session.
+    await shared.__aenter__()
+    assert shared.nesting == 1
+
+    # Second conversation opens a session on the same Client (the bug).
+    await shared.__aenter__()
+    assert shared.nesting == 2
+
+    # First conversation's session dies server-side without a clean exit.
+    shared.simulate_disconnect()
+
+    # The first conversation tries to reconnect — re-entry fails because
+    # nesting is still > 0. This is the failure mode the PR's
+    # per-conversation cache prevents from ever happening.
+    with pytest.raises(_NestingCounterError):
+        await shared.__aenter__()

--- a/atlas/tests/test_multi_prompt.py
+++ b/atlas/tests/test_multi_prompt.py
@@ -83,6 +83,8 @@ class TestMultiPromptSupport:
         mock_tool_manager.get_prompt.assert_called_once_with(
             "server", "wizard",
             meta={"user_email": "alice@example.com", "conversation_id": "conv-123"},
+            user_email="alice@example.com",
+            conversation_id="conv-123",
         )
 
     @pytest.mark.asyncio

--- a/docs/developer/mcp-session-isolation-2026-03-15.md
+++ b/docs/developer/mcp-session-isolation-2026-03-15.md
@@ -14,7 +14,7 @@ MCP session isolation prevents cross-user state leakage in multi-user deployment
 | Transport | State Strategy | Why |
 |-----------|---------------|-----|
 | STDIO | `BlockedStateStore` — reads return empty, writes raise `RuntimeError` | Single process shared across all users; any stored state would be visible to everyone |
-| HTTP | Per-user `Client` instances keyed by `(user_email, server_name)` | Each client gets its own MCP session ID, isolating state per user |
+| HTTP | Per-user/per-conversation `Client` instances keyed by `(user_email, server_name, conversation_id)` | Each client gets its own MCP session ID, isolating state per conversation. Per-conversation keying (not per-user) is required because `MCPSessionManager` opens persistent sessions per conversation and each open increments FastMCP's reentrant nesting counter on the underlying `Client`. Sharing one client across conversations accumulates the counter; if the underlying session task dies, FastMCP refuses to reconnect ("nesting counter should be 0 when starting new session, got N"). |
 
 ### BlockedStateStore (`atlas/mcp_shared/blocked_state.py`)
 
@@ -56,7 +56,7 @@ Holds live MCP sessions keyed by `(conversation_id, server_name)`:
 
 1. User calls a tool → `MCPSessionManager.acquire()` opens session if needed
 2. Subsequent tool calls reuse the open session
-3. WebSocket disconnect → `release_sessions(conversation_id, user_email)` closes all sessions and evicts per-user HTTP clients
+3. WebSocket disconnect → `release_sessions(conversation_id, user_email)` closes all sessions and evicts the conversation's HTTP clients
 4. Server shutdown → `cleanup()` closes all sessions and clears client caches
 
 ### Dead Session Recovery (PR #461, 2026-03-21)


### PR DESCRIPTION
## Summary

- Cache FastMCP HTTP `Client` instances by `(user_email, server_name, conversation_id)` instead of `(user_email, server_name)`. Sharing one client across conversations accumulates FastMCP's reentrant nesting counter and, once the underlying session task dies, prevents reconnection with `"nesting counter should be 0 when starting new session, got N"`.
- Per-conversation keying also gives each chat its own MCP session ID, so stateful HTTP servers (e.g. the 3D-printer sim's per-session `PrinterService`) stay isolated across the same user's conversations rather than leaking state between chats.
- `_get_user_client`, `_get_or_create_user_http_client`, and `get_prompt` accept `conversation_id`; `_invalidate_user_client` wipes every `(user, server, *)` entry on token revocation; `release_sessions` only evicts the current conversation's entries so other conversations keep their live sessions; `prompt_override_service` forwards `user_email` + `conversation_id` into `get_prompt`.

## Review-driven fixes added in this PR

- **`handle_reset_session` releases the old conversation's MCP sessions** (Tier-1 A). Each reset previously orphaned the `(user, server, old_conv_id)` cache entries and `MCPSessionManager` sessions because the cache key now includes `conversation_id`. `handle_reset_session` now captures the old `conversation_id` before tearing down the session and invokes `tool_manager.release_sessions` (best-effort via `getattr`) before generating the new id.
- **`get_prompt` mirrors `call_tool`'s auth routing** (Tier-2 E). For HTTP MCP servers with `auth_type` of oauth/jwt/bearer/api_key, `get_prompt` now routes through `_get_user_client` (per-user token) instead of `_get_or_create_user_http_client` (admin token), and raises `AuthenticationRequiredException` with the same OAuth start URL the tool path emits.
- **`_get_or_create_user_http_client` rejects falsy `conversation_id`** (Tier-1 B). Drops the `Optional` default and raises `ValueError` so future regressions surface immediately rather than silently aliasing every caller for `(user, server)` into one shared cache slot.
- **Test coverage** for the actual behavior, not just cache-key shape (Tier-1 C, D):
  - New `tests/test_mcp_session_isolation_integration.py` drives a faithful `FakeFastMCPClient` (with real `__aenter__`/`__aexit__`/nesting counter) through the real `MCPSessionManager` to verify cross-conversation independence and recover-from-dead-session, plus a documentation test that reproduces the pre-fix `nesting counter should be 0` error on a deliberately shared client.
  - New unit tests for `release_sessions` per-conversation eviction (covers the previously untested behavior change in this PR).
  - New unit tests for `get_prompt` auth routing on auth-typed and unauth-typed servers, including the missing-token and missing-user-email error paths.
  - New unit tests for `handle_reset_session` calling `release_sessions(old_conv_id)` and tolerating exceptions from it.

## Disposition of remaining review items

Tier-3 items are pre-existing conditions this PR makes more visible but does not regress; opened as follow-ups so this PR stays focused:

- Issue #560 — `_invalidate_user_client` should release live MCP sessions on token revocation.
- Issue #561 — `MCPSessionManager.acquire` is not user-scoped; chat path trusts WS-supplied `conversation_id` without ownership validation.
- Issue #562 — bound `_user_clients` cache (LRU/TTL) and add defensive cleanup on ungraceful WebSocket disconnect.

## Test plan

- [x] `pytest atlas/tests/test_mcp_client_auth.py atlas/tests/test_mcp_per_user_http_clients.py atlas/tests/test_multi_prompt.py atlas/tests/test_mcp_session_isolation_integration.py atlas/tests/test_chat_history.py atlas/tests/test_attach_file_flow.py` — all pass locally.
- [x] Faithful (non-mock) integration-style test reproduces the pre-fix `nesting counter should be 0` failure mode on a shared client and asserts that the post-fix per-conversation cache prevents it. Covers the original manual repro's intent (two conversations on the same user driving a stateful HTTP MCP server) without depending on a live `3dprintsim` server.