### PR TITLE
Allow configuring admin test user via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ APP_NAME=ATLAS
 # Default: X-User-Email
 # AUTH_USER_HEADER=X-User-Email
 
+# Admin test user for development/test auth flows.
+# Used by tests and debug-mode mock admin authorization.
+# Default: admin@example.com
+# ADMIN_TEST_USER=admin@example.com
+
 # Proxy secret authentication (enabled by default in production)
 # The reverse proxy must include a secret header to authenticate itself.
 # Without this, anyone with direct backend access can spoof the auth header.

--- a/atlas/core/auth.py
+++ b/atlas/core/auth.py
@@ -67,7 +67,7 @@ async def is_user_in_group(user_id: str, group_id: str) -> bool:
         mock_groups = {
             "test@test.com": ["users", "mcp_basic", "admin"],
             "user@example.com": ["users", "mcp_basic"],
-            "admin@example.com": ["admin", "users", "mcp_basic", "mcp_advanced"]
+            app_settings.admin_test_user: ["admin", "users", "mcp_basic", "mcp_advanced"]
         }
         user_groups = mock_groups.get(user_id, [])
         return group_id in user_groups

--- a/atlas/modules/config/config_manager.py
+++ b/atlas/modules/config/config_manager.py
@@ -483,6 +483,11 @@ class AppSettings(BaseSettings):
     # Admin settings
     admin_group: str = "admin"
     test_user: str = "test@test.com"  # Test user for development
+    admin_test_user: str = Field(
+        default="admin@example.com",
+        validation_alias="ADMIN_TEST_USER",
+        description="Admin test user for development/test auth flows"
+    )
     auth_group_check_url: Optional[str] = Field(default=None, validation_alias="AUTH_GROUP_CHECK_URL")
     auth_group_check_api_key: Optional[str] = Field(default=None, validation_alias="AUTH_GROUP_CHECK_API_KEY")
 

--- a/atlas/tests/test_admin_mcp_server_management_routes.py
+++ b/atlas/tests/test_admin_mcp_server_management_routes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from main import app
+from atlas.modules.config import config_manager
 from starlette.testclient import TestClient
 
 from atlas.infrastructure.app_factory import app_factory
@@ -28,7 +29,7 @@ def test_admin_mcp_available_servers_returns_inventory(monkeypatch, tmp_path):
     client = TestClient(app)
     response = client.get(
         "/admin/mcp/available-servers",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     )
     assert response.status_code == 200
 
