### PR TITLE
docs(release): off-cycle cut + version-reconciliation guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,9 @@ cd atlas && python main.py  # don't use uvicorn --reload
 
 **Changelog**: Add a 1-2 line entry to `CHANGELOG.md` for every PR. Format: `### PR #<number> - YYYY-MM-DD`. Always add the entry under the `## [Unreleased]` section — the monthly release automation renames that heading at cut time, so anything above a prior release heading has already shipped.
 
-**Releases**: Atlas ships monthly. The `release-cut` workflow opens a draft release PR on the 22nd of each month. Full runbook at [docs/developer/release-process.md](./docs/developer/release-process.md). Do not push `v*.*.*` tags or create GitHub Releases outside that flow.
+**Releases**: Atlas ships monthly via the `release-cut` workflow (draft PR on the 22nd of each month). Full runbook at [docs/developer/release-process.md](./docs/developer/release-process.md). Do not push `v*.*.*` tags or create GitHub Releases outside that flow.
+
+For an **off-cycle release**: `gh workflow run release-cut.yml -f version=X.Y.Z`. First determine the next version from the **highest *published* release** (`gh release list` / git tags / PyPI), not from `pyproject.toml` on `main` — after a back-merge `main` already equals the last shipped version, so it is not a reliable "next version". Close any superseded/stale release PR before cutting. The cut PR already targets `main` and **doubles as the back-merge PR** after tagging — don't open a second one. CI on the cut PR is the gate; `pypi-publish.yml` builds and uploads the wheel on Release publish, so **don't build a wheel locally** — the only manual confidence step beyond CI is the optional real-LLM smoke test in the runbook.
 
 **Date Stamps**: Include `YYYY-MM-DD` dates in doc filenames or section headers to track staleness.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #647 - 2026-06-12
+- **Docs**: Documented the off-cycle release path and version-reconciliation guardrails in `AGENTS.md` and the release runbook — manual `release-cut` dispatch, deriving the next version from the highest *published* release (not `pyproject.toml` on `main`), closing superseded/no-op release PRs before cutting, and that the cut PR doubles as the back-merge PR.
+
 ## [0.3.0] - 2026-06-12
 
 ### PR #643 - 2026-06-10

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -118,6 +118,22 @@ draft PR against the existing branch without touching any files. The
 recovery PR body is flagged with a banner so the captain knows to
 verify the inferred metadata.
 
+> **Before you cut, reconcile the version state.** The cron is
+> idempotent only *within* a month — it does not reason about releases
+> that already shipped. Two failure modes to check for, especially
+> before an off-cycle cut:
+>
+> - **Determine the next version from the highest *published* release**
+>   (`gh release list`, git tags, or PyPI), **not** from
+>   `pyproject.toml` on `main`. After a release's back-merge, `main`
+>   already equals the last shipped version, so reading it yields the
+>   *current* version, not the next one.
+> - **Close any superseded release PR first.** A recovery-path PR from a
+>   prior month can linger open carrying a *no-op* bump (e.g.
+>   `0.2.0 → 0.2.0`) if its version had already shipped by another
+>   path. Do not adopt it as the release vehicle — close it and cut a
+>   fresh branch for the new version.
+
 #### 2. Release captain takes ownership
 
 A maintainer claims the draft PR (self-assign) and becomes the


### PR DESCRIPTION
## What

Documents the release-process gaps surfaced while cutting `0.3.0` off-cycle. The existing docs are written around the monthly cron and don't cover an ad-hoc cut or a stale recovery-path PR.

### AGENTS.md — `Releases` note
- The off-cycle dispatch command: `gh workflow run release-cut.yml -f version=X.Y.Z`.
- Derive the next version from the **highest *published* release** (`gh release list` / tags / PyPI), **not** `pyproject.toml` on `main` — after a back-merge `main` equals the *last shipped* version.
- Close any superseded/stale release PR before cutting.
- The cut PR already targets `main` and **doubles as the back-merge PR** — don't open a second one.
- CI builds/uploads the wheel via `pypi-publish.yml`; **no local wheel build** is needed.

### docs/developer/release-process.md — "reconcile before you cut" note
- Added under the recovery-path paragraph: the cron is idempotent only *within* a month, so before an off-cycle cut, reconcile the next version against published releases and close superseded PRs.
- Calls out the concrete failure mode hit this cycle: a lingering recovery-path PR carrying a **no-op bump** (`0.2.0 → 0.2.0`).

## Why

During the `0.3.0` cut, `main` read `0.2.0` (already shipped), and PR #615 was an open release PR with a no-op bump — both easy traps for the next person/agent. These notes encode the reasoning so the next cut is mechanical.

Docs-only; no code or behavior change.