### PR TITLE
Fix Bedrock tool-calling failure on streaming follow-up requests

### DIFF
--- a/atlas/modules/llm/litellm_streaming.py
+++ b/atlas/modules/llm/litellm_streaming.py
@@ -7,10 +7,10 @@ These methods are mixed into LiteLLMCaller via LiteLLMStreamingMixin.
 import asyncio
 import logging
 import time
-from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from litellm import acompletion
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
 
 from atlas.core.metrics_logger import log_metric
 from atlas.core.telemetry import set_attrs, start_span
@@ -215,17 +215,26 @@ class LiteLLMStreamingMixin:
                                 if hasattr(tc_delta.function, "arguments") and tc_delta.function.arguments:
                                     entry["function"]["arguments"] += tc_delta.function.arguments
 
-                # Build final tool_calls list as namespace objects (matching
-                # litellm's non-streaming response format with attribute access)
+                # Build final tool_calls list using litellm's own response type
+                # rather than SimpleNamespace. The objects are appended verbatim
+                # to the assistant message and re-sent on the follow-up request
+                # (agentic loop). litellm's Bedrock Converse transformer accesses
+                # tool calls with dict syntax (``"function" in tool``,
+                # ``tool["id"]``); SimpleNamespace supports only attribute access,
+                # so a Bedrock follow-up raised "Unable to convert openai tool
+                # calls to bedrock tool calls". ChatCompletionMessageToolCall
+                # supports BOTH attribute access (used by the tool executor) and
+                # dict access (used by the Bedrock transform), matching the
+                # non-streaming path exactly.
                 tool_calls_list = None
                 if accumulated_tool_calls:
                     tool_calls_list = []
                     for k in sorted(accumulated_tool_calls.keys()):
                         tc = accumulated_tool_calls[k]
-                        tool_calls_list.append(SimpleNamespace(
+                        tool_calls_list.append(ChatCompletionMessageToolCall(
                             id=tc["id"],
                             type=tc["type"],
-                            function=SimpleNamespace(
+                            function=Function(
                                 name=tc["function"]["name"],
                                 arguments=tc["function"]["arguments"],
                             ),

--- a/atlas/tests/test_streaming_token_flow.py
+++ b/atlas/tests/test_streaming_token_flow.py
@@ -477,6 +477,76 @@ async def test_tools_streaming_tool_call_dict_conversion():
         assert tc["function"]["arguments"] == '{"q":"test"}'
 
 
+# -- Streaming tool_calls survive the Bedrock follow-up transform ------------
+
+@pytest.mark.asyncio
+async def test_stream_with_tools_emits_bedrock_compatible_tool_calls():
+    """Tool calls accumulated by stream_with_tools must survive a Bedrock
+    follow-up request.
+
+    Regression for the Bedrock tool-calling follow-up bug: the streaming
+    caller used to emit ``SimpleNamespace`` tool_call objects, which support
+    only attribute access. The agentic/react/act loops append those objects
+    verbatim to the assistant message and re-send them on the next turn.
+    litellm's Bedrock Converse transformer reads tool calls with *dict* syntax
+    (``"function" in tool``, ``tool["id"]``), so SimpleNamespace raised
+    "Unable to convert openai tool calls to bedrock tool calls". The objects
+    must therefore support BOTH dict access (Bedrock transform) and attribute
+    access (the tool executor).
+    """
+    from types import SimpleNamespace
+
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _convert_to_bedrock_tool_call_invoke,
+    )
+
+    from atlas.modules.llm.litellm_caller import LiteLLMCaller
+
+    # Build streaming chunks that deliver a single tool call in fragments,
+    # mirroring how providers stream tool_call deltas.
+    def _chunk(tool_id=None, name=None, args=None):
+        fn = SimpleNamespace(name=name, arguments=args)
+        tc = SimpleNamespace(index=0, id=tool_id, function=fn)
+        delta = SimpleNamespace(content=None, tool_calls=[tc])
+        return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+    async def _fake_acompletion(*args, **kwargs):
+        async def _gen():
+            yield _chunk(tool_id="call-xyz", name="search", args='{"q":')
+            yield _chunk(args='"hi"}')
+        return _gen()
+
+    mock_config = MagicMock()
+    mock_config.models = {}
+    caller = LiteLLMCaller(llm_config=mock_config)
+    caller._get_litellm_model_name = MagicMock(return_value="bedrock/claude")
+    caller._get_model_kwargs = MagicMock(return_value={"max_tokens": 100})
+    caller._prepare_messages = MagicMock(side_effect=lambda m, msgs: msgs)
+
+    final_response = None
+    with patch("atlas.modules.llm.litellm_streaming.acompletion", _fake_acompletion):
+        async for item in caller.stream_with_tools(
+            "test-model", [{"role": "user", "content": "hi"}], [{"type": "function"}],
+        ):
+            if not isinstance(item, str):
+                final_response = item
+
+    assert final_response is not None
+    assert final_response.tool_calls, "expected accumulated tool_calls"
+    tc = final_response.tool_calls[0]
+
+    # Attribute access (used by tool_executor).
+    assert tc.id == "call-xyz"
+    assert tc.function.name == "search"
+    assert tc.function.arguments == '{"q":"hi"}'
+
+    # Dict access via the Bedrock Converse transform (the follow-up request).
+    bedrock_blocks = _convert_to_bedrock_tool_call_invoke(final_response.tool_calls)
+    assert bedrock_blocks[0]["toolUse"]["toolUseId"] == "call-xyz"
+    assert bedrock_blocks[0]["toolUse"]["name"] == "search"
+    assert bedrock_blocks[0]["toolUse"]["input"] == {"q": "hi"}
+
+
 # -- CLI event publisher streaming -------------------------------------------
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

AWS Bedrock tool calling fails on **follow-up requests** within an agent turn (the second LLM call, after a tool has been executed and its result appended). The request errors out with:

```
Unable to convert openai tool calls=[...] to bedrock tool calls.
Received error=argument of type 'types.SimpleNamespace' is not iterable
```

## Root cause

In streaming mode, the streaming caller (`litellm_streaming.py`) accumulated tool-call fragments and emitted them as `types.SimpleNamespace` objects. The agentic/react/act/think_act loops append these objects verbatim onto the assistant message and re-send them on the next turn.

litellm's Bedrock Converse transformer (`_convert_to_bedrock_tool_call_invoke`) reads tool calls with **dict** syntax (`"function" in tool`, `tool["id"]`, `tool["function"]`). `SimpleNamespace` supports only attribute access, so the Bedrock follow-up request blows up during message transformation. Other providers normalize the objects differently, so the failure is Bedrock-specific.

The `tools` mode already had a local `SimpleNamespace -> dict` workaround (with a comment describing exactly this), but the agent loops never got it.

## Fix

Build the accumulated streaming tool calls with litellm's own `ChatCompletionMessageToolCall` / `Function` types instead of `SimpleNamespace`. These support **both**:

- attribute access (`tc.function.name`) — used by the tool executor, and
- dict access (`tool["id"]`) — used by the Bedrock transform,

matching the non-streaming path exactly and fixing every agent loop centrally rather than just one mode.

## Testing

- Added `test_stream_with_tools_emits_bedrock_compatible_tool_calls`, which drives the real `stream_with_tools` with a mocked streaming response and asserts the emitted tool calls survive the Bedrock Converse transform while still supporting attribute access. (Fails on the old `SimpleNamespace` code.)
- `tests/test_streaming_token_flow.py`, `test_multi_tool_calling.py`, `test_agentic_loop.py` pass; broader tool/agent/streaming subset (442 tests) green.

Scope is limited to the bug and its regression test.