### PR TITLE
fix(canvas): vertically center images in canvas panel

### DIFF
--- a/frontend/src/components/CanvasPanel.jsx
+++ b/frontend/src/components/CanvasPanel.jsx
@@ -281,7 +281,7 @@ const CanvasPanel = ({ isOpen, onClose, onWidthChange }) => {
       switch (currentFileContent.type) {
         case 'image':
           return (
-            <div className="p-4">
+            <div className="p-4 flex items-center justify-center min-h-full">
               <img
                 src={currentFileContent.url}
                 alt={currentFileContent.file.filename}


### PR DESCRIPTION
## Problem

When an item — especially an image — is shown in the canvas panel, it is always pinned to the top of the panel instead of being vertically centered.

## Root cause

In `CanvasPanel.jsx`, the image is wrapped in a plain block `<div className="p-4">` inside the `flex-1 overflow-y-auto` content container. A block child renders at the top of the available space, so the image is never centered regardless of the panel's height.

## Fix

Make the image wrapper a flex container that fills the available height and centers its child:

```jsx
<div className="p-4 flex items-center justify-center min-h-full">
```

- `min-h-full` makes the wrapper fill the panel height, giving vertical space to center within.
- `items-center justify-center` centers short images both vertically and horizontally.
- Tall images grow the wrapper past `min-h-full`, so the parent's `overflow-y-auto` still scrolls normally.

Scoped to the `image` case only. PDF/iframe cases already use `h-full` (they should fill, not center), and text/HTML/markdown stay top-aligned for readability.