### PR TITLE
fix(chat): block sending while WebSocket is disconnected (#448)

### DIFF
--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { useChat } from '../contexts/ChatContext'
 import { useWS } from '../contexts/WSContext'
-import { Send, Paperclip, X, Square, FileText, FileSearch, FileX, Search, Image, Wrench } from 'lucide-react'
+import { Send, Paperclip, X, Square, FileText, FileSearch, FileX, Search, Image, Wrench, WifiOff } from 'lucide-react'
 import Message from './Message'
 import WelcomeScreen from './WelcomeScreen'
 import encodeFileKeyPath from '../utils/encodeFileKeyPath'
@@ -60,7 +60,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
     followUpSuggestions,
     setFollowUpSuggestions,
   } = useChat()
-  const { isConnected } = useWS()
+  const { isConnected, connectionStatus } = useWS()
 
   // Whether the currently selected model supports vision (image) input
   const currentModelSupportsVision = models?.some(
@@ -185,7 +185,9 @@ const ChatArea = ({ onOpenRagPanel }) => {
       const processedFiles = await processFileReferences(message)
       const allFiles = { ...uploadedFiles, ...processedFiles }
 
-      sendChatMessage(message, allFiles, forceRag)
+      // Keep the user's text if the send was rejected (e.g. disconnected) so
+      // they don't lose their message.
+      if (!sendChatMessage(message, allFiles, forceRag)) return
       setInputValue('')
 
       // Reset textarea height
@@ -195,7 +197,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
     } catch (error) {
       console.error('Error in handleSubmit:', error)
       // Still try to send the message without file processing
-      sendChatMessage(message, uploadedFiles, forceRag)
+      if (!sendChatMessage(message, uploadedFiles, forceRag)) return
       setInputValue('')
 
       // Reset textarea height
@@ -893,6 +895,20 @@ const ChatArea = ({ onOpenRagPanel }) => {
         <div className="max-w-4xl mx-auto">
           {/* Enabled Tools Indicator */}
           <EnabledToolsIndicator />
+
+          {/* Warning: WebSocket disconnected - sending is blocked until reconnected */}
+          {!isConnected && (
+            <div
+              className="mb-2 px-3 py-2 bg-red-900/40 border border-red-600/50 rounded-lg flex items-center gap-2 text-red-300 text-sm"
+              role="status"
+              data-testid="ws-disconnected-banner"
+            >
+              <WifiOff className="w-4 h-4 flex-shrink-0" />
+              <span>
+                Disconnected from server{connectionStatus ? ` (${connectionStatus})` : ''}. Messages can't be sent until the connection is restored.
+              </span>
+            </div>
+          )}
 
           {/* Warning: tools selected but model doesn't support tools */}
           {selectedTools.size > 0 && !currentModelSupportsTools && (

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -1,6 +1,7 @@
 // Slim ChatContext (clean refactor)
 import { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react'
 import { useWS } from './WSContext'
+import { useToast } from '../components/ui/toastContext'
 import { useChatConfig } from '../hooks/chat/useChatConfig'
 import { useSelections } from '../hooks/chat/useSelections'
 import { useAgentMode } from '../hooks/chat/useAgentMode'
@@ -87,7 +88,8 @@ export const ChatProvider = ({ children }) => {
 		})
 	}, [mapMessages])
 
-		const { sendMessage, addMessageHandler } = useWS()
+		const { sendMessage, addMessageHandler, isConnected } = useWS()
+	const toast = useToast()
 	const { currentModel } = config
 	const { selectedTools, selectedPrompts, activePrompts, selectedDataSources, ragEnabled, toggleRagEnabled } = selections
 
@@ -308,17 +310,13 @@ export const ChatProvider = ({ children }) => {
 	}, [config.ragServers])
 
 	const sendChatMessage = useCallback((content, extraFiles = {}, forceRag = false) => {
-		if (!content.trim() || !currentModel) return
-		if (isWelcomeVisible) setIsWelcomeVisible(false)
-		setFollowUpSuggestions([])
-		addMessage({
-			role: 'user',
-			content,
-			timestamp: new Date().toISOString(),
-			_activePromptKey: selections.activePromptKey || null,
-		})
-		setIsThinking(true)
-		setIsSynthesizing(false)
+		if (!content.trim() || !currentModel) return false
+		// Don't allow sending while the WebSocket is disconnected -- the message
+		// would never reach the backend and the UI would hang on "Thinking...".
+		if (!isConnected) {
+			toast.error('Not connected. Waiting to reconnect before sending.')
+			return false
+		}
 		const tagged = files.getTaggedFilesContent()
 
 		// Determine data sources to send:
@@ -332,7 +330,7 @@ export const ChatProvider = ({ children }) => {
 			? (hasSelectedSources ? [...selectedDataSources] : getAllRagSourceIds())
 			: []
 
-		sendMessage({
+		const sent = sendMessage({
 			type: 'chat',
 			content,
 			model: currentModel,
@@ -352,7 +350,26 @@ export const ChatProvider = ({ children }) => {
 			incognito: saveMode !== 'server',
 			conversation_id: activeConversationId || undefined,
 		})
-	}, [addMessage, currentModel, selectedTools, activePrompts, selectedDataSources, ragEnabled, config, selections, agent, files, isWelcomeVisible, sendMessage, settings, getAllRagSourceIds, saveMode, activeConversationId])
+		// Guard against a stale isConnected: if the socket dropped between the
+		// check above and the send, bail out without mutating the UI so we don't
+		// hang on "Thinking...".
+		if (!sent) {
+			toast.error('Not connected. Waiting to reconnect before sending.')
+			return false
+		}
+		// Only mutate the UI once the message is actually on the wire.
+		if (isWelcomeVisible) setIsWelcomeVisible(false)
+		setFollowUpSuggestions([])
+		addMessage({
+			role: 'user',
+			content,
+			timestamp: new Date().toISOString(),
+			_activePromptKey: selections.activePromptKey || null,
+		})
+		setIsThinking(true)
+		setIsSynthesizing(false)
+		return true
+	}, [addMessage, currentModel, selectedTools, activePrompts, selectedDataSources, ragEnabled, config, selections, agent, files, isWelcomeVisible, isConnected, toast, sendMessage, settings, getAllRagSourceIds, saveMode, activeConversationId])
 
 	const clearChat = useCallback(({ skipConfirm = false } = {}) => {
 		// If there is any chat content or generation in progress, confirm before

--- a/frontend/src/contexts/WSContext.jsx
+++ b/frontend/src/contexts/WSContext.jsx
@@ -71,12 +71,16 @@ export const WSProvider = ({ children }) => {
     }
   }
 
+  // Returns true if the message was handed to an open socket, false otherwise.
+  // Callers use the return value to avoid leaving the UI in a "waiting" state
+  // (e.g. an eternal "Thinking..." spinner) when the socket is disconnected.
   const sendMessage = (message) => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify(message))
-    } else {
-      console.error('WebSocket is not connected, readyState:', wsRef.current?.readyState)
+      return true
     }
+    console.error('WebSocket is not connected, readyState:', wsRef.current?.readyState)
+    return false
   }
 
   const addMessageHandler = (handler) => {

--- a/frontend/src/test/ws-disconnect-blocks-send.test.jsx
+++ b/frontend/src/test/ws-disconnect-blocks-send.test.jsx
@@ -1,0 +1,103 @@
+/**
+ * Regression test for issue #448 — don't allow sending a message while the
+ * WebSocket is disconnected.
+ *
+ * When disconnected, ChatArea must:
+ *   - disable the send button,
+ *   - show a "disconnected" banner, and
+ *   - refuse to call sendChatMessage (so the UI never hangs on "Thinking...").
+ * When connected again, sending works as normal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import ChatArea from '../components/ChatArea'
+import { useChat } from '../contexts/ChatContext'
+import { useWS } from '../contexts/WSContext'
+
+vi.mock('../contexts/ChatContext')
+vi.mock('../contexts/WSContext')
+
+describe('ChatArea - blocks sending while WebSocket is disconnected (#448)', () => {
+  const sendChatMessage = vi.fn()
+
+  const defaultChatContext = {
+    messages: [],
+    isWelcomeVisible: false,
+    isThinking: false,
+    sendChatMessage,
+    currentModel: 'gpt-4',
+    tools: [],
+    prompts: [],
+    selectedTools: new Set(),
+    selectedPrompts: new Set(),
+    toggleTool: vi.fn(),
+    togglePrompt: vi.fn(),
+    setToolChoiceRequired: vi.fn(),
+    sessionFiles: { files: [], total_files: 0, categories: {} },
+    agentModeEnabled: false,
+    agentPendingQuestion: null,
+    setAgentPendingQuestion: vi.fn(),
+    stopAgent: vi.fn(),
+    answerAgentQuestion: vi.fn(),
+    followUpSuggestions: [],
+    setFollowUpSuggestions: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useChat.mockReturnValue(defaultChatContext)
+  })
+
+  const renderChat = () =>
+    render(
+      <BrowserRouter>
+        <ChatArea />
+      </BrowserRouter>
+    )
+
+  const typeMessage = (text) => {
+    const textarea = screen.getByPlaceholderText(/Type a message/i)
+    fireEvent.change(textarea, { target: { value: text } })
+    return textarea
+  }
+
+  it('shows a disconnected banner and disables send when not connected', () => {
+    useWS.mockReturnValue({ isConnected: false, connectionStatus: 'Disconnected', sendMessage: vi.fn() })
+    const { container } = renderChat()
+
+    expect(screen.getByTestId('ws-disconnected-banner')).toBeInTheDocument()
+
+    typeMessage('hello')
+    // The submit (send) button must be disabled while disconnected, even with text.
+    const sendButton = container.querySelector('button[type="submit"]')
+    expect(sendButton).toBeTruthy()
+    expect(sendButton).toBeDisabled()
+  })
+
+  it('does not call sendChatMessage when Enter is pressed while disconnected', () => {
+    useWS.mockReturnValue({ isConnected: false, connectionStatus: 'Disconnected', sendMessage: vi.fn() })
+    renderChat()
+
+    const textarea = typeMessage('hello while offline')
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false })
+
+    expect(sendChatMessage).not.toHaveBeenCalled()
+  })
+
+  it('hides the banner and allows sending when connected', async () => {
+    sendChatMessage.mockReturnValue(true)
+    useWS.mockReturnValue({ isConnected: true, connectionStatus: 'Connected', sendMessage: vi.fn() })
+    renderChat()
+
+    expect(screen.queryByTestId('ws-disconnected-banner')).not.toBeInTheDocument()
+
+    const textarea = typeMessage('hello online')
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false })
+
+    // handleSubmit awaits @file reference processing, so the send is async.
+    await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(1))
+    expect(sendChatMessage).toHaveBeenCalledWith('hello online', expect.any(Object), false)
+  })
+})


### PR DESCRIPTION
Closes #448.

## Problem
Starting a conversation, letting the WebSocket disconnect, then trying to send a message would add the user's message bubble and show the "Thinking..." spinner — but the message never reached the backend, so the UI hung forever. The user should not have been allowed to send while disconnected.

## Root cause
`handleSubmit` and the send button already guarded on `isConnected`, but two gaps remained:
1. Follow-up suggestion buttons called `sendChatMessage()` directly with no connection guard.
2. `sendChatMessage` added the user message and set `isThinking(true)` *before* calling `sendMessage()`, which silently no-op'd when the socket was closed → permanent "Thinking…" with no reply.

## Fix
- `WSContext.sendMessage` now returns `true`/`false` based on whether the socket was actually open.
- `ChatContext.sendChatMessage` guards on `isConnected` up front **and** on the send result (catching a socket that drops mid-call), and only mutates the UI after the message is on the wire. This makes the central funnel safe for every caller, not just the form submit. Returns a boolean.
- A toast notifies the user when a send is rejected, and a disconnected banner above the input explains why sending is blocked.
- `handleSubmit` keeps the user's typed text if the send is rejected, so nothing is lost.

## Testing
- New regression test `ws-disconnect-blocks-send.test.jsx` (banner + disabled send when offline, Enter does not send when offline, normal send when online).
- Full frontend suite: 429 tests passing.
- Lint clean on changed files.