### PR TITLE
feat(config): assemble chat-history DB URL from DB_* parts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,20 @@ CHAT_HISTORY_DB_URL=duckdb:///data/chat_history.db
 # Requires a running PostgreSQL instance (see docker-compose.yml postgres service).
 # Start with: docker compose up -d postgres
 # CHAT_HISTORY_DB_URL=postgresql://atlas:atlas@localhost:5432/atlas_chat_history
+#
+# --- Option C: Individual DB_* variables (alternative to a full URL) ---
+# If CHAT_HISTORY_DB_URL is unset, the chat-history URL is assembled from the
+# variables below. Useful when secrets (especially DB_PASSWORD) come from a
+# secret manager and you don't want to construct a full URL yourself.
+# CHAT_HISTORY_DB_URL takes precedence whenever it is set.
+# DB_DRIVER defaults to "postgresql"; override for other SQLAlchemy schemes.
+# DB_USER and DB_PASSWORD are URL-encoded automatically, so '@', ':', '/' etc. are safe.
+# DB_DRIVER=postgresql
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_NAME=atlas_chat_history
+# DB_USER=atlas
+# DB_PASSWORD=atlas
 # Compliance level filtering for MCP servers and data sources
 FEATURE_COMPLIANCE_LEVELS_ENABLED=false
 # Startup splash screen for displaying policies and information

--- a/atlas/modules/config/config_manager.py
+++ b/atlas/modules/config/config_manager.py
@@ -598,6 +598,19 @@ class AppSettings(BaseSettings):
         description="Database URL for chat history. Use duckdb:///path for local, postgresql://... for production",
         validation_alias="CHAT_HISTORY_DB_URL",
     )
