### PR TITLE
feat(chat-export): include custom prompt info in chat download (#590)

### DIFF
--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -10,6 +10,7 @@ import { useSettings } from '../hooks/useSettings'
 import { usePersistentState } from '../hooks/chat/usePersistentState'
 import { createWebSocketHandler, cleanupStreamState } from '../handlers/chat/websocketHandlers'
 import { saveConversation as saveLocalConv } from '../utils/localConversationDB'
+import { buildPromptInfoByKey, resolvePromptInfo, buildExportConversation } from '../utils/chatExport'
 
 // Safety timeout for stuck thinking state (no backend response)
 const THINKING_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
@@ -310,7 +311,12 @@ export const ChatProvider = ({ children }) => {
 		if (!content.trim() || !currentModel) return
 		if (isWelcomeVisible) setIsWelcomeVisible(false)
 		setFollowUpSuggestions([])
-		addMessage({ role: 'user', content, timestamp: new Date().toISOString() })
+		addMessage({
+			role: 'user',
+			content,
+			timestamp: new Date().toISOString(),
+			_activePromptKey: selections.activePromptKey || null,
+		})
 		setIsThinking(true)
 		setIsSynthesizing(false)
 		const tagged = files.getTaggedFilesContent()
@@ -481,9 +487,17 @@ export const ChatProvider = ({ children }) => {
 		const ragSourcesDisplay = ragEnabled
 			? ([...selectedDataSources].join(', ') || 'None selected')
 			: 'None (RAG disabled)'
+
+		const promptInfoByKey = buildPromptInfoByKey(config.prompts)
+		const activePromptInfo = resolvePromptInfo(selections.activePromptKey, promptInfoByKey)
+		const exportConversation = buildExportConversation(messages, promptInfoByKey)
+
 		if (asText) {
-			let text = `Chat Export - ${config.appName}\nDate: ${new Date().toLocaleString()}\nUser: ${config.user}\nModel: ${currentModel}\nSelected Tools: ${[...selectedTools].join(', ') || 'None'}\nSelected RAG Sources: ${ragSourcesDisplay}\nAgent Mode: ${agent.agentModeEnabled ? 'Enabled' : 'Disabled'}\n\n${'='.repeat(50)}\n\n`
-			messages.forEach(m => { text += `${m.role.toUpperCase()}:\n${m.content}\n\n` })
+			const promptLine = activePromptInfo
+				? `Active Custom Prompt: ${activePromptInfo.name}${activePromptInfo.server ? ` (from ${activePromptInfo.server})` : ''}${activePromptInfo.description ? ` — ${activePromptInfo.description}` : ''}\n`
+				: 'Active Custom Prompt: Default\n'
+			let text = `Chat Export - ${config.appName}\nDate: ${new Date().toLocaleString()}\nUser: ${config.user}\nModel: ${currentModel}\nSelected Tools: ${[...selectedTools].join(', ') || 'None'}\nSelected RAG Sources: ${ragSourcesDisplay}\nAgent Mode: ${agent.agentModeEnabled ? 'Enabled' : 'Disabled'}\n${promptLine}\n${'='.repeat(50)}\n\n`
+			exportConversation.forEach(m => { text += `${m.role.toUpperCase()}:\n${m.content}\n\n` })
 			if (files.canvasContent) text += `${'='.repeat(50)}\nCANVAS CONTENT:\n${files.canvasContent}\n`
 			const blob = new Blob([text], { type: 'text/plain' })
 			const url = URL.createObjectURL(blob)
@@ -500,15 +514,16 @@ export const ChatProvider = ({ children }) => {
 					user: config.user,
 					model: currentModel,
 					selectedTools: [...selectedTools],
+					activePrompt: activePromptInfo,
 					ragEnabled: ragEnabled,
 					selectedRagSources: ragEnabled ? [...selectedDataSources] : null,
 					toolChoiceRequired: selections.toolChoiceRequired,
 					agentModeEnabled: agent.agentModeEnabled,
 					agentMaxSteps: agent.agentMaxSteps,
 					messageCount: messages.length,
-					exportVersion: '1.1'
+					exportVersion: '1.2'
 				},
-				conversation: messages,
+				conversation: exportConversation,
 				canvasContent: files.canvasContent || null
 			}
 			const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
@@ -519,7 +534,7 @@ export const ChatProvider = ({ children }) => {
 			a.download = `chat-export-${ts}.json`
 			document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(url)
 		}
-	}, [messages, config.appName, config.user, config.features, currentModel, selectedTools, selectedDataSources, agent.agentModeEnabled, agent.agentMaxSteps, selections.toolChoiceRequired, files.canvasContent])
+	}, [messages, config.appName, config.user, config.features, config.prompts, currentModel, selectedTools, selectedDataSources, agent.agentModeEnabled, agent.agentMaxSteps, selections.toolChoiceRequired, selections.activePromptKey, files.canvasContent])
 
 	const downloadChat = useCallback(() => exportData(false), [exportData])
 	const downloadChatAsText = useCallback(() => exportData(true), [exportData])

