### PR TITLE
Fix missing Stop button in agent mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #672 - 2026-06-22
+- **Fixed missing Stop button in agent mode**: The agent-mode Stop button was gated on `isThinking`, which the native agentic loop clears the moment the first answer token streams. The button therefore flashed on send and then vanished for the rest of the run — through every tool call and the streamed final answer — leaving no way to interrupt a running agent (regressed in #664). It now hangs off a dedicated `isAgentRunning` flag set on an agent-mode send and cleared only on the terminal agent events (`agent_completion` / `agent_error` / `agent_max_steps`, plus `response_complete` / `chat_response` / `error`, and an explicit stop or the thinking-timeout safety net), so it stays visible for the whole run regardless of streaming sub-state. Normal-mode streaming/Stop behavior is unchanged. Added regression tests that token streaming does not clear the flag mid-run and that each terminal event does.
+
 ### PR #669 - 2026-06-22
 - **Fixed stateful MCP session errors in agent mode**: Agent mode didn't thread a `conversation_id` through the agentic loop, so each tool call opened a fresh single-use MCP session and stateful servers lost their session between sequential calls (regular chat was unaffected). `AgentContext` now carries `conversation_id` and the loop forwards it so `MCPSessionManager` reuses one persistent session per conversation. Added a regression test.
 

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -1065,7 +1065,13 @@ const ChatArea = ({ onOpenRagPanel }) => {
                   <Search className="w-5 h-5" />
                 </button>
               )}
