### PR TITLE
Fix CodeQL sanitizer model for sanitize_for_logging

### DIFF
--- a/.github/codeql/extensions.yml
+++ b/.github/codeql/extensions.yml
@@ -5,10 +5,8 @@
 extensions:
   - addsTo:
       pack: codeql/python-all
-      extensible: sanitizer
+      extensible: sanitizerModel
     data:
-      # Format: [module, function, output, taintKinds]
-      # Mark the function's return value as sanitized for all taint kinds.
-      - ["core.log_sanitizer", "sanitize_for_logging", "ReturnValue", "All"]
-      # Also include fully-qualified path with atlas prefix in case imports resolve that way in analysis
-      - ["atlas.core.log_sanitizer", "sanitize_for_logging", "ReturnValue", "All"]
+      # Format: [module, member/path, kind]
+      # Teach py/log-injection that sanitize_for_logging's return value is safe.
+      - ["atlas.core.log_sanitizer", "Member[sanitize_for_logging].ReturnValue", "log-injection"]


### PR DESCRIPTION
## Summary
- switch the CodeQL extension to the Python `sanitizerModel` schema for `py/log-injection`
- model `atlas.core.log_sanitizer.sanitize_for_logging` return values as sanitized
- keep existing CodeQL config/workflow wiring intact

Closes #574