+    # Individual database connection components (alternative to CHAT_HISTORY_DB_URL).
+    # When CHAT_HISTORY_DB_URL is not set in the environment but DB_HOST or DB_NAME is,
+    # chat_history_db_url is assembled from these parts in a model validator below.
+    db_driver: str = Field(
+        default="postgresql",
+        description="SQLAlchemy driver scheme used when assembling chat_history_db_url from DB_* parts",
+        validation_alias="DB_DRIVER",
+    )
+    db_host: Optional[str] = Field(default=None, validation_alias="DB_HOST")
+    db_port: Optional[int] = Field(default=None, validation_alias="DB_PORT")
+    db_name: Optional[str] = Field(default=None, validation_alias="DB_NAME")
+    db_user: Optional[str] = Field(default=None, validation_alias="DB_USER")
+    db_password: Optional[str] = Field(default=None, validation_alias="DB_PASSWORD")
     # Compliance level filtering feature gate
     feature_compliance_levels_enabled: bool = Field(
         False,
@@ -704,6 +717,38 @@ class AppSettings(BaseSettings):
 
     # Runtime directories
     runtime_feedback_dir: Optional[str] = Field(default=None, validation_alias="RUNTIME_FEEDBACK_DIR")
+
+    @model_validator(mode='after')
+    def assemble_chat_history_db_url(self):
+        """Build chat_history_db_url from DB_* parts when no full URL is supplied.
+
+        CHAT_HISTORY_DB_URL (if set in the environment) always wins. Otherwise, if any
+        of DB_HOST / DB_NAME / DB_USER is provided we treat the user as opting in to
+        component-based config and assemble a SQLAlchemy URL from the parts. User and
+        password are URL-encoded so special characters (e.g. '@', ':', '/') are safe.
+        """
+        if "CHAT_HISTORY_DB_URL" in os.environ:
+            return self
+        if not (self.db_host or self.db_name or self.db_user):
+            return self
+
+        from urllib.parse import quote
+
+        user_part = ""
+        if self.db_user:
+            user_part = quote(self.db_user, safe="")
+            if self.db_password is not None:
+                user_part += ":" + quote(self.db_password, safe="")
+            user_part += "@"
+
+        host_part = self.db_host or "localhost"
+        port_part = f":{self.db_port}" if self.db_port else ""
+        name_part = f"/{self.db_name}" if self.db_name else ""
+
+        self.chat_history_db_url = (
+            f"{self.db_driver}://{user_part}{host_part}{port_part}{name_part}"
+        )
+        return self
 
     @model_validator(mode='after')
     def validate_aws_alb_config(self):

--- a/atlas/tests/test_chat_history_db_url.py
+++ b/atlas/tests/test_chat_history_db_url.py
@@ -1,0 +1,118 @@
+"""Tests for assembling chat_history_db_url from individual DB_* env vars.
+
+Covers the behavior added for issue #581: support DB_HOST, DB_PORT, DB_NAME,
+DB_USER, DB_PASSWORD, DB_DRIVER as an alternative to a full CHAT_HISTORY_DB_URL.
+"""
+
+import pytest
+
+from atlas.modules.config.config_manager import AppSettings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_db_env(monkeypatch):
+    """Strip every DB_* / CHAT_HISTORY_DB_URL env var so the host shell can't leak in."""
+    for var in (
+        "CHAT_HISTORY_DB_URL",
+        "DB_DRIVER",
+        "DB_HOST",
+        "DB_PORT",
+        "DB_NAME",
+        "DB_USER",
+        "DB_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def _settings():
+    # _env_file=None prevents pydantic-settings from reading the repo's .env file
+    # (which would otherwise inject CHAT_HISTORY_DB_URL during local test runs).
+    return AppSettings(_env_file=None)
+
+
+class TestChatHistoryDbUrlAssembly:
+    def test_default_when_nothing_set(self):
+        settings = _settings()
+        assert settings.chat_history_db_url == "duckdb:///data/chat_history.db"
+
+    def test_explicit_url_wins_over_parts(self, monkeypatch):
+        monkeypatch.setenv("CHAT_HISTORY_DB_URL", "postgresql://explicit:pw@db.example.com:5432/explicit")
+        monkeypatch.setenv("DB_HOST", "ignored.example.com")
+        monkeypatch.setenv("DB_NAME", "ignored")
+        monkeypatch.setenv("DB_USER", "ignored")
+        monkeypatch.setenv("DB_PASSWORD", "ignored")
+        settings = _settings()
+        assert settings.chat_history_db_url == "postgresql://explicit:pw@db.example.com:5432/explicit"
+
+    def test_assembles_full_postgres_url(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "db.example.com")
+        monkeypatch.setenv("DB_PORT", "5432")
+        monkeypatch.setenv("DB_NAME", "atlas_chat_history")
+        monkeypatch.setenv("DB_USER", "atlas")
+        monkeypatch.setenv("DB_PASSWORD", "secret")
+        settings = _settings()
+        assert (
+            settings.chat_history_db_url
+            == "postgresql://atlas:secret@db.example.com:5432/atlas_chat_history"
+        )
+
+    def test_default_driver_is_postgres(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "db")
+        monkeypatch.setenv("DB_NAME", "x")
+        settings = _settings()
+        assert settings.chat_history_db_url.startswith("postgresql://")
+
+    def test_custom_driver(self, monkeypatch):
+        monkeypatch.setenv("DB_DRIVER", "postgresql+psycopg")
+        monkeypatch.setenv("DB_HOST", "db")
+        monkeypatch.setenv("DB_NAME", "x")
+        settings = _settings()
+        assert settings.chat_history_db_url == "postgresql+psycopg://db/x"
+
+    def test_omits_port_when_unset(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "db")
+        monkeypatch.setenv("DB_NAME", "atlas")
+        monkeypatch.setenv("DB_USER", "atlas")
+        monkeypatch.setenv("DB_PASSWORD", "pw")
+        settings = _settings()
+        assert settings.chat_history_db_url == "postgresql://atlas:pw@db/atlas"
+
+    def test_omits_credentials_when_user_unset(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "db")
+        monkeypatch.setenv("DB_NAME", "atlas")
+        settings = _settings()
+        assert settings.chat_history_db_url == "postgresql://db/atlas"
+
+    def test_url_encodes_special_chars_in_password(self, monkeypatch):
+        # '@', ':', '/', and '#' would otherwise corrupt the URL
+        monkeypatch.setenv("DB_HOST", "db")
+        monkeypatch.setenv("DB_NAME", "atlas")
+        monkeypatch.setenv("DB_USER", "atlas")
+        monkeypatch.setenv("DB_PASSWORD", "p@ss:w/rd#1")
+        settings = _settings()
+        assert (
+            settings.chat_history_db_url
+            == "postgresql://atlas:p%40ss%3Aw%2Frd%231@db/atlas"
+        )
+
+    def test_url_encodes_special_chars_in_user(self, monkeypatch):
+        monkeypatch.setenv("DB_HOST", "db")
+        monkeypatch.setenv("DB_NAME", "atlas")
+        monkeypatch.setenv("DB_USER", "user@domain")
+        monkeypatch.setenv("DB_PASSWORD", "pw")
+        settings = _settings()
+        assert (
+            settings.chat_history_db_url == "postgresql://user%40domain:pw@db/atlas"
+        )
+
+    def test_only_host_set_uses_default_db_name_omitted(self, monkeypatch):
+        # Edge case: DB_HOST alone is enough to opt in; URL has no db path segment
+        monkeypatch.setenv("DB_HOST", "db")
+        settings = _settings()
+        assert settings.chat_history_db_url == "postgresql://db"
+
+    def test_only_db_name_assumes_localhost(self, monkeypatch):
+        monkeypatch.setenv("DB_NAME", "atlas")
+        settings = _settings()
+        assert settings.chat_history_db_url == "postgresql://localhost/atlas"


### PR DESCRIPTION
## Summary

Closes #581.

Adds support for assembling the chat-history database URL from individual
environment variables (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`,
`DB_DRIVER`) as an alternative to providing the full `CHAT_HISTORY_DB_URL`.

- `CHAT_HISTORY_DB_URL` still wins when set — existing deployments are unaffected.
- If `CHAT_HISTORY_DB_URL` is unset and any of `DB_HOST`/`DB_NAME`/`DB_USER` is
  set, the URL is assembled in the `AppSettings` model validator.
- `DB_DRIVER` defaults to `postgresql`; override it for other SQLAlchemy schemes
  (e.g. `postgresql+psycopg`).
- `DB_USER` and `DB_PASSWORD` are URL-encoded with `urllib.parse.quote(..., safe="")`,
  so credentials containing `@`, `:`, `/`, `#`, etc. are safe.
- Port is omitted from the URL when `DB_PORT` is unset (driver default applies).
- Credentials are omitted when `DB_USER` is unset.

This is useful when secrets come from a secret manager (e.g. only `DB_PASSWORD`
is injected separately) and the operator does not want to construct a full URL
by hand.

## Notable defaults

- `DB_DRIVER` defaults to `postgresql` since the existing PostgreSQL guidance in
  `.env.example` is the production target. Operators wanting a non-PostgreSQL
  driver can set `DB_DRIVER` explicitly.
- The opt-in check is `db_host or db_name or db_user`. If none of these is set,
  the existing default (`duckdb:///data/chat_history.db`) still applies.

## Files changed

- `atlas/modules/config/config_manager.py` — new `db_*` fields and
  `assemble_chat_history_db_url` model validator on `AppSettings`.
- `.env.example` — documents the new `DB_*` option C.
- `atlas/tests/test_chat_history_db_url.py` — 11 unit tests covering URL
  precedence, assembly, default driver, custom driver, port/credential
  omission, and URL encoding.

## Test plan

- [x] `pytest atlas/tests/test_chat_history_db_url.py` — 11/11 pass.
- [x] `pytest atlas/tests/test_config_manager.py` — 51/51 pass (no regressions).
- [x] Smoke check that an assembled URL with a password containing `@` is
      properly percent-encoded.
- [ ] CI green on PR.