### PR TITLE
Remove the /search chat quick command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ frontend/src/
 
 **RAG+Tools**: When both RAG and tools are active, RAG `is_completion=True` responses must NOT short-circuit the LLM call; inject as context so tools remain available.
 
-**RAG Activation vs Selection**: Data sources are only sent to backend when RAG is explicitly activated (`ragEnabled` or `/search`). Selecting sources only marks availability.
+**RAG Activation vs Selection**: Data sources are only sent to backend when RAG is explicitly activated (`ragEnabled` toggle or one or more selected sources). Selecting sources only marks availability.
 
 ## Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### 2026-06-09
+- **RAG**: Removed the `/search` chat quick command, which silently forced RAG on from the message input and was a confusing entry point. RAG is still activated explicitly via the search-button toggle or by selecting one or more data sources; the `/search` autocomplete entry, its green input highlighting, and the `forceRag` send path are gone.
+
 ### PR #632 - 2026-06-03
 - **Config**: Split the 1300-line `atlas/modules/config/config_manager.py` into focused modules — `models.py` (Pydantic config models + `resolve_env_var`), `settings.py` (`AppSettings` + `build_db_url_from_parts`), and `config_loader.py` (`ConfigManager`). `config_manager.py` is now a thin entry point that re-exports every public symbol plus the singleton and getters, so existing `from atlas.modules.config.config_manager import ...` imports are unchanged. No behavior change; all four modules are now under 500 lines.
 

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -169,16 +169,8 @@ const ChatArea = ({ onOpenRagPanel }) => {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    let message = inputValue.trim()
+    const message = inputValue.trim()
     if (!message || !currentModel || !isConnected) return
-
-    // Check for /search command - strip prefix and force RAG
-    let forceRag = false
-    if (message.toLowerCase().startsWith('/search ')) {
-      message = message.substring(8).trim() // Remove '/search ' prefix
-      forceRag = true
-      if (!message) return
-    }
 
     try {
       // Process @file references in the message
@@ -187,7 +179,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
 
       // Keep the user's text if the send was rejected (e.g. disconnected) so
       // they don't lose their message.
-      if (!sendChatMessage(message, allFiles, forceRag)) return
+      if (!sendChatMessage(message, allFiles)) return
       setInputValue('')
 
       // Reset textarea height
@@ -197,7 +189,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
     } catch (error) {
       console.error('Error in handleSubmit:', error)
       // Still try to send the message without file processing
-      if (!sendChatMessage(message, uploadedFiles, forceRag)) return
+      if (!sendChatMessage(message, uploadedFiles)) return
       setInputValue('')
 
       // Reset textarea height
@@ -319,20 +311,9 @@ const ChatArea = ({ onOpenRagPanel }) => {
     handleAutoComplete(value)
   }
 
-  // Get all available tools as flat list (including special commands)
+  // Get all available tools as flat list
   const getAllAvailableTools = () => {
     const allTools = []
-
-    // Add /search command if RAG is enabled
-    if (features?.rag) {
-      allTools.push({
-        key: '_special_search',
-        name: 'search',
-        server: 'RAG',
-        description: 'Search across all RAG data sources',
-        isSpecialCommand: true
-      })
-    }
 
     tools.forEach(toolServer => {
       toolServer.tools.forEach(toolName => {
@@ -474,28 +455,14 @@ const ChatArea = ({ onOpenRagPanel }) => {
     setShowToolAutocomplete(false)
   }
 
-  // Check if input contains a slash command (but not /search)
-  const hasSlashCommand = inputValue.startsWith('/') && inputValue.includes(' ') && !inputValue.toLowerCase().startsWith('/search ')
-
-  // Check if input is a /search command
-  const hasSearchCommand = inputValue.toLowerCase().startsWith('/search ')
+  // Check if input contains a slash command
+  const hasSlashCommand = inputValue.startsWith('/') && inputValue.includes(' ')
 
   // Check if input contains @file references
   const hasFileReference = inputValue.includes('@file ')
 
   // Handle tool selection from autocomplete
   const selectTool = (tool) => {
-    // Handle special commands differently
-    if (tool.isSpecialCommand) {
-      // For special commands like /search, just set the input value
-      setInputValue(`/${tool.name} `)
-      setShowToolAutocomplete(false)
-      if (textareaRef.current) {
-        textareaRef.current.focus()
-      }
-      return
-    }
-
     // Enable the tool if not already selected
     if (!selectedTools.has(tool.key)) {
       toggleTool(tool.key)
@@ -1079,7 +1046,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
                     }
                   }}
                   className={`px-3 py-3 rounded-lg flex items-center justify-center transition-colors flex-shrink-0 ${
-                    ragEnabled || hasSearchCommand || selectedDataSources?.size > 0
+                    ragEnabled || selectedDataSources?.size > 0
                       ? 'bg-green-600 hover:bg-green-700 text-white'
                       : 'bg-gray-700 hover:bg-gray-600 text-gray-300'
                   }`}
@@ -1108,9 +1075,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
                 placeholder={isMobile ? "Type a message..." : "Type a message... (/ or @ for help)"}
                 rows={1}
                 className={`w-full px-4 py-3 bg-gray-800 rounded-lg text-gray-200 placeholder-gray-400 resize-none focus:outline-none focus:ring-2 focus:border-transparent ${
-                  hasSearchCommand
-                    ? 'border-2 border-green-500 focus:ring-green-500 bg-green-900/10'
-                    : hasSlashCommand
+                  hasSlashCommand
                     ? 'border-2 border-yellow-500 focus:ring-yellow-500 bg-yellow-900/10'
                     : hasFileReference
                     ? 'border-2 border-green-500 focus:ring-green-500 bg-green-900/10'

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -328,7 +328,7 @@ export const ChatProvider = ({ children }) => {
 		)
 	}, [config.ragServers])
 
-	const sendChatMessage = useCallback((content, extraFiles = {}, forceRag = false) => {
+	const sendChatMessage = useCallback((content, extraFiles = {}) => {
 		if (!content.trim() || !currentModel) return false
 		// Don't allow sending while the WebSocket is disconnected -- the message
 		// would never reach the backend and the UI would hang on "Thinking...".
@@ -339,12 +339,11 @@ export const ChatProvider = ({ children }) => {
 		const tagged = files.getTaggedFilesContent()
 
 		// Determine data sources to send:
-		// RAG is activated when any of these are true:
+		// RAG is activated when either of these are true:
 		//   1. The RAG toggle is on (ragEnabled)
-		//   2. The /search command was used (forceRag)
-		//   3. One or more data sources are selected (hasSelectedSources)
+		//   2. One or more data sources are selected (hasSelectedSources)
 		const hasSelectedSources = selectedDataSources.size > 0
-		const ragActivated = forceRag || ragEnabled || hasSelectedSources
+		const ragActivated = ragEnabled || hasSelectedSources
 		const dataSourcesToSend = ragActivated
 			? (hasSelectedSources ? [...selectedDataSources] : getAllRagSourceIds())
 			: []

--- a/frontend/src/test/rag-activation-gating.test.js
+++ b/frontend/src/test/rag-activation-gating.test.js
@@ -3,8 +3,7 @@
  *
  * Verifies that RAG is activated when:
  *   1. The ragEnabled toggle is on
- *   2. The /search command is used (forceRag)
- *   3. One or more data sources are selected
+ *   2. One or more data sources are selected
  */
 
 import { describe, it, expect } from 'vitest'
@@ -14,9 +13,9 @@ import { describe, it, expect } from 'vitest'
  * This mirrors the logic in ChatContext.jsx without needing to render the full
  * React context tree.
  */
-function computeDataSourcesToSend({ forceRag, ragEnabled, selectedDataSources, allRagSourceIds }) {
+function computeDataSourcesToSend({ ragEnabled, selectedDataSources, allRagSourceIds }) {
   const hasSelectedSources = selectedDataSources.size > 0
-  const ragActivated = forceRag || ragEnabled || hasSelectedSources
+  const ragActivated = ragEnabled || hasSelectedSources
   return ragActivated
     ? (hasSelectedSources ? [...selectedDataSources] : allRagSourceIds)
     : []
@@ -27,7 +26,6 @@ describe('RAG activation gating', () => {
 
   it('sends selected data sources when sources are selected (even without ragEnabled toggle)', () => {
     const result = computeDataSourcesToSend({
-      forceRag: false,
       ragEnabled: false,
       selectedDataSources: new Set(['server:source1', 'server:source2']),
       allRagSourceIds: allSources,
@@ -37,7 +35,6 @@ describe('RAG activation gating', () => {
 
   it('sends selected data sources when ragEnabled toggle is on', () => {
     const result = computeDataSourcesToSend({
-      forceRag: false,
       ragEnabled: true,
       selectedDataSources: new Set(['server:source1']),
       allRagSourceIds: allSources,
@@ -45,29 +42,8 @@ describe('RAG activation gating', () => {
     expect(result).toEqual(['server:source1'])
   })
 
-  it('sends selected data sources when forceRag (/search) is true', () => {
-    const result = computeDataSourcesToSend({
-      forceRag: true,
-      ragEnabled: false,
-      selectedDataSources: new Set(['server:source2']),
-      allRagSourceIds: allSources,
-    })
-    expect(result).toEqual(['server:source2'])
-  })
-
-  it('falls back to all sources when forceRag is true and none are selected', () => {
-    const result = computeDataSourcesToSend({
-      forceRag: true,
-      ragEnabled: false,
-      selectedDataSources: new Set(),
-      allRagSourceIds: allSources,
-    })
-    expect(result).toEqual(allSources)
-  })
-
   it('falls back to all sources when ragEnabled is true and none are selected', () => {
     const result = computeDataSourcesToSend({
-      forceRag: false,
       ragEnabled: true,
       selectedDataSources: new Set(),
       allRagSourceIds: allSources,
@@ -77,21 +53,10 @@ describe('RAG activation gating', () => {
 
   it('returns empty when nothing is selected and RAG is not activated', () => {
     const result = computeDataSourcesToSend({
-      forceRag: false,
       ragEnabled: false,
       selectedDataSources: new Set(),
       allRagSourceIds: allSources,
     })
     expect(result).toEqual([])
-  })
-
-  it('sends selected sources when both ragEnabled and forceRag are true', () => {
-    const result = computeDataSourcesToSend({
-      forceRag: true,
-      ragEnabled: true,
-      selectedDataSources: new Set(['server:source1', 'server:source3']),
-      allRagSourceIds: allSources,
-    })
-    expect(result).toEqual(['server:source1', 'server:source3'])
   })
 })

--- a/frontend/src/test/ws-disconnect-blocks-send.test.jsx
+++ b/frontend/src/test/ws-disconnect-blocks-send.test.jsx
@@ -98,6 +98,6 @@ describe('ChatArea - blocks sending while WebSocket is disconnected (#448)', () 
 
     // handleSubmit awaits @file reference processing, so the send is async.
     await waitFor(() => expect(sendChatMessage).toHaveBeenCalledTimes(1))
-    expect(sendChatMessage).toHaveBeenCalledWith('hello online', expect.any(Object), false)
+    expect(sendChatMessage).toHaveBeenCalledWith('hello online', expect.any(Object))
   })
 })


### PR DESCRIPTION
## Summary

Removes the `/search` chat quick command from the Atlas UI. It silently forced RAG on from the message input, which was a confusing entry point. RAG remains fully available — it's just activated explicitly now, the way users already expect.

## What changed

- **`frontend/src/components/ChatArea.jsx`**
  - Dropped the `_special_search` entry from the slash-command autocomplete and its `isSpecialCommand` handling in `selectTool`.
  - Removed the `/search ` prefix parsing in `handleSubmit` and the `forceRag` argument it passed to `sendChatMessage`.
  - Removed the `hasSearchCommand` green highlighting on the input border and RAG button.
- **`frontend/src/contexts/ChatContext.jsx`** — dropped the `forceRag` parameter from `sendChatMessage`; RAG activation now keys off the toggle (`ragEnabled`) or having selected data sources.
- **Tests** — updated `rag-activation-gating.test.js` and `ws-disconnect-blocks-send.test.jsx` to the new (no-`forceRag`) signature.
- **Docs** — updated `AGENTS.md` RAG activation note and added a `CHANGELOG.md` entry.

## How RAG still works

RAG is activated by the search-button toggle or by selecting one or more data sources. No backend changes — the backend never parsed `/search`; it only received `selected_data_sources`, which the remaining paths still populate.

## Verification

- `vitest run` — 430/430 pass
- `eslint` on changed files — clean
- `vite build` — succeeds