### PR TITLE
test: make suite hermetic against developer .env / MCP_TOKEN_ENCRYPTION_KEY

### DIFF
--- a/atlas/tests/conftest.py
+++ b/atlas/tests/conftest.py
@@ -30,6 +30,24 @@ if str(project_root) not in sys.path:
 _TELEMETRY_TMPDIR = tempfile.mkdtemp(prefix="atlas-test-telemetry-")
 os.environ.setdefault("APP_LOG_DIR", _TELEMETRY_TMPDIR)
 
+# --- .env isolation ------------------------------------------------------
+# ``AppSettings`` is configured to load ``../.env`` (see
+# ``atlas/modules/config/settings.py``). During tests that file is the
+# *developer's* local .env, whose contents must never influence the suite —
+# otherwise results depend on each contributor's machine. The concrete bug
+# this guards against: a developer with ``MCP_TOKEN_ENCRYPTION_KEY`` set in
+# their .env made ``test_refuses_to_start_without_encryption_key`` (which
+# deletes the env var, then expects construction to fail) pass locally for
+# CI but fail on their machine, because pydantic-settings re-read the key
+# from .env after monkeypatch cleared it from ``os.environ``.
+#
+# Disable env-file loading for the whole test session so AppSettings reads
+# only the process environment, which tests fully control via monkeypatch /
+# os.environ. This is a test-isolation guard, not a product behavior change.
+from atlas.modules.config.settings import AppSettings  # noqa: E402
+
+AppSettings.model_config["env_file"] = None
+
 # MCP token storage now refuses to start without an explicit encryption key
 # (previously a per-process ephemeral key was generated, which silently lost
 # every stored token on restart). Provide a deterministic test key so module

--- a/atlas/tests/test_env_isolation.py
+++ b/atlas/tests/test_env_isolation.py
@@ -1,0 +1,45 @@
+"""Regression tests for developer .env leakage into the test suite.
+
+``AppSettings`` is configured to read ``../.env`` (relative to the process
+working directory). If that file were honored during tests, the suite's
+results would depend on each contributor's local .env — most visibly,
+``test_token_storage.TestRequiresEncryptionKey`` would flip between pass and
+fail depending on whether the developer happened to have
+``MCP_TOKEN_ENCRYPTION_KEY`` set locally.
+
+``tests/conftest.py`` disables env-file loading for the whole session
+(``AppSettings.model_config["env_file"] = None``). These tests lock that
+guard in place so it cannot be silently removed.
+"""
+
+import os
+
+from atlas.modules.config.settings import AppSettings
+
+
+def test_env_file_loading_is_disabled_for_tests():
+    """The session-wide guard in conftest must keep .env loading off."""
+    assert AppSettings.model_config.get("env_file") is None
+
+
+def test_dotenv_on_disk_does_not_leak_into_settings(tmp_path, monkeypatch):
+    """A ``.env`` at the location AppSettings would read must be ignored.
+
+    This reproduces the original leak mechanism end to end: AppSettings'
+    configured ``env_file`` is ``../.env`` relative to the working directory,
+    so we place a sentinel .env one level above a working dir, chdir into it,
+    clear the variable from the process environment, and confirm the on-disk
+    value does not reappear.
+    """
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    sentinel = "sentinel-dotenv-value-must-not-leak-into-tests"
+    (tmp_path / ".env").write_text(f"MCP_TOKEN_ENCRYPTION_KEY={sentinel}\n")
+
+    monkeypatch.delenv("MCP_TOKEN_ENCRYPTION_KEY", raising=False)
+    monkeypatch.chdir(work_dir)
+
+    settings = AppSettings()
+
+    assert settings.mcp_token_encryption_key != sentinel
+    assert os.environ.get("MCP_TOKEN_ENCRYPTION_KEY") is None


### PR DESCRIPTION
## Problem

`AppSettings` is configured to load `../.env` (`atlas/modules/config/settings.py`). During tests that file is the *developer's* local `.env`, and pydantic-settings honored it. So `test_token_storage.py::TestRequiresEncryptionKey::test_refuses_to_start_without_encryption_key` — which deletes `MCP_TOKEN_ENCRYPTION_KEY` from the environment and expects construction to raise — read the key straight back from `.env`. The result: the test **passed in CI** (no `.env`) but **failed for any developer with `MCP_TOKEN_ENCRYPTION_KEY` in their `.env`**. Test outcomes depended on per-machine `.env` state.

## Fix

Disable env-file loading for the entire test session in `atlas/tests/conftest.py`:

```python
AppSettings.model_config["env_file"] = None
```

`AppSettings` now reads only the process environment, which tests fully control via `monkeypatch` / `os.environ`. This is a **test-isolation guard only** — runtime behavior is unchanged; the app still loads `.env` normally in production.

## Tests

New `atlas/tests/test_env_isolation.py`:
- asserts the conftest guard stays active (`env_file is None`);
- reproduces the leak end to end — writes a sentinel `.env` at the `../.env` location, chdirs, clears the env var, and asserts the on-disk value does not leak into `AppSettings`. Verified this test fails if the guard is removed.

## Verification

- `test_token_storage.py` + `test_env_isolation.py`: 36 passed, with and without a populated `.env` present.
- Full backend suite: same 147 pre-existing failures (unrelated telemetry-route 503s) on this branch as on baseline `main` — this change introduces **zero new failures** and adds 2 passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)