### PR TITLE
release: 0.2.0 (2026.04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-30
+
 ### PR #559 - 2026-04-25
 - MCP cross-conversation isolation: cache FastMCP HTTP `Client` instances by
   `(user_email, server_name, conversation_id)` so each conversation gets its

--- a/atlas/version.py
+++ b/atlas/version.py
@@ -3,4 +3,4 @@
 Single source of truth for the application version number.
 """
 
-VERSION = "0.1.5"
+VERSION = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-chat"
-version = "0.1.5"
+version = "0.2.0"
 description = "Full-stack LLM chat interface with Model Context Protocol (MCP) integration"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
<!--
This file is used as the body of the draft release PR opened by
.github/workflows/release-cut.yml. Keep it actionable and
review-friendly. Full process docs live at
docs/developer/release-process.md.
-->

# Release 0.2.0 (2026.04)

This PR was opened by the `release-cut` automation. It cuts
`release/2026.04` from `main` and bumps the version. Nothing
publishes until a maintainer manually tags `v0.2.0` on this
branch — see the runbook at
[docs/developer/release-process.md](../docs/developer/release-process.md).

## What this PR contains

- New branch `release/2026.04` cut from `main` at
  `4f0222333069eba486fd75b88a18490207fa2f39`.
- `atlas/version.py` and `pyproject.toml` bumped from
  `0.1.5` → `0.2.0`.
- `CHANGELOG.md`: `## [Unreleased]` section finalized as
  `## [0.2.0] - 2026-04-30`; new empty `[Unreleased]`
  prepended.

## Release captain

Assign yourself to this PR. You own the checklist below, the smoke
test, the tag push, and the GitHub Release.

## Stabilization window

This PR stays open for the rest of the month. During that window:

- Only bug fixes merge to `release/2026.04`. Features and
  refactors continue to land on `main` as normal.
- Fix on `main` first, then cherry-pick to the release branch:
  `git cherry-pick -x <sha>`.
- Each cherry-pick gets a CHANGELOG note under the
  `## [0.2.0]` section on the release branch.

## Pre-tag checklist

Complete every item before pushing the tag. Do not merge this PR
until the tag is pushed and publish workflows are green.

### Code & CI

- [ ] `CI/CD Pipeline` is green on the latest commit of
      `release/2026.04`.
- [ ] `Security Checks` is green.
- [ ] No known P0 or P1 bugs filed against the release branch.
- [ ] `atlas/version.py` and `pyproject.toml` both show `0.2.0`.
- [ ] `CHANGELOG.md` has a populated `## [0.2.0]` section with
      at least one entry per user-visible change since the previous
      release.

### Smoke test (manual)

See [docs/developer/release-process.md#smoke-test](../docs/developer/release-process.md#smoke-test).

- [ ] `uv build --wheel` succeeds on `release/2026.04`.
- [ ] Fresh `atlas-init` + `atlas-chat` one-shot call works against
      a real LLM.
- [ ] Tool-call path works (`atlas-chat --tools calculator_evaluate
      --tool-choice-required`).
- [ ] `atlas-server` boots and `/api/health` returns `0.2.0`.

### Publish

- [ ] Tag pushed: `git tag -a v0.2.0 -m "Atlas UI 3 v0.2.0" && git push origin v0.2.0`.
- [ ] GitHub Release created from the tag, targeting
      `release/2026.04`, with CHANGELOG section as the body.
- [ ] `pypi-publish.yml` completed, `atlas-chat==0.2.0`
      visible on PyPI.
- [ ] `quay-publish.yml` completed, `quay.io/<ns>/atlas-ui-3:0.2.0`
      image pushed.

### Post-publish

- [ ] This PR merged into `main` (fast-forward if possible) so the
      version bump and any hotfixes carry forward.
- [ ] Follow-up issue filed for any deferred items surfaced during
      stabilization.

## Rollback

If the release is broken in the wild, **do not rewrite history**.
Yank the bad version on PyPI and cut a patch release via the hotfix
flow in the runbook. Rolling forward beats rolling back.