-              {agentModeEnabled && (isAgentRunning || isThinking || agentPendingQuestion) && (
+              {/* Gate on the run-in-flight signals, NOT the live agentModeEnabled
+                  toggle: agent mode can be flipped off mid-run (Ctrl+Alt+A / the
+                  toggle button), and the user must still be able to stop a
+                  running agent. isAgentRunning is only ever set on an agent-mode
+                  send and agentPendingQuestion is agent-specific, so neither
+                  fires during a normal chat turn. */}
+              {(isAgentRunning || agentPendingQuestion) && (
                 <button
                   type="button"
                   onClick={stopAgent}
@@ -1150,7 +1156,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
                 </div>
               )}
             </div>
-            {(isThinking || isStreaming) && !agentModeEnabled ? (
+            {(isThinking || isStreaming) && !agentModeEnabled && !isAgentRunning ? (
               <button
                 type="button"
                 onClick={stopStreaming}

--- a/frontend/src/components/ChatArea.jsx
+++ b/frontend/src/components/ChatArea.jsx
@@ -34,6 +34,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
     messages,
     isWelcomeVisible,
     isThinking,
+    isAgentRunning,
     isSynthesizing,
     sendChatMessage,
     rewindAndResubmit,
@@ -1064,7 +1065,7 @@ const ChatArea = ({ onOpenRagPanel }) => {
                   <Search className="w-5 h-5" />
                 </button>
               )}
-              {agentModeEnabled && (isThinking || agentPendingQuestion) && (
+              {agentModeEnabled && (isAgentRunning || isThinking || agentPendingQuestion) && (
                 <button
                   type="button"
                   onClick={stopAgent}

--- a/frontend/src/contexts/ChatContext.jsx
+++ b/frontend/src/contexts/ChatContext.jsx
@@ -51,6 +51,13 @@ export const ChatProvider = ({ children }) => {
 
 	const [isWelcomeVisible, setIsWelcomeVisible] = useState(true)
 	const [isThinking, setIsThinking] = useState(false)
+	// Tracks an in-flight agent-mode run end to end. Unlike isThinking (which the
+	// native agentic loop clears the moment token streaming begins) this stays
+	// true for the whole run -- tool calls, streamed segments, and the final
+	// answer -- so the agent Stop button remains visible until the run actually
+	// ends. Cleared on the terminal agent events (see websocketHandlers) and on
+	// an explicit stop.
+	const [isAgentRunning, setIsAgentRunning] = useState(false)
 	const [isSynthesizing, setIsSynthesizing] = useState(false)
 	const [sessionId, setSessionId] = useState(null)
 	const [attachments, setAttachments] = useState(new Set())
@@ -122,6 +129,7 @@ export const ChatProvider = ({ children }) => {
 			addMessage,
 			mapMessages,
 			setIsThinking,
+			setIsAgentRunning,
 			setIsSynthesizing,
 				setCurrentAgentStep: agent.setCurrentAgentStep,
 					setAgentPendingQuestion: agent.setAgentPendingQuestion,
@@ -152,6 +160,7 @@ export const ChatProvider = ({ children }) => {
 		if (isThinking) {
 			thinkingTimeoutRef.current = setTimeout(() => {
 				setIsThinking(false)
+				setIsAgentRunning(false)
 				setIsSynthesizing(false)
 				agent.setCurrentAgentStep(0)
 				addMessage({
@@ -426,6 +435,11 @@ export const ChatProvider = ({ children }) => {
 		})
 		setIsThinking(true)
 		setIsSynthesizing(false)
+		// Drive the agent Stop button off a dedicated run flag rather than
+		// isThinking, which the native agentic loop clears as soon as the first
+		// token streams. Only true in agent mode; the terminal agent events clear
+		// it (websocketHandlers).
+		setIsAgentRunning(agent.agentModeEnabled)
 		return true
 	}, [addMessage, mapMessages, currentModel, selectedTools, activePrompts, selectedDataSources, ragEnabled, config, selections, agent, files, isWelcomeVisible, isConnected, toast, sendMessage, settings, getAllRagSourceIds, saveMode, activeConversationId, customPromptsEnabled, userPrompts.prompts])
 
@@ -548,6 +562,9 @@ export const ChatProvider = ({ children }) => {
 
 		// Agent controls
 		const stopAgent = useCallback(() => {
+			// Hide the Stop button immediately; the backend stop is best-effort and
+			// the terminal agent_completion event will also clear this.
+			setIsAgentRunning(false)
 			if (sendMessage) sendMessage({ type: 'agent_control', action: 'stop' })
 		}, [sendMessage])
 
@@ -814,6 +831,7 @@ export const ChatProvider = ({ children }) => {
 		messages,
 		isWelcomeVisible,
 		isThinking,
+		isAgentRunning,
 		isSynthesizing,
 		sendChatMessage,
 		rewindAndResubmit,

--- a/frontend/src/handlers/chat/websocketHandlers.js
+++ b/frontend/src/handlers/chat/websocketHandlers.js
@@ -32,6 +32,7 @@ export function cleanupStreamState() {
  * @param {Function} deps.addMessage - Add a message to the messages list.
  * @param {Function} deps.mapMessages - Transform the messages list via a mapper function.
  * @param {Function} deps.setIsThinking - Set the "thinking" indicator state.
+ * @param {Function} [deps.setIsAgentRunning] - Set the agent-run-in-flight state (drives the agent Stop button).
  * @param {Function} deps.setCurrentAgentStep - Set the current agent step number.
  * @param {Function} [deps.setAgentPendingQuestion] - Set pending agent question.
  * @param {Function} [deps.setCanvasContent] - Set canvas HTML/markdown content.
@@ -58,6 +59,7 @@ export function createWebSocketHandler(deps) {
     setIsThinking,
     setCurrentAgentStep,
   // Optional setters for extra UI state
+  setIsAgentRunning,
   setAgentPendingQuestion,
     setCanvasContent,
     setCanvasFiles,
@@ -75,6 +77,12 @@ export function createWebSocketHandler(deps) {
     streamToken,
     streamEnd,
   } = deps
+
+  // Clear the agent-run-in-flight flag on any terminal agent event. Optional so
+  // existing handler tests that don't inject the setter keep working.
+  function clearAgentRunning() {
+    if (typeof setIsAgentRunning === 'function') setIsAgentRunning(false)
+  }
 
   function flushTokenBuffer() {
     if (_tokenBuffer && typeof streamToken === 'function') {
@@ -142,6 +150,7 @@ export function createWebSocketHandler(deps) {
         case 'agent_completion':
           setCurrentAgentStep(0)
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
           if (typeof setAgentPendingQuestion === 'function') setAgentPendingQuestion(null)
           // Note: Do NOT add a chat message here — the final answer already
@@ -151,12 +160,14 @@ export function createWebSocketHandler(deps) {
         case 'agent_error':
           addMessage({ role: 'system', content: `Agent Error (Step ${data.turn}): ${data.message}`, type: 'agent_error', timestamp: new Date().toISOString() })
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
           setCurrentAgentStep(0)
           break
         case 'agent_max_steps':
           addMessage({ role: 'system', content: `Agent Max Steps Reached - ${data.message}`, type: 'agent_status', timestamp: new Date().toISOString() })
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
           setCurrentAgentStep(0)
           break
@@ -422,6 +433,7 @@ export function createWebSocketHandler(deps) {
         }
         case 'response_complete': {
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
           endTokenStream()
           break
@@ -463,6 +475,7 @@ export function createWebSocketHandler(deps) {
         }
         case 'chat_response':
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
           addMessage({ role: 'assistant', content: data.message, timestamp: new Date().toISOString() })
           break
@@ -471,6 +484,7 @@ export function createWebSocketHandler(deps) {
           break
         case 'error':
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
           setCurrentAgentStep(0)
           if (typeof setAgentPendingQuestion === 'function') setAgentPendingQuestion(null)
@@ -482,6 +496,7 @@ export function createWebSocketHandler(deps) {
           break
         case 'agent_final_response':
           setIsThinking(false)
+          clearAgentRunning()
           if (typeof setIsSynthesizing === 'function') setIsSynthesizing(false)
             setCurrentAgentStep(0)
             addMessage({ role: 'assistant', content: `${data.message}\n\n*Agent completed in ${data.steps_taken} steps*`, timestamp: new Date().toISOString() })

--- a/frontend/src/handlers/chat/websocketHandlers.test.js
+++ b/frontend/src/handlers/chat/websocketHandlers.test.js
@@ -201,15 +201,22 @@ describe('createWebSocketHandler – agent message handling', () => {
     const deps = makeDeps()
     const handler = createWebSocketHandler(deps)
 
-    // First token of the (streamed) answer: clears isThinking but must leave
-    // the agent-run flag untouched so the Stop button stays visible.
-    handler({ type: 'token_stream', is_first: true, token: 'Hel' })
-    expect(deps.setIsThinking).toHaveBeenCalledWith(false)
-    expect(deps.setIsAgentRunning).not.toHaveBeenCalled()
+    try {
+      // First token of the (streamed) answer: clears isThinking but must leave
+      // the agent-run flag untouched so the Stop button stays visible.
+      handler({ type: 'token_stream', is_first: true, token: 'Hel' })
+      expect(deps.setIsThinking).toHaveBeenCalledWith(false)
+      expect(deps.setIsAgentRunning).not.toHaveBeenCalled()
 
-    // The run actually ends -> flag clears.
-    handler({ type: 'agent_update', update_type: 'agent_completion', steps: 2 })
-    expect(deps.setIsAgentRunning).toHaveBeenCalledWith(false)
+      // The run actually ends -> flag clears.
+      handler({ type: 'agent_update', update_type: 'agent_completion', steps: 2 })
+      expect(deps.setIsAgentRunning).toHaveBeenCalledWith(false)
+    } finally {
+      // The first token schedules a module-level real setTimeout to flush the
+      // buffer. This test runs outside the fake-timers harness, so clear that
+      // state here to avoid leaking a timer into later (order-dependent) tests.
+      cleanupStreamState()
+    }
   })
 
   it('clears isAgentRunning on agent_error and agent_max_steps', () => {

--- a/frontend/src/handlers/chat/websocketHandlers.test.js
+++ b/frontend/src/handlers/chat/websocketHandlers.test.js
@@ -10,6 +10,7 @@ const makeDeps = () => {
       fn(sample)
     }),
     setIsThinking: vi.fn(),
+    setIsAgentRunning: vi.fn(),
     setCurrentAgentStep: vi.fn(),
     setAgentPendingQuestion: vi.fn(),
     setCanvasContent: vi.fn(),
@@ -185,10 +186,44 @@ describe('createWebSocketHandler – agent message handling', () => {
     // Should clear agent UI state
     expect(deps.setCurrentAgentStep).toHaveBeenCalledWith(0)
     expect(deps.setIsThinking).toHaveBeenCalledWith(false)
+    expect(deps.setIsAgentRunning).toHaveBeenCalledWith(false)
     expect(deps.setIsSynthesizing).toHaveBeenCalledWith(false)
     expect(deps.setAgentPendingQuestion).toHaveBeenCalledWith(null)
     // Should NOT add a duplicate completion message
     expect(deps.addMessage).not.toHaveBeenCalled()
+  })
+
+  // Regression: the native agentic loop clears isThinking the moment the first
+  // token streams, so the agent Stop button must hang off the separate
+  // isAgentRunning flag instead. token_stream must NOT clear that flag mid-run;
+  // only the terminal agent_completion (or agent_error / agent_max_steps) may.
+  it('keeps isAgentRunning across token streaming and clears it only on completion', () => {
+    const deps = makeDeps()
+    const handler = createWebSocketHandler(deps)
+
+    // First token of the (streamed) answer: clears isThinking but must leave
+    // the agent-run flag untouched so the Stop button stays visible.
+    handler({ type: 'token_stream', is_first: true, token: 'Hel' })
+    expect(deps.setIsThinking).toHaveBeenCalledWith(false)
+    expect(deps.setIsAgentRunning).not.toHaveBeenCalled()
+
+    // The run actually ends -> flag clears.
+    handler({ type: 'agent_update', update_type: 'agent_completion', steps: 2 })
+    expect(deps.setIsAgentRunning).toHaveBeenCalledWith(false)
+  })
+
+  it('clears isAgentRunning on agent_error and agent_max_steps', () => {
+    const errDeps = makeDeps()
+    createWebSocketHandler(errDeps)({
+      type: 'agent_update', update_type: 'agent_error', turn: 1, message: 'boom',
+    })
+    expect(errDeps.setIsAgentRunning).toHaveBeenCalledWith(false)
+
+    const maxDeps = makeDeps()
+    createWebSocketHandler(maxDeps)({
+      type: 'agent_update', update_type: 'agent_max_steps', message: 'hit cap',
+    })
+    expect(maxDeps.setIsAgentRunning).toHaveBeenCalledWith(false)
   })
 
   it('agent_start adds a status message', () => {


### PR DESCRIPTION
## Problem

In agent mode, the **Stop** button is effectively missing — it flashes on send and then disappears for the rest of the run, so there's no way to interrupt a running agent. This regressed when agent mode collapsed to the single native `agentic` loop (#664).

## Root cause

The agent-mode Stop button (`ChatArea.jsx`) was gated on `isThinking`:

```jsx
{agentModeEnabled && (isThinking || agentPendingQuestion) && ( …Stop… )}
```

`isThinking` is set `true` once on send and is set back to `false` the instant the first answer token streams (`websocketHandlers.js`, `token_stream`/`is_first`). The native loop streams the model's output (including the final answer), so:

1. Send → `isThinking = true` → Stop shows
2. First token streams → `isThinking = false` → **Stop vanishes**
3. Rest of the multi-step run (tool calls + streamed answer) → stays gone

Nothing ever re-sets `isThinking` to `true` during the loop. The old `react`/`think-act`/`act` strategies drove the run through discrete `agent_*` events and kept `isThinking` true throughout, which is why it appeared to work before. (The normal-mode Stop button survives because it also checks `isStreaming`.)

## Fix

Drive the agent Stop button off a dedicated `isAgentRunning` flag instead of `isThinking`:

- Set `true` on an agent-mode send (`sendChatMessage`).
- Cleared only on the terminal agent events: `agent_completion`, `agent_error`, `agent_max_steps`, plus `response_complete` / `chat_response` / `error`, and an explicit `stopAgent()` (optimistic) and the existing thinking-timeout safety net.

The flag spans the entire run regardless of streaming sub-state, so Stop stays visible until the agent actually finishes. `agent_completion` is emitted after the final answer finishes streaming (on both the success and exception paths in `modes/agent.py`), so timing is correct. Normal-mode streaming/Stop behavior is unchanged.

## Tests

- Extended the existing `agent_completion` handler test to assert `isAgentRunning` is cleared.
- Added a regression test: `token_stream` (first token) clears `isThinking` but must **not** clear `isAgentRunning`; the subsequent `agent_completion` does.
- Added a test that `agent_error` and `agent_max_steps` also clear the flag.

Full frontend suite: **472 passed**. ESLint clean on all changed files.