### PR TITLE
ci(security): add Grype image scan and Syft SBOM

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -225,6 +225,36 @@ jobs:
       with:
         sarif_file: 'scout-results.sarif'
 
+    # SBOM generation with Syft (Anchore) — bundled into the container scan artifact
+    - name: Generate SBOM (Syft)
+      uses: anchore/sbom-action@v0
+      with:
+        image: security-scan:latest
+        format: spdx-json
+        output-file: sbom.spdx.json
+        upload-artifact: false
+
+    # Grype for image vulnerability scanning. Report-first defaults: fail-build=false,
+    # only-fixed=true so signal stays focused on actionable, fixable CVEs.
+    - name: Run Grype vulnerability scanner
+      id: grype
+      uses: anchore/scan-action@v7
+      continue-on-error: true
+      with:
+        image: security-scan:latest
+        fail-build: false
+        severity-cutoff: high
+        only-fixed: true
+        output-format: sarif
+        output-file: grype-results.sarif
+
+    - name: Upload Grype scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always() && hashFiles('grype-results.sarif') != ''
+      with:
+        sarif_file: grype-results.sarif
+        category: grype
+
     # Upload container scan artifacts
     - name: Upload container scan reports
       uses: actions/upload-artifact@v7
@@ -234,6 +264,8 @@ jobs:
         path: |
           trivy-results.sarif
           scout-results.sarif
+          grype-results.sarif
+          sbom.spdx.json
         if-no-files-found: ignore
 
   security-summary:


### PR DESCRIPTION
## Summary
- Adds [Anchore Grype](https://github.com/anchore/grype) vulnerability scanning and [Syft](https://github.com/anchore/syft) SBOM generation to the existing `container-scan` job in `.github/workflows/security.yml`.
- Closes the main remaining gap in the security pipeline: container-image scanning is currently only Trivy + Docker Scout; Grype gives a second independent CVE database (Anchore) and the SBOM gives us a portable artifact for downstream review.
- Minimal-impact change (32 added lines, same workflow, same image build — no new workflow file).

## Why these defaults
Report-first to avoid breaking PRs while we baseline noise:
- `fail-build: false` — don't fail builds on findings yet
- `severity-cutoff: high` — focus on what matters
- `only-fixed: true` — only show vulns with a known fix, so the signal is actionable
- `continue-on-error: true` on the scan step itself, matching the pattern used for Docker Scout

If the Grype baseline turns out to be quiet enough in practice, we can flip `fail-build` to `true` in a follow-up.

## What gets uploaded
- Grype SARIF → GitHub Security tab under category `grype` (doesn't collide with the existing Trivy upload)
- SBOM (SPDX JSON) + Grype SARIF → bundled into the existing `container-scan-reports` artifact for offline review

## Test plan
- [ ] `Container Security Scan` job completes (Grype + Syft steps pass)
- [ ] `grype-results.sarif` and `sbom.spdx.json` appear in the `container-scan-reports` artifact
- [ ] Grype findings show up under category `grype` in the Security → Code scanning alerts tab
- [ ] No regression in Trivy / Docker Scout uploads
- [ ] Existing PR security-summary comment still posts as before