--- a/frontend/src/test/chatExport.test.js
+++ b/frontend/src/test/chatExport.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildPromptInfoByKey,
+  resolvePromptInfo,
+  buildExportConversation,
+} from '../utils/chatExport'
+
+const PROMPTS_CONFIG = [
+  {
+    server: 'prompts',
+    prompts: [
+      { name: 'intel_analyst', description: 'Acts as an intelligence analyst' },
+      { name: 'plain_summary' },
+    ],
+  },
+  {
+    server: 'work_helper',
+    prompts: [
+      { name: 'pirate_voice', description: 'Talk like a pirate' },
+    ],
+  },
+]
+
+describe('chatExport.buildPromptInfoByKey', () => {
+  it('keys prompts by server_name and preserves description/server', () => {
+    const lookup = buildPromptInfoByKey(PROMPTS_CONFIG)
+    expect(lookup.prompts_intel_analyst).toEqual({
+      key: 'prompts_intel_analyst',
+      name: 'intel_analyst',
+      description: 'Acts as an intelligence analyst',
+      server: 'prompts',
+    })
+    expect(lookup.work_helper_pirate_voice.server).toBe('work_helper')
+    expect(lookup.prompts_plain_summary.description).toBe('')
+  })
+
+  it('handles empty/missing input', () => {
+    expect(buildPromptInfoByKey(undefined)).toEqual({})
+    expect(buildPromptInfoByKey([])).toEqual({})
+    expect(buildPromptInfoByKey([{ server: 'x' }])).toEqual({})
+  })
+})
+
+describe('chatExport.resolvePromptInfo', () => {
+  const lookup = buildPromptInfoByKey(PROMPTS_CONFIG)
+
+  it('returns null for null/empty key', () => {
+    expect(resolvePromptInfo(null, lookup)).toBeNull()
+    expect(resolvePromptInfo('', lookup)).toBeNull()
+  })
+
+  it('resolves a known key', () => {
+    expect(resolvePromptInfo('prompts_intel_analyst', lookup).name).toBe('intel_analyst')
+  })
+
+  it('falls back to a stub for unknown keys', () => {
+    expect(resolvePromptInfo('gone_server_gone_prompt', lookup)).toEqual({
+      key: 'gone_server_gone_prompt',
+      name: 'gone_server_gone_prompt',
+      description: '',
+      server: '',
+    })
+  })
+})
+
+describe('chatExport.buildExportConversation', () => {
+  const lookup = buildPromptInfoByKey(PROMPTS_CONFIG)
+
+  it('passes messages through unchanged when none carry a prompt snapshot', () => {
+    const messages = [
+      { role: 'user', content: 'hi', timestamp: '2026-05-08T00:00:00Z' },
+      { role: 'assistant', content: 'hello', timestamp: '2026-05-08T00:00:01Z' },
+    ]
+    expect(buildExportConversation(messages, lookup)).toEqual(messages)
+  })
+
+  it('injects a system entry when a custom prompt is first activated', () => {
+    const messages = [
+      { role: 'user', content: 'plain', timestamp: 't0', _activePromptKey: null },
+      { role: 'assistant', content: 'reply', timestamp: 't0a' },
+      { role: 'user', content: 'with prompt', timestamp: 't1', _activePromptKey: 'prompts_intel_analyst' },
+      { role: 'assistant', content: 'analyst reply', timestamp: 't1a' },
+    ]
+    const out = buildExportConversation(messages, lookup)
+    expect(out).toHaveLength(5)
+    const sys = out[2]
+    expect(sys.role).toBe('system')
+    expect(sys._promptChange).toBe(true)
+    expect(sys.promptKey).toBe('prompts_intel_analyst')
+    expect(sys.promptName).toBe('intel_analyst')
+    expect(sys.promptServer).toBe('prompts')
+    expect(sys.content).toContain('intel_analyst')
+    expect(sys.content).toContain('Acts as an intelligence analyst')
+    expect(sys.timestamp).toBe('t1')
+  })
+
+  it('strips _activePromptKey from exported messages', () => {
+    const messages = [
+      { role: 'user', content: 'hi', _activePromptKey: 'prompts_intel_analyst', timestamp: 't0' },
+    ]
+    const out = buildExportConversation(messages, lookup)
+    out.forEach(m => expect(m).not.toHaveProperty('_activePromptKey'))
+  })
+
+  it('injects a system entry when switching from one custom prompt to another', () => {
+    const messages = [
+      { role: 'user', content: 'a', timestamp: 't0', _activePromptKey: 'prompts_intel_analyst' },
+      { role: 'assistant', content: 'r', timestamp: 't0a' },
+      { role: 'user', content: 'b', timestamp: 't1', _activePromptKey: 'work_helper_pirate_voice' },
+    ]
+    const out = buildExportConversation(messages, lookup)
+    const changes = out.filter(m => m._promptChange)
+    expect(changes).toHaveLength(2)
+    expect(changes[0].promptKey).toBe('prompts_intel_analyst')
+    expect(changes[1].promptKey).toBe('work_helper_pirate_voice')
+  })
+
+  it('emits a "cleared" entry when switching from custom back to default', () => {
+    const messages = [
+      { role: 'user', content: 'a', timestamp: 't0', _activePromptKey: 'prompts_intel_analyst' },
+      { role: 'user', content: 'b', timestamp: 't1', _activePromptKey: null },
+    ]
+    const out = buildExportConversation(messages, lookup)
+    const cleared = out.find(m => m._promptChange && m.promptKey === null)
+    expect(cleared).toBeDefined()
+    expect(cleared.content).toMatch(/cleared/i)
+  })
+
+  it('does not emit a "cleared" entry when the conversation simply starts on default', () => {
+    const messages = [
+      { role: 'user', content: 'a', timestamp: 't0', _activePromptKey: null },
+      { role: 'user', content: 'b', timestamp: 't1', _activePromptKey: null },
+    ]
+    const out = buildExportConversation(messages, lookup)
+    expect(out.find(m => m._promptChange)).toBeUndefined()
+  })
+
+  it('falls back to a stub for prompts no longer present in config', () => {
+    const messages = [
+      { role: 'user', content: 'a', timestamp: 't0', _activePromptKey: 'gone_server_gone_prompt' },
+    ]
+    const out = buildExportConversation(messages, lookup)
+    const sys = out.find(m => m._promptChange)
+    expect(sys.promptName).toBe('gone_server_gone_prompt')
+    expect(sys.promptServer).toBe('')
+  })
+})

