### PR TITLE
Close subprocess transports on event-loop teardown

### DIFF
--- a/INVESTIGATION_unraisable_warning.md
+++ b/INVESTIGATION_unraisable_warning.md
@@ -1,0 +1,117 @@
+# PytestUnraisableExceptionWarning investigation
+
+Branch: `investigate/unraisable-py313-warning` (local-only, no PR.)
+
+## Symptom
+CI on Python 3.12.13 and 3.13.2 emits ~3–5
+`PytestUnraisableExceptionWarning` lines that all trace back to
+`BaseSubprocessTransport.__del__` ending in
+`RuntimeError: Event loop is closed`. Tests still pass. Different runs
+attribute the warning to different tests (the user-reported set spans
+`test_agent_portal_groups`, `test_agent_portal_polish`,
+`test_process_manager::test_get_missing_raises`,
+`test_websocket_auth_header`, `test_rag_citations`,
+`test_streaming_token_flow`) — i.e. the named test is whichever one
+happened to be running when GC ran, not the one that leaked.
+
+## Reproduction
+Running the named tests in isolation never emits the warning. Running
+the full suite under `PYTHONDEVMODE=1 PYTHONWARNINGS=always` on Python
+3.13.12 surfaces 7 `ResourceWarning: unclosed transport
+<_UnixSubprocessTransport pid=… running stdout=… stderr=…>` entries plus
+a clutch of follow-on pipe / file warnings — this is the same leak the
+CI run trips on, just before GC has had a chance to convert it to the
+unraisable form.
+
+## Root cause
+`atlas.modules.process_manager.manager.ProcessManager.launch` spawns
+each subprocess via `asyncio.create_subprocess_exec` and creates two
+background tasks per process: `_pump_stream`/`_pump_pty` and
+`_wait_and_finalize` (which awaits `proc.wait()` and pops the entry
+from `_asyncio_procs` once the child exits). `cancel` additionally
+schedules a fire-and-forget `_kill_if_still_alive` task.
+
+Several tests — both bare `pm = ProcessManager()` cases and the HTTP
+fixture in `test_agent_portal_polish.py` / `test_agent_portal_groups.py`
+— end while a child is still running. pytest-asyncio's per-test event
+loop is then torn down: pending tasks receive `CancelledError`,
+`asyncio_proc.wait()` aborts, and the asyncio subprocess transport
+never has `_process_exited` invoked. Result: the
+`_UnixSubprocessTransport` is reachable (still referenced through the
+about-to-be-dropped `ProcessManager`) but `_closed` is still `False`
+and `_loop` points at the now-closed loop.
+
+When a later test triggers a GC pass, `BaseSubprocessTransport.__del__`
+fires:
+* On Python 3.12 it unconditionally calls `proto.pipe.close()`, which
+  schedules `loop.call_soon(self._call_connection_lost, exc)` on the
+  closed loop → `RuntimeError: Event loop is closed` → pytest converts
+  it to `PytestUnraisableExceptionWarning`. CPython
+  [gh-114177](https://github.com/python/cpython/issues/114177) added a
+  loop-is-closed guard to that branch in 3.13 which kills most of the
+  3.13 occurrences, but residual code paths plus the fact that we
+  leave subprocess pipe transports half-open still produces warnings
+  in some 3.13 runs.
+
+So this is *both* a Python-version interaction and a real cleanup bug
+in our ProcessManager — the test-time leak is what gives `__del__`
+anything to run against.
+
+## Fix
+`atlas/modules/process_manager/manager.py`: handle `CancelledError` in
+the two long-lived tasks that wrap `asyncio_proc.wait()`
+(`_wait_and_finalize` and the inner `_kill_if_still_alive` inside
+`cancel`). When the loop is being torn down we now:
+1. `asyncio_proc.kill()` (idempotent / tolerates `ProcessLookupError`),
+2. call `asyncio_proc._transport.close()` while the loop is still
+   alive — this flips `transport._closed` to `True` so the later
+   `__del__` short-circuits before touching the closed loop,
+3. pop the entry from `_asyncio_procs`,
+4. re-raise `CancelledError` so the task ends cleanly.
+
+This is intentionally surgical: no test code changes, no public-API
+changes, no warning suppression — the underlying leak is what we
+plug.
+
+## Verification
+
+Full suite, Python 3.13.12, `PYTHONDEVMODE=1 PYTHONWARNINGS=always`:
+
+| Metric                                      | Before | After |
+|---------------------------------------------|--------|-------|
+| `ResourceWarning: ... _UnixSubprocessTransport` | 7      | **0** |
+| Warnings reported by pytest                  | 33     | 2     |
+| Tests                                        | 1469 passed, 17 skipped | 1469 passed, 17 skipped |
+
+Full suite, Python 3.12.3, `PYTHONDEVMODE=1`:
+
+| Metric                                                         | After |
+|----------------------------------------------------------------|-------|
+| `_UnixSubprocessTransport` leaks                              | **0** |
+| `PytestUnraisableExceptionWarning` / "Event loop is closed"   | **0** |
+| Tests                                                          | 1469 passed, 17 skipped |
+
+The two residual warnings on 3.13 (and four on 3.12) are unrelated —
+an OTEL JSONL exporter file kept open across the test session, a
+`_UnixSelectorEventLoop` finalizer warning emitted by pytest-asyncio's
+own loop teardown, and on 3.12 two `subprocess … is still running`
+warnings from `subprocess.Popen.__del__` (not the asyncio transport
+path that was the original symptom).
+
+Spot-checking the five CI-named tests under 3.12 dev mode:
+`test_group_max_panes_enforced_server_side`,
+`test_http_pause_resume_records_audit`, `test_http_snapshot_endpoint`,
+`test_process_manager::test_get_missing_raises`,
+`test_websocket_uses_x_user_email_header` — all pass, zero warnings.
+
+## Recommended next step
+Land the manager.py change. Lower-priority follow-ups (out of scope
+for this branch):
+* The OTEL exporter file (`atlas/core/otel_config.py:271`) is never
+  closed during pytest sessions — small leak that would be visible
+  under `PYTHONDEVMODE=1` to anyone investigating.
+* `cancel` is still fire-and-forget for the SIGKILL escalation; if a
+  test wants deterministic teardown it currently has to poll status.
+  Adding an `async def aclose(self)` to `ProcessManager` (drain
+  `_asyncio_procs`, close transports, await waits) would let fixtures
+  do `await pm.aclose()` instead of nulling singletons and hoping.

--- a/INVESTIGATION_unraisable_warning.md
+++ b/INVESTIGATION_unraisable_warning.md
@@ -1,6 +1,7 @@
 # PytestUnraisableExceptionWarning investigation
 
-Branch: `investigate/unraisable-py313-warning` (local-only, no PR.)
+Branch: `investigate/unraisable-py313-warning` — shipped as
+[sandialabs/atlas-ui-3#603](https://github.com/sandialabs/atlas-ui-3/pull/603).
 
 ## Symptom
 CI on Python 3.12.13 and 3.13.2 emits ~3–5

--- a/atlas/modules/process_manager/manager.py
+++ b/atlas/modules/process_manager/manager.py
@@ -856,6 +856,23 @@ class ProcessManager:
                         sanitize_for_logging(process_id),
                         sanitize_for_logging(e),
                     )
+            except asyncio.CancelledError:
+                # Loop is shutting down before we finished policing the
+                # SIGTERM grace period. Force-kill and close the asyncio
+                # transport so its __del__ doesn't fire on a closed loop
+                # later. See _wait_and_finalize for the longer
+                # explanation.
+                try:
+                    asyncio_proc.kill()
+                except (ProcessLookupError, OSError):
+                    pass
+                transport = getattr(asyncio_proc, "_transport", None)
+                if transport is not None:
+                    try:
+                        transport.close()
+                    except Exception:
+                        pass
+                raise
 
         asyncio.create_task(_kill_if_still_alive())
         managed.status = ProcessStatus.CANCELLED
@@ -980,7 +997,33 @@ class ProcessManager:
         managed: ManagedProcess,
         asyncio_proc: asyncio.subprocess.Process,
     ) -> None:
