### PR TITLE
ci: grant id-token write permission to PyPI publish jobs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -72,6 +72,9 @@ jobs:
     environment:
       name: testpypi
       url: https://test.pypi.org/p/atlas-chat
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Download distribution artifacts
         uses: actions/download-artifact@v8
@@ -93,6 +96,9 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/atlas-chat
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Download distribution artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- TestPyPI publish failed in [run 25779035610](https://github.com/sandialabs/atlas-ui-3/actions/runs/25779035610) with `Trusted publishing exchange failure: ACTIONS_ID_TOKEN_REQUEST_TOKEN was unset`.
- Root cause: `pypa/gh-action-pypi-publish@release/v1` enables PEP 740 attestations by default, which requires an OIDC token even when authenticating via API token. The `publish-testpypi` and `publish-pypi` jobs did not grant `id-token: write`.
- Fix: add `permissions: { id-token: write, contents: read }` to both publish jobs. Auth still uses the existing `*_PYPI_API_TOKEN` secrets; attestations are now generated and uploaded alongside the artifacts.

## Test plan
- [ ] Re-run the workflow against TestPyPI via `workflow_dispatch` and confirm the publish step succeeds.
- [ ] Confirm `.publish.attestation` files are uploaded next to the wheel/sdist.