### PR TITLE
fix(release): bump pyproject.toml to 0.2.0; gate publish on version agreement

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,6 +24,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Verify version agreement
+        shell: bash
+        run: |
+          set -euo pipefail
+          pyproject_version="$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)"
+          atlas_version="$(grep -m1 '^VERSION' atlas/version.py | cut -d'"' -f2)"
+          echo "pyproject.toml version: ${pyproject_version}"
+          echo "atlas/version.py VERSION: ${atlas_version}"
+          if [ "${pyproject_version}" != "${atlas_version}" ]; then
+            echo "::error::Version mismatch: pyproject.toml=${pyproject_version} but atlas/version.py=${atlas_version}. Both must agree before publishing."
+            exit 1
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-chat"
-version = "0.1.5"
+version = "0.2.0"
 description = "Full-stack LLM chat interface with Model Context Protocol (MCP) integration"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- **Root cause**: PR #610 (release: 0.2.0) was hand-crafted and bumped only `atlas/version.py`, leaving `pyproject.toml` at `0.1.5`. When the v0.2.0 release fired `pypi-publish.yml`, the build produced `atlas_chat-0.1.5-*` artifacts and PyPI rejected them: **400 File already exists**.
- **Fix**: bump `pyproject.toml` to `0.2.0` so the two sources of truth agree.
- **Guardrail**: add a "Verify version agreement" step at the top of the build job in `pypi-publish.yml` — if `pyproject.toml` and `atlas/version.py` disagree, the publish fails fast instead of silently producing wrong artifacts.

## Why this happened

The `release-cut.yml` workflow correctly bumps both files (steps "Bump atlas/version.py" and "Bump pyproject.toml"), but in this case `chore(release): cut v0.2.0` (commit `85a2b1b78`) was made manually and only touched `version.py` and `CHANGELOG.md`. The guardrail catches future drift regardless of how the bump commit was made.

## Failed run for reference

[Run 25981211353](https://github.com/sandialabs/atlas-ui-3/actions/runs/25981211353) — `Publish Python Package to PyPI` for v0.2.0, with the 400 from `upload.pypi.org/legacy/`.

## Follow-up after merge

1. Trigger `pypi-publish.yml` via workflow_dispatch with `target=testpypi`, verify on test.pypi.org.
2. Trigger same workflow with `target=pypi`, verify on pypi.org.
3. Re-attach the built `dist/*` to the existing v0.2.0 GitHub release.

## Test plan

- [ ] CI on this PR is green (the new step prints both versions and they match: `0.2.0`).
- [ ] Post-merge: TestPyPI publish via workflow_dispatch produces `atlas_chat-0.2.0-*` artifacts.
- [ ] Post-merge: PyPI publish succeeds (no 400).