-        exit_code = await asyncio_proc.wait()
+        try:
+            exit_code = await asyncio_proc.wait()
+        except asyncio.CancelledError:
+            # The event loop is being torn down (typically a test ending
+            # while the child is still running). If we let the task die
+            # here, the asyncio subprocess transport is left "open" — its
+            # __del__ then fires at some later GC point and, depending on
+            # Python version, either emits a ResourceWarning or tries to
+            # use the now-closed loop and raises RuntimeError("Event loop
+            # is closed"), which pytest captures as
+            # PytestUnraisableExceptionWarning. Closing the transport
+            # synchronously while the loop is still alive flips
+            # ``_closed`` to True so __del__ becomes a no-op. (Python
+            # 3.13 partially fixes this via CPython gh-114177, but 3.12
+            # still trips on it; both benefit from explicit close.)
+            try:
+                asyncio_proc.kill()
+            except (ProcessLookupError, OSError):
+                pass
+            transport = getattr(asyncio_proc, "_transport", None)
+            if transport is not None:
+                try:
+                    transport.close()
+                except Exception:
+                    pass
+            self._asyncio_procs.pop(managed.id, None)
+            raise
         managed.exit_code = exit_code
         managed.ended_at = time.time()
         if managed.status == ProcessStatus.CANCELLED:

