### PR TITLE
release: 0.4.0 (2026.07)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-06
+
 ### PR #700 - 2026-07-05
 - **Agent-mode tool calls persisted in saved conversations**: #685 covered tools mode only; the agentic loop now wraps its tool update callback in the same `ToolCallRecorder` and flushes the captured tool input/output into history after each step (id-reuse safe, always before the final assistant message), so reloaded agent conversations re-render user → tool_call(s) → assistant (also with no websocket connection, e.g. the chat CLI). Added agentic-loop wiring tests and updated `docs/admin/chat-history.md`.
 

--- a/atlas/version.py
+++ b/atlas/version.py
@@ -3,4 +3,4 @@
 Single source of truth for the application version number.
 """
 
-VERSION = "0.3.0"
+VERSION = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-chat"
-version = "0.3.0"
+version = "0.4.0"
 description = "Trusted AI agent platform with MCP, RAG, access control, and auditable tool use"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
<!--
This file is used as the body of the draft release PR opened by
.github/workflows/release-cut.yml. Keep it actionable and
review-friendly. Full process docs live at
docs/developer/release-process.md.
-->

# Release 0.4.0 (2026.07)

This PR was opened by the `release-cut` automation. It cuts
`release/2026.07` from `main` and bumps the version. Nothing
publishes until a maintainer manually tags `v0.4.0` on this
branch — see the runbook at
[docs/developer/release-process.md](../docs/developer/release-process.md).

## What this PR contains

- New branch `release/2026.07` cut from `main` at
  `4953a1ba2f5c8019a83bf7a0242a871caaaa582c`.
- `atlas/version.py` and `pyproject.toml` bumped from
  `0.3.0` → `0.4.0`.
- `CHANGELOG.md`: `## [Unreleased]` section finalized as
  `## [0.4.0] - 2026-07-06`; new empty `[Unreleased]`
  prepended.

## Release captain

Assign yourself to this PR. You own the checklist below, the smoke
test, the tag push, and the GitHub Release.

## Stabilization window

This PR stays open for the rest of the month. During that window:

- Only bug fixes merge to `release/2026.07`. Features and
  refactors continue to land on `main` as normal.
- Fix on `main` first, then cherry-pick to the release branch:
  `git cherry-pick -x <sha>`.
- Each cherry-pick gets a CHANGELOG note under the
  `## [0.4.0]` section on the release branch.

## Pre-tag checklist

Complete every item before pushing the tag. Do not merge this PR
until the tag is pushed and publish workflows are green.

### Code & CI

- [ ] `CI/CD Pipeline` is green on the latest commit of
      `release/2026.07`.
- [ ] `Security Checks` is green.
- [ ] No known P0 or P1 bugs filed against the release branch.
- [ ] `atlas/version.py` and `pyproject.toml` both show `0.4.0`.
- [ ] `CHANGELOG.md` has a populated `## [0.4.0]` section with
      at least one entry per user-visible change since the previous
      release.

### Smoke test (manual)

See [docs/developer/release-process.md#smoke-test](../docs/developer/release-process.md#smoke-test).

- [ ] `uv build --wheel` succeeds on `release/2026.07`.
- [ ] Fresh `atlas-init` + `atlas-chat` one-shot call works against
      a real LLM.
- [ ] Tool-call path works (`atlas-chat --tools calculator_evaluate`).
- [ ] `atlas-server` boots and `/api/health` returns `0.4.0`.

### Publish

- [ ] Tag pushed: `git tag -a v0.4.0 -m "Atlas UI 3 v0.4.0" && git push origin v0.4.0`.
- [ ] GitHub Release created from the tag, targeting
      `release/2026.07`, with CHANGELOG section as the body.
- [ ] `pypi-publish.yml` completed, `atlas-chat==0.4.0`
      visible on PyPI.
- [ ] `quay-publish.yml` completed, `quay.io/<ns>/atlas-ui-3:0.4.0`
      image pushed.

### Post-publish

- [ ] This PR merged into `main` (fast-forward if possible) so the
      version bump and any hotfixes carry forward.
- [ ] Follow-up issue filed for any deferred items surfaced during
      stabilization.

## Rollback

If the release is broken in the wild, **do not rewrite history**.
Yank the bad version on PyPI and cut a patch release via the hotfix
flow in the runbook. Rolling forward beats rolling back.