--- a/frontend/src/utils/chatExport.js
+++ b/frontend/src/utils/chatExport.js
@@ -1,0 +1,70 @@
+// Helpers for the chat-download / export flow.
+//
+// The frontend does not have the actual prompt body (that lives on the backend
+// MCP server), so when the user selects a custom prompt mid-conversation we
+// surface the prompt's name / description / server in the export instead.
+
+export function buildPromptInfoByKey(promptsConfig) {
+  const out = {}
+  ;(promptsConfig || []).forEach(server => {
+    (server.prompts || []).forEach(p => {
+      const key = `${server.server}_${p.name}`
+      out[key] = {
+        key,
+        name: p.name,
+        description: p.description || '',
+        server: server.server,
+      }
+    })
+  })
+  return out
+}
+
+export function resolvePromptInfo(key, promptInfoByKey) {
+  if (!key) return null
+  return promptInfoByKey[key] || { key, name: key, description: '', server: '' }
+}
+
+// Walk through messages and inject synthetic system entries at points where the
+// active custom prompt changed (based on the per-user-message _activePromptKey
+// snapshot). Strips _activePromptKey from the exported messages.
+export function buildExportConversation(messages, promptInfoByKey) {
+  const out = []
+  let prev = null
+  let sawAny = false
+  for (const m of messages) {
+    if (m && m.role === 'user' && Object.prototype.hasOwnProperty.call(m, '_activePromptKey')) {
+      const cur = m._activePromptKey || null
+      if (!sawAny || cur !== prev) {
+        if (cur) {
+          const info = resolvePromptInfo(cur, promptInfoByKey)
+          out.push({
+            role: 'system',
+            content: info.description
+              ? `Custom prompt activated: ${info.name} (from ${info.server}) — ${info.description}`
+              : `Custom prompt activated: ${info.name} (from ${info.server})`,
+            timestamp: m.timestamp,
+            _promptChange: true,
+            promptKey: info.key,
+            promptName: info.name,
+            promptServer: info.server,
+            promptDescription: info.description,
+          })
+        } else if (sawAny && prev) {
+          out.push({
+            role: 'system',
+            content: 'Custom prompt cleared (using default prompt)',
+            timestamp: m.timestamp,
+            _promptChange: true,
+            promptKey: null,
+          })
+        }
+        prev = cur
+        sawAny = true
+      }
+    }
+    const { _activePromptKey, ...rest } = m || {}
+    out.push(rest)
+  }
+  return out
+}