@@ -56,7 +57,7 @@ def test_admin_mcp_active_servers_empty_when_no_override_file(monkeypatch, tmp_p
     client = TestClient(app)
     response = client.get(
         "/admin/mcp/active-servers",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     )
     assert response.status_code == 200
     data = response.json()
@@ -72,14 +73,14 @@ def test_admin_mcp_add_server_persists_to_overrides(monkeypatch, tmp_path):
 
     available = client.get(
         "/admin/mcp/available-servers",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     ).json()["available_servers"]
 
     server_name = next(iter(available.keys()))
 
     add_response = client.post(
         "/admin/mcp/add-server",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
         json={"server_name": server_name},
     )
     assert add_response.status_code == 200
@@ -89,7 +90,7 @@ def test_admin_mcp_add_server_persists_to_overrides(monkeypatch, tmp_path):
     # Active endpoint should reflect the new server.
     active = client.get(
         "/admin/mcp/active-servers",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     ).json()["active_servers"]
     assert server_name in active
 
@@ -102,7 +103,7 @@ def test_admin_mcp_add_server_persists_to_overrides(monkeypatch, tmp_path):
     # Re-adding returns the already_active response.
     add_again = client.post(
         "/admin/mcp/add-server",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
         json={"server_name": server_name},
     )
     assert add_again.status_code == 200
@@ -117,7 +118,7 @@ def test_admin_mcp_remove_server_updates_overrides(monkeypatch, tmp_path):
 
     available = client.get(
         "/admin/mcp/available-servers",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     ).json()["available_servers"]
 
     server_name = next(iter(available.keys()))
@@ -125,14 +126,14 @@ def test_admin_mcp_remove_server_updates_overrides(monkeypatch, tmp_path):
     # Add then remove.
     add_response = client.post(
         "/admin/mcp/add-server",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
         json={"server_name": server_name},
     )
     assert add_response.status_code == 200
 
     remove_response = client.post(
         "/admin/mcp/remove-server",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
         json={"server_name": server_name},
     )
     assert remove_response.status_code == 200
@@ -142,7 +143,7 @@ def test_admin_mcp_remove_server_updates_overrides(monkeypatch, tmp_path):
 
     active = client.get(
         "/admin/mcp/active-servers",
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     ).json()["active_servers"]
     assert server_name not in active
 
@@ -155,7 +156,7 @@ def test_admin_mcp_routes_reject_mock_users_in_production():
     """In production mode, mock admin users must be denied access."""
     client = TestClient(app)
     for path in ["/admin/mcp/available-servers", "/admin/mcp/active-servers"]:
-        response = client.get(path, headers={"X-User-Email": "admin@example.com"})
+        response = client.get(path, headers={"X-User-Email": config_manager.app_settings.admin_test_user})
         # 403 = admin auth correctly denied; 503 = proxy secret also blocks (both are correct)
         assert response.status_code in (403, 503), (
             f"{path} should deny access in production mode, got {response.status_code}"

--- a/atlas/tests/test_banner_logging.py
+++ b/atlas/tests/test_banner_logging.py
@@ -4,9 +4,8 @@ import os
 
 import pytest
 from main import app
-from starlette.testclient import TestClient
-
 from atlas.modules.config import config_manager
+from starlette.testclient import TestClient
 
 _IS_PRODUCTION = os.environ.get("DEBUG_MODE", "true").lower() == "false"
 
@@ -44,7 +43,7 @@ def test_banner_save_success_logging(caplog, tmp_path, monkeypatch):
         response = client.post(
             "/admin/banners",
             json={"messages": ["Test banner message", "Another test message"]},
-            headers={"X-User-Email": "admin@example.com"}
+            headers={"X-User-Email": config_manager.app_settings.admin_test_user}
         )
 
     # Verify request succeeded
@@ -64,7 +63,7 @@ def test_banner_save_success_logging(caplog, tmp_path, monkeypatch):
     # Verify log contains file path and admin user
     log_message = banner_logs[0].message
     assert "messages.txt" in log_message
-    assert "admin@example.com" in log_message
+    assert config_manager.app_settings.admin_test_user in log_message
 
 
 @_requires_debug
@@ -102,7 +101,7 @@ def test_banner_save_failure_logging(caplog, tmp_path, monkeypatch):
         response = client.post(
             "/admin/banners",
             json={"messages": ["Test banner message"]},
-            headers={"X-User-Email": "admin@example.com"}
+            headers={"X-User-Email": config_manager.app_settings.admin_test_user}
         )
 
     # Verify request failed
@@ -152,7 +151,7 @@ def test_banner_save_logs_sanitized_paths(caplog, tmp_path, monkeypatch):
         response = client.post(
             "/admin/banners",
             json={"messages": ["Test message"]},
-            headers={"X-User-Email": "admin@example.com"}
+            headers={"X-User-Email": config_manager.app_settings.admin_test_user}
         )
 
     # Verify request succeeded
@@ -199,7 +198,7 @@ def test_banner_get_includes_enabled_status(tmp_path, monkeypatch):
     # Make request to get banner config
     response = client.get(
         "/admin/banners",
-        headers={"X-User-Email": "admin@example.com"}
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user}
     )
 
     # Verify request succeeded
@@ -245,7 +244,7 @@ def test_banner_get_with_feature_disabled(tmp_path, monkeypatch):
     # Make request to get banner config
     response = client.get(
         "/admin/banners",
-        headers={"X-User-Email": "admin@example.com"}
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user}
     )
 
     # Verify request succeeded
