### PR TITLE
chore: release smoke-test follow-ups (pptx extra, --version, doc fix)

### DIFF
--- a/.github/release-checklist.md
+++ b/.github/release-checklist.md
@@ -62,8 +62,7 @@ See [docs/developer/release-process.md#smoke-test](../docs/developer/release-pro
 - [ ] `uv build --wheel` succeeds on `release/{{YEAR_MONTH}}`.
 - [ ] Fresh `atlas-init` + `atlas-chat` one-shot call works against
       a real LLM.
-- [ ] Tool-call path works (`atlas-chat --tools calculator_evaluate
-      --tool-choice-required`).
+- [ ] Tool-call path works (`atlas-chat --tools calculator_evaluate`).
 - [ ] `atlas-server` boots and `/api/health` returns `{{VERSION}}`.
 
 ### Publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #605 - 2026-05-13
+- **Packaging**: New focused `[pptx]` extras group (`pip install atlas-chat[pptx]`) pulls Pillow + python-pptx for the `pptx_generator` MCP server. Without it the server logged `ModuleNotFoundError: No module named 'PIL'` on a bare wheel install. Pillow stays in the broader `[mcp-demos]` extras as well.
+- **CLI**: `atlas-chat --version` now prints `atlas-chat version X.Y.Z` and exits, matching `atlas-init`. The release smoke test references this flag.
+- **Docs**: Removed `--tool-choice-required` from the smoke-test recipe in `docs/developer/release-process.md` and the release checklist; it is not (and was not) a real `atlas-chat` flag.
+
 ### PR #602 - 2026-05-12
 - Docker runtime-only image now installs with `--ignore-requires-python` for LiteLLM compatibility on Chainguard Python 3.14, and CI now validates `Dockerfile.runtimeonly` builds.
 

--- a/atlas/atlas_chat_cli.py
+++ b/atlas/atlas_chat_cli.py
@@ -26,6 +26,14 @@ import os
 import sys
 from pathlib import Path
 
+# Short-circuit --version before any heavy imports so version reporting stays
+# instant. argparse still registers --version below for --help discoverability.
+if "--version" in sys.argv[1:]:
+    from atlas.version import VERSION
+
+    print(f"atlas-chat version {VERSION}")
+    sys.exit(0)
+
 # Suppress LiteLLM verbose stdout noise BEFORE any transitive import of litellm.
 # litellm._logging reads LITELLM_LOG at import time and defaults to DEBUG.
 if "LITELLM_LOG" not in os.environ:
@@ -211,6 +219,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--file-extractors-config",
         default=None,
         help="Override file extractors config file (sets FILE_EXTRACTORS_CONFIG_FILE). Accepts a filename or path.",
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print version and exit.",
     )
     return parser
 

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -307,7 +307,7 @@ cd /tmp && rm -rf atlas-smoke-work && mkdir atlas-smoke-work && cd atlas-smoke-w
 
 # Tool call path
 /tmp/atlas-smoke/bin/atlas-chat "What is 2+2?" \
-  --tools calculator_evaluate --tool-choice-required
+  --tools calculator_evaluate
 
 # Web server smoke
 /tmp/atlas-smoke/bin/atlas-server --port 18000 &

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Focused extras for the pptx_generator MCP server. Install with
+# `pip install atlas-chat[pptx]` to enable the markdown-to-PowerPoint
+# tool without pulling the full mcp-demos set. Keep in sync with the
+# [dependency-groups] pptx entry below.
+pptx = [
+    "Pillow>=10.0.0,<13.0.0",
+    "python-pptx>=0.6.21,<2.0.0",
+]
 # Keep in sync with [dependency-groups] mcp-demos below
 mcp-demos = [
     "beautifulsoup4>=4.12.0,<5.0.0",
@@ -86,6 +94,11 @@ Repository = "https://github.com/sandialabs/atlas"
 Issues = "https://github.com/sandialabs/atlas/issues"
 
 [dependency-groups]
+# Keep in sync with [project.optional-dependencies] pptx above
+pptx = [
+    "Pillow>=10.0.0,<13.0.0",
+    "python-pptx>=0.6.21,<2.0.0",
+]
 # Keep in sync with [project.optional-dependencies] mcp-demos above
 mcp-demos = [
     "beautifulsoup4>=4.12.0,<5.0.0",


### PR DESCRIPTION
## Summary

Three small follow-ups uncovered by the v0.2.0 wheel smoke test against `release/2026.05`:

- **Packaging** — new focused `[pptx]` extras group (`pip install atlas-chat[pptx]`) pulls Pillow + python-pptx so the `pptx_generator` MCP server starts cleanly on a bare wheel install. A plain `pip install atlas-chat` was logging `ModuleNotFoundError: No module named 'PIL'` during MCP tool discovery. Pillow stays in the broader `[mcp-demos]` extras as well.
- **CLI** — `atlas-chat --version` now prints `atlas-chat version X.Y.Z` and exits, mirroring `atlas-init --version`. The check short-circuits before the heavy litellm imports so it returns instantly. The release smoke-test recipe already referenced this flag (it just didn't exist yet).
- **Docs** — removed `--tool-choice-required` from `docs/developer/release-process.md` and `.github/release-checklist.md`. It is not (and was not) a real `atlas-chat` CLI flag; the `tool_choice_required` Python kwarg in `README.md` is unrelated and left alone.

## Context

PR #587 (packaged prompts) has already been cherry-picked onto `release/2026.05` so the system-prompt-not-found warning is resolved there. These three nits are the remaining doc/packaging gaps from the smoke test. They're not blockers for tagging v0.2.0 — they target `main` and can be cherry-picked to `release/2026.05` if the release captain wants them in.

## Test plan

- [x] `pyproject.toml` parses with `tomllib`; new `pptx` extras group lists Pillow + python-pptx in both `[project.optional-dependencies]` and `[dependency-groups]`.
- [x] `atlas-chat --version` prints `atlas-chat version <current>` and exits 0 (verified locally against `main`'s 0.1.5).
- [x] `atlas-chat --help` lists `--version` (auto via argparse).
- [x] No other `--tool-choice-required` references remain in the repo (`README.md` uses the Python kwarg `tool_choice_required`, which is real).
- [ ] CI green.