### PR TITLE
fix(quality): clear CodeQL code-quality alerts

### DIFF
--- a/atlas/core/otel_config.py
+++ b/atlas/core/otel_config.py
@@ -101,8 +101,10 @@ class JSONLSpanExporter(SpanExporter):
             self._fh = self.file_path.open("a", encoding="utf-8")
         try:
             os.chmod(self.file_path, 0o600)
-        except OSError:
-            pass
+        except OSError as e:
+            logging.getLogger(__name__).debug(
+                "Could not restrict span file permissions on %s: %s", self.file_path, e
+            )
 
     def export(self, spans: list[ReadableSpan]) -> SpanExportResult:  # noqa: D401
         with self._lock:
@@ -145,8 +147,10 @@ class JSONLSpanExporter(SpanExporter):
                     self._fh.flush()
                     try:
                         os.fsync(self._fh.fileno())
-                    except (OSError, ValueError):
-                        pass
+                    except (OSError, ValueError) as e:
+                        logging.getLogger(__name__).debug(
+                            "fsync of span file failed during shutdown: %s", e
+                        )
                     self._fh.close()
                 except Exception as e:  # noqa: BLE001
                     logging.getLogger(__name__).debug(
@@ -281,8 +285,10 @@ class OpenTelemetryConfig:
         # filesystems without POSIX modes.
         try:
             os.chmod(self.log_file, 0o600)
-        except OSError:
-            pass
+        except OSError as e:
+            logging.getLogger(__name__).debug(
+                "Could not restrict log file permissions on %s: %s", self.log_file, e
+            )
         root.addHandler(file_handler)
         root.setLevel(self.log_level)
 

--- a/atlas/core/telemetry.py
+++ b/atlas/core/telemetry.py
@@ -316,8 +316,8 @@ def write_tool_output_sidecar(content: Any) -> Optional[str]:
         # network mounts).
         try:
             os.chmod(out_dir, 0o700)
-        except OSError:
-            pass
+        except OSError as e:
+            logger.debug("Could not restrict sidecar dir permissions on %s: %s", out_dir, e)
         out_path = out_dir / f"{span_id}.txt"
         # Create with restrictive mode from the start rather than chmod-after
         # so there's no window where the file is readable by other users.
@@ -332,14 +332,14 @@ def write_tool_output_sidecar(content: Any) -> Optional[str]:
         except Exception:
             try:
                 os.close(fd)
-            except OSError:
-                pass
+            except OSError as e:
+                logger.debug("Failed to close sidecar fd during error cleanup: %s", e)
             raise
         # On filesystems that honor umask over the open() mode, re-apply.
         try:
             os.chmod(out_path, 0o600)
-        except OSError:
-            pass
+        except OSError as e:
+            logger.debug("Could not restrict sidecar file permissions on %s: %s", out_path, e)
         return str(out_path)
     except Exception as e:  # noqa: BLE001
         logger.debug("Failed to write tool output sidecar: %s", e)

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -1044,11 +1044,13 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
         lines = [
             "",
             "## Source documents (for inline citations)",
-            "When you use information from these sources, cite them inline using "
-            "bracketed numbers like [1], [2], etc. Place citations immediately after "
-            "the claim they support. You may cite multiple sources for the same "
-            "claim, e.g. [1][3]. Do not fabricate citations — only cite sources "
-            "listed below.",
+            (
+                "When you use information from these sources, cite them inline using "
+                + "bracketed numbers like [1], [2], etc. Place citations immediately after "
+                + "the claim they support. You may cite multiple sources for the same "
+                + "claim, e.g. [1][3]. Do not fabricate citations — only cite sources "
+                + "listed below."
+            ),
             "",
         ]
 

--- a/atlas/modules/mcp_tools/client.py
+++ b/atlas/modules/mcp_tools/client.py
@@ -2129,8 +2129,8 @@ class MCPToolManager:
             if init_result and hasattr(init_result, 'capabilities'):
                 caps = init_result.capabilities
                 supports = getattr(caps, 'tasks', None) is not None
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Could not determine task support for server '%s': %s", server_name, e)
 
         self._server_task_support[server_name] = supports
         return supports
@@ -2337,8 +2337,8 @@ class MCPToolManager:
                                         "type": "tool_task_completed",
                                         "tool_call_id": meta.get("tool_call_id") if meta else None,
                                     })