@@ -289,7 +288,7 @@ def test_banner_get_with_feature_enabled(tmp_path, monkeypatch):
     # Make request to get banner config
     response = client.get(
         "/admin/banners",
-        headers={"X-User-Email": "admin@example.com"}
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user}
     )
 
     # Verify request succeeded
@@ -309,7 +308,7 @@ def test_banner_admin_routes_reject_mock_users_in_production():
         response = client.request(
             method,
             path,
-            headers={"X-User-Email": "admin@example.com"},
+            headers={"X-User-Email": config_manager.app_settings.admin_test_user},
             json={"messages": ["test"]} if method == "POST" else None,
         )
         # 403 = admin auth correctly denied; 503 = proxy secret also blocks (both are correct)

--- a/atlas/tests/test_help_content.py
+++ b/atlas/tests/test_help_content.py
@@ -10,6 +10,7 @@ Covers:
 
 import pytest
 from main import app
+from atlas.modules.config import config_manager
 from starlette.testclient import TestClient
 
 
@@ -62,7 +63,7 @@ def test_config_help_content_not_empty_with_default_file():
 def test_admin_get_help_config_returns_content():
     """Admin GET should return content and file_path."""
     client = TestClient(app)
-    resp = client.get("/admin/help-config", headers={"X-User-Email": "admin@example.com"})
+    resp = client.get("/admin/help-config", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
     assert resp.status_code == 200
     data = resp.json()
     assert "content" in data
@@ -88,7 +89,7 @@ def test_admin_put_help_config_writes_content(isolated_config_dir):
     new_content = "# Updated Help\n\nThis is test content."
     resp = client.put(
         "/admin/help-config",
-        headers={"X-User-Email": "admin@example.com", "Content-Type": "application/json"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user, "Content-Type": "application/json"},
         json={"content": new_content},
     )
     assert resp.status_code == 200
@@ -97,7 +98,7 @@ def test_admin_put_help_config_writes_content(isolated_config_dir):
     assert "file_path" in data
 
     # Verify the content was written by reading it back
-    resp2 = client.get("/admin/help-config", headers={"X-User-Email": "admin@example.com"})
+    resp2 = client.get("/admin/help-config", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
     assert resp2.status_code == 200
     assert resp2.json()["content"] == new_content
     # And the file actually lives in the isolated tmp dir
@@ -121,7 +122,7 @@ def test_admin_put_help_config_rejects_oversized_content(isolated_config_dir):
     oversized = "x" * (1_048_576 + 1)
     resp = client.put(
         "/admin/help-config",
-        headers={"X-User-Email": "admin@example.com", "Content-Type": "application/json"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user, "Content-Type": "application/json"},
         json={"content": oversized},
     )
     assert resp.status_code == 413
@@ -133,7 +134,7 @@ def test_admin_put_help_config_accepts_content_at_size_limit(isolated_config_dir
     at_limit = "x" * 1_048_576
     resp = client.put(
         "/admin/help-config",
-        headers={"X-User-Email": "admin@example.com", "Content-Type": "application/json"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user, "Content-Type": "application/json"},
         json={"content": at_limit},
     )
     assert resp.status_code == 200
@@ -145,7 +146,7 @@ def test_admin_put_help_config_rejects_non_string_content(bad_content, isolated_
     client = TestClient(app)
     resp = client.put(
         "/admin/help-config",
-        headers={"X-User-Email": "admin@example.com", "Content-Type": "application/json"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user, "Content-Type": "application/json"},
         json={"content": bad_content},
     )
     assert resp.status_code == 400
@@ -157,7 +158,7 @@ def test_admin_put_help_config_missing_content_field_defaults_to_empty(isolated_
     client = TestClient(app)
     resp = client.put(
         "/admin/help-config",
-        headers={"X-User-Email": "admin@example.com", "Content-Type": "application/json"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user, "Content-Type": "application/json"},
         json={},
     )
     assert resp.status_code == 200
@@ -181,7 +182,7 @@ def test_admin_get_help_config_legacy_fallback(isolated_config_dir):
     legacy_path.write_text(legacy_content, encoding="utf-8")
 
     client = TestClient(app)
-    resp = client.get("/admin/help-config", headers={"X-User-Email": "admin@example.com"})
+    resp = client.get("/admin/help-config", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
     assert resp.status_code == 200
     data = resp.json()
     assert data["content"] == legacy_content
@@ -191,7 +192,7 @@ def test_admin_get_help_config_legacy_fallback(isolated_config_dir):
 def test_admin_get_help_config_returns_empty_when_nothing_exists(isolated_config_dir):
     """When neither help.md nor legacy help-config.json exist, GET returns empty content."""
     client = TestClient(app)
-    resp = client.get("/admin/help-config", headers={"X-User-Email": "admin@example.com"})
+    resp = client.get("/admin/help-config", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
     assert resp.status_code == 200
     data = resp.json()
     assert data["content"] == ""

--- a/atlas/tests/test_mcp_hot_reload.py
+++ b/atlas/tests/test_mcp_hot_reload.py
@@ -15,6 +15,7 @@ class TestMCPAdminEndpoints:
     def test_mcp_status_endpoint_requires_admin(self):
         """Test that MCP status endpoint requires admin access."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
         # Non-admin user should be denied
@@ -24,10 +25,11 @@ class TestMCPAdminEndpoints:
     def test_mcp_status_endpoint_returns_data(self):
         """Test that MCP status endpoint returns expected data structure."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
         # Admin user should get response
-        r = client.get("/admin/mcp/status", headers={"X-User-Email": "admin@example.com"})
+        r = client.get("/admin/mcp/status", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
         assert r.status_code == 200
 
         data = r.json()
@@ -49,6 +51,7 @@ class TestMCPAdminEndpoints:
     def test_mcp_status_marks_failed_servers_not_connected(self):
         """Servers with recorded failures should not appear as connected."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
         # Seed a fake failure in the MCP manager
@@ -63,7 +66,7 @@ class TestMCPAdminEndpoints:
         mcp.available_tools["failing-server"] = {"tools": [], "config": {}}
         mcp.available_prompts["failing-server"] = {"prompts": [], "config": {}}
 
-        r = client.get("/admin/mcp/status", headers={"X-User-Email": "admin@example.com"})
+        r = client.get("/admin/mcp/status", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
         assert r.status_code == 200
 
         data = r.json()
@@ -72,6 +75,7 @@ class TestMCPAdminEndpoints:
     def test_mcp_reload_endpoint_requires_admin(self):
         """Test that MCP reload endpoint requires admin access."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
         # Non-admin user should be denied
@@ -81,6 +85,7 @@ class TestMCPAdminEndpoints:
     def test_mcp_reconnect_endpoint_requires_admin(self):
         """Test that MCP reconnect endpoint requires admin access."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
         # Non-admin user should be denied
@@ -90,10 +95,11 @@ class TestMCPAdminEndpoints:
     def test_mcp_reconnect_endpoint_returns_data(self):
         """Test that MCP reconnect endpoint returns expected data structure."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
         # Admin user should get response
-        r = client.post("/admin/mcp/reconnect", headers={"X-User-Email": "admin@example.com"})
+        r = client.post("/admin/mcp/reconnect", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
         assert r.status_code == 200
 
         data = r.json()
@@ -106,9 +112,10 @@ class TestMCPAdminEndpoints:
     def test_admin_dashboard_includes_mcp_endpoints(self):
         """Test that admin dashboard lists MCP endpoints."""
         from main import app
+        from atlas.modules.config import config_manager
         client = TestClient(app)
 
-        r = client.get("/admin/", headers={"X-User-Email": "admin@example.com"})
+        r = client.get("/admin/", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
         assert r.status_code == 200
 
         data = r.json()

--- a/atlas/tests/test_security_admin_routes.py
+++ b/atlas/tests/test_security_admin_routes.py
@@ -1,4 +1,5 @@
 from main import app
+from atlas.modules.config import config_manager
 from starlette.testclient import TestClient
 
 
@@ -11,8 +12,8 @@ def test_admin_routes_require_admin(monkeypatch):
     assert r.status_code in (302, 403)
 
     # Admin access when user is in admin group (mocked via config in core.auth)
-    r2 = client.get("/admin/", headers={"X-User-Email": "admin@example.com"})
-    # In debug mode off, should allow if auth module says admin@example.com is admin
+    r2 = client.get("/admin/", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
+    # In debug mode off, should allow if auth module says admin test user is admin
     assert r2.status_code == 200
     data = r2.json()
     assert data.get("available_endpoints") is not None
@@ -23,7 +24,7 @@ def test_system_status_endpoint():
     client = TestClient(app)
 
     # Test with admin user
-    r = client.get("/admin/system-status", headers={"X-User-Email": "admin@example.com"})
+    r = client.get("/admin/system-status", headers={"X-User-Email": config_manager.app_settings.admin_test_user})
     assert r.status_code == 200
 
     data = r.json()

--- a/atlas/tests/test_telemetry_routes.py
+++ b/atlas/tests/test_telemetry_routes.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 import pytest
 from main import app
+from atlas.modules.config import config_manager
 from starlette.testclient import TestClient
 
 from atlas.routes import telemetry_routes
@@ -176,7 +177,7 @@ def _admin(path: str, client: TestClient, **params: Any):
     return client.get(
         path,
         params=params,
-        headers={"X-User-Email": "admin@example.com"},
+        headers={"X-User-Email": config_manager.app_settings.admin_test_user},
     )
 
 

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -53,6 +53,7 @@ WebSocket connections follow the same authentication model as HTTP requests:
 - Primary: Uses configured auth header if present
 - Fallback 1: Uses `?user=` query parameter if no header
 - Fallback 2: Uses `TEST_USER` from config (default: `test@test.com`)
+- Mock admin authorization uses `ADMIN_TEST_USER` (default: `admin@example.com`)
 
 **Security Note:** The WebSocket endpoint validates authentication **before** accepting the connection. This prevents unauthenticated users from establishing a connection that could receive error messages or timing information.
 

--- a/test/pr-validation/test_pr550_admin_telemetry.sh
+++ b/test/pr-validation/test_pr550_admin_telemetry.sh
@@ -95,7 +95,7 @@ from atlas.routes import telemetry_routes
 # Reset to default FileSpanReader backed by APP_LOG_DIR
 telemetry_routes.set_span_reader(None)
 
-ADMIN = {"X-User-Email": "admin@example.com"}
+ADMIN = {"X-User-Email": "${ADMIN_TEST_USER:-admin@example.com}"}
 USER = {"X-User-Email": "user@example.com"}
 client = TestClient(app)
 

--- a/test/pr-validation/test_pr550_admin_telemetry.sh
+++ b/test/pr-validation/test_pr550_admin_telemetry.sh
@@ -95,7 +95,8 @@ from atlas.routes import telemetry_routes
 # Reset to default FileSpanReader backed by APP_LOG_DIR
 telemetry_routes.set_span_reader(None)
 
-ADMIN = {"X-User-Email": "${ADMIN_TEST_USER:-admin@example.com}"}
+admin_user = os.environ.get("ADMIN_TEST_USER", config_manager.app_settings.admin_test_user)
+ADMIN = {"X-User-Email": admin_user}
 USER = {"X-User-Email": "user@example.com"}
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- add an `ADMIN_TEST_USER` app setting/env var with a default of `admin@example.com`
- use that setting for debug-mode mock admin authorization and relevant tests
- document the new env var in `.env.example` and auth docs

Closes #563