--- a/atlas/modules/process_manager/manager.py
+++ b/atlas/modules/process_manager/manager.py
@@ -858,20 +858,11 @@ class ProcessManager:
                     )
             except asyncio.CancelledError:
                 # Loop is shutting down before we finished policing the
-                # SIGTERM grace period. Force-kill and close the asyncio
-                # transport so its __del__ doesn't fire on a closed loop
-                # later. See _wait_and_finalize for the longer
-                # explanation.
-                try:
-                    asyncio_proc.kill()
-                except (ProcessLookupError, OSError):
-                    pass
-                transport = getattr(asyncio_proc, "_transport", None)
-                if transport is not None:
-                    try:
-                        transport.close()
-                    except Exception:
-                        pass
+                # SIGTERM grace period. Force-kill the whole process
+                # group and close the asyncio transport so its __del__
+                # doesn't fire on a closed loop later. See
+                # _wait_and_finalize for the longer explanation.
+                self._kill_and_close_transport(managed, asyncio_proc)
                 raise
 
         asyncio.create_task(_kill_if_still_alive())
@@ -992,6 +983,54 @@ class ProcessManager:
                 # fd already closed — expected during teardown.
                 pass
 
+    def _kill_and_close_transport(
+        self,
+        managed: ManagedProcess,
+        asyncio_proc: asyncio.subprocess.Process,
+    ) -> None:
+        """Force-kill ``asyncio_proc`` and close its asyncio transport.
+
+        Used from the ``CancelledError`` paths in ``_wait_and_finalize``
+        and the inner ``_kill_if_still_alive`` task. Mirrors the
+        process-group kill that ``cancel()`` uses for normal teardown
+        — ``launch()`` always starts children with
+        ``start_new_session=True``, so killing only the session leader
+        would orphan any descendants (e.g. ``bash -c 'sleep 999'``).
+        Closing the asyncio transport while the loop is still alive
+        flips ``transport._closed`` so a later ``__del__`` short-
+        circuits before touching the closed loop.
+        """
+        if asyncio_proc.pid is not None:
+            try:
+                os.killpg(os.getpgid(asyncio_proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                # Process group already gone or we lost the right to
+                # signal it — fall through to the direct-kill path.
+                try:
+                    asyncio_proc.kill()
+                except (ProcessLookupError, OSError):
+                    pass
+        else:
+            try:
+                asyncio_proc.kill()
+            except (ProcessLookupError, OSError):
+                pass
+
+        transport = getattr(asyncio_proc, "_transport", None)
+        if transport is not None:
+            try:
+                transport.close()
+            except (RuntimeError, OSError) as exc:
+                # RuntimeError surfaces when the loop has already
+                # closed; OSError covers pipe-fd churn during teardown.
+                # Either way the transport is on its way out and the
+                # only goal here is the ``_closed=True`` side effect.
+                logger.debug(
+                    "transport.close() during teardown of %s raised: %s",
+                    sanitize_for_logging(managed.id),
+                    sanitize_for_logging(exc),
+                )
+
     async def _wait_and_finalize(
         self,
         managed: ManagedProcess,
@@ -1012,16 +1051,7 @@ class ProcessManager:
             # ``_closed`` to True so __del__ becomes a no-op. (Python
             # 3.13 partially fixes this via CPython gh-114177, but 3.12
             # still trips on it; both benefit from explicit close.)
-            try:
-                asyncio_proc.kill()
-            except (ProcessLookupError, OSError):
-                pass
-            transport = getattr(asyncio_proc, "_transport", None)
-            if transport is not None:
-                try:
-                    transport.close()
-                except Exception:
-                    pass
+            self._kill_and_close_transport(managed, asyncio_proc)
             self._asyncio_procs.pop(managed.id, None)
             raise
         managed.exit_code = exit_code

--- a/atlas/tests/test_process_manager.py
+++ b/atlas/tests/test_process_manager.py
@@ -369,3 +369,117 @@ async def test_child_env_is_isolated(monkeypatch):
     assert "LANG" in env_keys
     for denied in secrets:
         assert denied not in env_keys, f"{denied} leaked to child"
+
+
+# ---------------------------------------------------------------------------
+# Loop-teardown cleanup — regression coverage for the CancelledError paths in
+# ``_wait_and_finalize`` / ``_kill_if_still_alive``. Without this, the asyncio
+# subprocess transport is left ``_closed=False`` when pytest-asyncio cancels
+# the wait task at end-of-test; ``BaseSubprocessTransport.__del__`` then fires
+# at the next GC pass and (under Python 3.12) raises
+# ``RuntimeError("Event loop is closed")``, which pytest surfaces as
+# ``PytestUnraisableExceptionWarning``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_and_close_transport_marks_transport_closed():
+    """Calling the helper directly should kill the child and flip the
+    asyncio subprocess transport's ``_closed`` flag synchronously."""
+    manager = ProcessManager()
+    managed = await manager.launch(
+        command="/usr/bin/sleep", args=["30"], user_email="alice@x",
+    )
+    asyncio_proc = manager._asyncio_procs[managed.id]
+    transport = asyncio_proc._transport
+    assert transport is not None
+    assert transport.is_closing() is False
+
+    manager._kill_and_close_transport(managed, asyncio_proc)
+
+    # _closed flips immediately; pipe-cleanup is fire-and-forget via
+    # call_soon, but is_closing() returns the _closed flag.
+    assert transport.is_closing() is True
+    # Drain so the wait task observes the dead child and clears state,
+    # otherwise we'd be the test that leaks transports.
+    await asyncio.wait_for(asyncio_proc.wait(), timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_and_finalize_closes_transport_on_cancellation():
+    """Simulate pytest-asyncio's loop teardown: cancel the long-lived
+    wait task that ``launch()`` registered while the child is still
+    running, and confirm the transport is closed and the entry is
+    dropped from ``_asyncio_procs`` so the unraisable warning path
+    can't fire later."""
+    manager = ProcessManager()
+    managed = await manager.launch(
+        command="/usr/bin/sleep", args=["30"], user_email="alice@x",
+    )
+    asyncio_proc = manager._asyncio_procs[managed.id]
+    transport = asyncio_proc._transport
+    assert transport is not None
+
+    # The wait task isn't held by ProcessManager, so locate it via the
+    # loop. There is exactly one task awaiting this proc's wait() — the
+    # one scheduled by launch(). Yield first so the task actually
+    # enters its body and reaches ``await asyncio_proc.wait()``;
+    # cancelling a task that has not yet run aborts it without running
+    # the except handler we're trying to exercise.
+    await asyncio.sleep(0)
+    wait_task = next(
+        t for t in asyncio.all_tasks()
+        if t.get_coro().__qualname__ == "ProcessManager._wait_and_finalize"
+    )
+
+    wait_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await wait_task
+
+    assert transport.is_closing() is True
+    assert managed.id not in manager._asyncio_procs
+
+
+@pytest.mark.asyncio
+async def test_loop_teardown_does_not_emit_unraisable_warning():
+    """End-to-end: after the wait task is cancelled, a GC pass must not
+    produce any ``PytestUnraisableExceptionWarning`` from
+    ``BaseSubprocessTransport.__del__``. This is the user-visible
+    symptom we shipped this fix for."""
+    import gc
+    import warnings
+
+    manager = ProcessManager()
+    managed = await manager.launch(
+        command="/usr/bin/sleep", args=["30"], user_email="alice@x",
+    )
+
+    # See companion test above for why this yield matters.
+    await asyncio.sleep(0)
+    wait_task = next(
+        t for t in asyncio.all_tasks()
+        if t.get_coro().__qualname__ == "ProcessManager._wait_and_finalize"
+    )
+    wait_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await wait_task
+
+    # Drop the only remaining strong references the test holds. The
+    # subprocess.Process and its transport should then be eligible for
+    # collection and __del__ should be a no-op (because _closed=True).
+    del managed
+    del manager
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        gc.collect()
+
+    offenders = [
+        w for w in captured
+        if "Event loop is closed" in str(w.message)
+        or "unclosed transport" in str(w.message)
+    ]
+    assert offenders == [], (
+        f"unexpected unraisable / unclosed-transport warning(s): "
+        f"{[str(w.message) for w in offenders]}"
+    )


### PR DESCRIPTION
## Summary

CI was emitting `PytestUnraisableExceptionWarning` lines on every run (Python 3.12.13 and 3.13.2), all tracing back to `BaseSubprocessTransport.__del__` ending in `RuntimeError: Event loop is closed`. Tests still passed, but the warnings were noisy and the named test rotated run-to-run — classic GC-attribution red herring.

## Root cause

`ProcessManager.launch` (atlas/modules/process_manager/manager.py) registers `_wait_and_finalize`, and `cancel` registers an inner `_kill_if_still_alive`. Both sit on `await asyncio_proc.wait()`. When a test ends with the child still running, pytest-asyncio's per-test loop is torn down and those tasks are cancelled mid-wait, so asyncio never calls `_process_exited` on the `_UnixSubprocessTransport`. The transport is still reachable (through `pm._asyncio_procs` and the stream readers) with `_closed=False` and a stale `_loop`. A later GC pass fires `BaseSubprocessTransport.__del__` which, on Python 3.12, unconditionally calls `proto.pipe.close()` → `loop.call_soon(...)` on the closed loop → `RuntimeError: Event loop is closed`. pytest surfaces it as `PytestUnraisableExceptionWarning` against whatever test happened to be running at GC time. CPython [gh-114177](https://github.com/python/cpython/issues/114177) added a loop-is-closed guard to that branch in 3.13 which kills most 3.13 occurrences, but residual paths still trip.

Both a real cleanup bug in our code *and* a Python-version interaction — the test-time leak is what gives `__del__` anything to run against, and 3.12 is just stricter than 3.13 about the consequences.

## Fix

Handle `CancelledError` inside the two long-lived tasks that await `asyncio_proc.wait()`. On cancellation:
1. `os.killpg(getpgid(pid), SIGKILL)` to take down the whole process group (matches the rest of the module — `launch()` always starts children with `start_new_session=True`, so killing only the session leader would orphan descendants); fall back to `asyncio_proc.kill()` if the group kill fails.
2. `asyncio_proc._transport.close()` while the loop is still alive — this flips `transport._closed=True` so the later `__del__` short-circuits before touching the closed loop. Narrow exception scope to `(RuntimeError, OSError)` with debug logging so a real bug isn't swallowed silently.
3. Pop the entry from `_asyncio_procs`, re-raise `CancelledError`.

The shared cleanup is extracted into a single private helper `_kill_and_close_transport()` so the two call sites can't drift.

## Regression tests (`atlas/tests/test_process_manager.py`)
- `test_kill_and_close_transport_marks_transport_closed` — unit test of the helper.
- `test_wait_and_finalize_closes_transport_on_cancellation` — simulates pytest-asyncio's loop teardown by locating the `_wait_and_finalize` task in `asyncio.all_tasks()` and cancelling it.
- `test_loop_teardown_does_not_emit_unraisable_warning` — end-to-end: cancel + drop refs + `gc.collect()` inside `warnings.catch_warnings(record=True)`, asserts zero `unclosed transport` / `Event loop is closed` warnings.

All three tests fail against pristine `main` and pass with this PR — confirmed by running them with the manager.py change reverted.

## Verification

Full suite under `PYTHONDEVMODE=1 PYTHONWARNINGS=always` (which exposes `ResourceWarning: unclosed transport <_UnixSubprocessTransport ...>` before GC converts it to the unraisable form):

**Python 3.13.12**

| Metric | Before | After |
| --- | --- | --- |
| `_UnixSubprocessTransport` leak warnings | 7 | **0** |
| pytest warnings total | 33 | 1 |
| Tests | 1469 passed / 17 skipped | 1472 passed / 17 skipped (3 new) |

**Python 3.12.3** (after fix)

- `_UnixSubprocessTransport` leaks: **0**
- `PytestUnraisableExceptionWarning` / "Event loop is closed": **0**
- 1472 passed / 17 skipped

Residual warnings (1 on 3.13, 2 on 3.12) are unrelated infrastructure: an OTEL JSONL exporter file kept open across the test session, pytest-asyncio's own loop-teardown finalizer, and on 3.12 a couple of `subprocess.Popen.__del__` "still running" warnings (separate code path from the asyncio transport issue this PR fixes). Captured as low-priority follow-ups in `INVESTIGATION_unraisable_warning.md`.

## Review response

Inline comments from Codex / Copilot were all addressed in commit `6d54a53`:
- **Codex P2 — process-group kill on teardown:** now uses `os.killpg(getpgid(pid), SIGKILL)` to match `cancel()`'s semantics.
- **Copilot — narrow `except Exception`:** narrowed to `(RuntimeError, OSError)` with `logger.debug(...)` on failure.
- **Copilot — extract helper:** new `_kill_and_close_transport()` shared by both call sites.
- **Copilot — regression test:** three new tests added (see above).
- **Copilot — investigation doc wording:** updated to reference this PR.

## Test plan
- [x] `PYTHONDEVMODE=1 PYTHONWARNINGS=always pytest atlas/tests` clean on 3.13.12
- [x] `PYTHONDEVMODE=1 pytest atlas/tests` clean on 3.12.3
- [x] New regression tests fail against pristine `main`, pass with this PR
- [x] All five originally-CI-named tests still pass with zero warnings under 3.12 dev mode
- [ ] CI green on this PR