-                                except Exception:
-                                    pass
+                                except Exception as e:
+                                    logger.debug("tool_task_completed update callback failed: %s", e)
                     except asyncio.CancelledError:
                         await tool_task.cancel()
                         raise

--- a/atlas/routes/telemetry_routes.py
+++ b/atlas/routes/telemetry_routes.py
@@ -18,7 +18,6 @@ counts, model names, tool names, data source IDs, status codes, and durations.
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import time
@@ -31,8 +30,6 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from atlas.modules.config import config_manager
 from atlas.routes.admin_routes import require_admin
-
-logger = logging.getLogger(__name__)
 
 telemetry_router = APIRouter(prefix="/admin/telemetry", tags=["admin", "telemetry"])
 

--- a/frontend/src/components/AgentPortal.jsx
+++ b/frontend/src/components/AgentPortal.jsx
@@ -189,12 +189,6 @@ const STATUS_COLORS = {
   failed: 'bg-red-900 text-red-300 border-red-700',
 }
 
-const STREAM_COLORS = {
-  stdout: 'text-gray-200',
-  stderr: 'text-red-300',
-  system: 'text-blue-300 italic',
-}
-
 function ProcessListItem({ proc, isSelected, onSelect, onRename, onRemove }) {
   const statusCls = STATUS_COLORS[proc.status] || STATUS_COLORS.exited
   const started = proc.started_at ? new Date(proc.started_at * 1000).toLocaleTimeString() : ''
@@ -1562,9 +1556,9 @@ function AgentPortal() {
       if (e.ctrlKey && e.shiftKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
         const slots = layout.slots
         if (slots.length === 0) return
-        let next = focusedSlot
-        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (focusedSlot + 1) % slots.length
-        else next = (focusedSlot - 1 + slots.length) % slots.length
+        const next = (e.key === 'ArrowRight' || e.key === 'ArrowDown')
+          ? (focusedSlot + 1) % slots.length
+          : (focusedSlot - 1 + slots.length) % slots.length
         setFocusedSlot(next)
         e.preventDefault()
       }


### PR DESCRIPTION
## Summary

Triage + cleanup of the CodeQL **code-quality** alerts on `main`. This fixes the 12 genuine findings in source and leaves the rest documented as false positives / by-design (dismissed in the code-scanning UI).

### Fixed in code
- **`py/empty-except` (8)** — added `logger.debug(...)` to best-effort `except` blocks instead of silently `pass`ing, so failures are diagnosable:
  - `atlas/core/otel_config.py` — span-file `chmod`, shutdown `fsync`, log-file `chmod`
  - `atlas/core/telemetry.py` — sidecar dir `chmod`, error-path `os.close`, sidecar file `chmod`
  - `atlas/modules/mcp_tools/client.py` — server task-support probe, `tool_task_completed` callback
- **`py/unused-global-variable` (1)** — removed the unused module-level `logger` (and now-unused `import logging`) in `atlas/routes/telemetry_routes.py` (0 references in the module).
- **`py/implicit-string-concatenation-in-list` (1)** — `atlas/modules/llm/litellm_caller.py`: made the RAG citation instruction an explicit `+` concatenation (string value unchanged) to remove the missing-comma ambiguity.
- **`js/unused-local-variable` + `js/useless-assignment-to-local` (2)** — `frontend/src/components/AgentPortal.jsx`: removed the dead `STREAM_COLORS` constant (the live copy lives in `agent-portal/Pane.jsx`) and replaced a useless `next` initializer with a ternary.

### Not changed (dismissed as non-issues)
- **`py/unused-global-variable` ×3** — `_ephemeral_warned`, `_HMAC_WARNED` (warn-once flags), `_resolved_path` (memoization cache). These are read on subsequent calls; CodeQL's per-call view can't see it. Deleting them would break behavior → false positives.
- **`py/print-during-import` ×3** — `atlas/atlas_chat_cli.py`. Intentional CLI bootstrap output (version / missing-env-file diagnostics).

## Validation
- `ruff check` on all changed Python: clean
- Targeted tests: `test_telemetry_routes`, `test_telemetry_spans`, `test_mcp_*`, capabilities/audit-log suites — **138 passed, 1 skipped**
- Frontend: `eslint` 0 errors, `vite build` succeeds