### PR DESCRIPTION
## Summary

Closes #590. Chat export now surfaces the custom prompt the user selected.

- `metadata.activePrompt` (key, name, description, server) added to the JSON export, and a corresponding line added to the text export.
- User messages now carry an `_activePromptKey` snapshot at send-time. The export walks the conversation and injects synthetic `{ role: "system", _promptChange: true, ... }` entries at every point the active prompt changed (or was cleared back to default).
- `exportVersion` bumped from `1.1` → `1.2`.
- Logic extracted into `frontend/src/utils/chatExport.js` and unit-tested.

## Tradeoff

The actual prompt body lives on the backend MCP server (see `atlas/application/chat/preprocessors/prompt_override_service.py`) — it is never sent to the frontend. So the injected system entry describes the prompt by name/description/server rather than embedding the full prompt text shown in the issue's mock-up. Structured fields (`promptKey`, `promptName`, `promptServer`, `promptDescription`) are included so a downstream consumer can resolve or render it. Embedding the full body would require a new backend endpoint or expanding `/api/config` — out of scope for this issue.

Conversations loaded from history that pre-date this PR won't have `_activePromptKey` on their stored user messages, so they won't get retroactive prompt-change markers; `metadata.activePrompt` still reflects the prompt active at export time.

## Test plan

- [x] New unit tests in `frontend/src/test/chatExport.test.js` (12 cases: activation, switching, clearing, snapshot stripping, missing-config fallback)
- [x] Full frontend suite green: 418/418 across 37 files
- [x] ESLint clean on touched files
- [ ] Manual: select a custom prompt mid-conversation, download as JSON, verify `metadata.activePrompt` and the injected `system` entry at the switch point
- [ ] Manual: download as text and verify the `Active Custom Prompt:` header line