### PR TITLE
Add optional per-model group-based access control

### DIFF
--- a/atlas/application/chat/orchestrator.py
+++ b/atlas/application/chat/orchestrator.py
@@ -4,7 +4,8 @@ import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from atlas.domain.errors import SessionNotFoundError
+from atlas.core.model_access import is_model_allowed
+from atlas.domain.errors import AuthorizationError, SessionNotFoundError
 from atlas.domain.messages.models import Message, MessageRole
 from atlas.interfaces.events import EventPublisher
 from atlas.interfaces.llm import LLMProtocol
@@ -145,6 +146,35 @@ class ChatOrchestrator:
         except Exception:
             return True
 
+    async def _ensure_model_authorized(self, model: str, user_email: Optional[str]) -> None:
+        """Reject the turn if the user may not access the requested model.
+
+        Enforces the per-model ``groups`` access-control list. Models without a
+        ``groups`` restriction (the default) are allowed for everyone, so this is
+        a no-op unless an operator has opted a model into group restriction.
+        Unknown models are left to the downstream caller to reject so behavior is
+        unchanged when access control is not configured.
+        """
+        if not self.config_manager:
+            return
+        try:
+            model_config = self.config_manager.llm_config.models.get(model)
+        except Exception:
+            return
+        if model_config is None:
+            return
+        if await is_model_allowed(model_config, user_email):
+            return
+        logger.warning(
+            "Rejected chat: user %s not authorized for model %s",
+            user_email or "<anonymous>",
+            model,
+        )
+        raise AuthorizationError(
+            "You are not authorized to use the selected model.",
+            code="MODEL_ACCESS_DENIED",
+        )
+
     async def execute(
         self,
         session_id: UUID,
@@ -188,6 +218,11 @@ class ChatOrchestrator:
         session = await self.session_repository.get(session_id)
         if not session:
             raise SessionNotFoundError(f"Session {session_id} not found")
+
+        # Enforce per-model group access control at request time. The `model`
+        # string comes straight off the client, so listing-layer filtering alone
+        # is bypassable -- a crafted request must be rejected here too.
+        await self._ensure_model_authorized(model, user_email)
 
         # Rewind/edit-and-resubmit: drop the targeted prompt and everything after
         # it so the new content takes its place in a single linear thread.

--- a/atlas/application/chat/orchestrator.py
+++ b/atlas/application/chat/orchestrator.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
+from atlas.core.log_sanitizer import sanitize_for_logging
 from atlas.core.model_access import is_model_allowed
 from atlas.domain.errors import AuthorizationError, SessionNotFoundError
 from atlas.domain.messages.models import Message, MessageRole
@@ -167,8 +168,8 @@ class ChatOrchestrator:
             return
         logger.warning(
             "Rejected chat: user %s not authorized for model %s",
-            user_email or "<anonymous>",
-            model,
+            sanitize_for_logging(user_email or "<anonymous>"),
+            sanitize_for_logging(model),
         )
         raise AuthorizationError(
             "You are not authorized to use the selected model.",

--- a/atlas/config/llmconfig.yml
+++ b/atlas/config/llmconfig.yml
@@ -182,11 +182,6 @@ models:
     description: "Local mock LLM for testing"
     compliance_level: "Internal"
     supports_tools: false
-    # Optional: restrict this model to specific groups. Omit (as here) to keep
-    # the default of "available to everyone". When set, only users in at least
-    # one listed group can see or use the model. See docs/admin/llm-config.md.
-    # groups:
-    #   - admin
     model_card: >
       Mock model for local development and testing. Returns canned responses
       and does not call any real LLM API. Does not support tool calling or

--- a/atlas/config/llmconfig.yml
+++ b/atlas/config/llmconfig.yml
@@ -182,6 +182,11 @@ models:
     description: "Local mock LLM for testing"
     compliance_level: "Internal"
     supports_tools: false
+    # Optional: restrict this model to specific groups. Omit (as here) to keep
+    # the default of "available to everyone". When set, only users in at least
+    # one listed group can see or use the model. See docs/admin/llm-config.md.
+    # groups:
+    #   - admin
     model_card: >
       Mock model for local development and testing. Returns canned responses
       and does not call any real LLM API. Does not support tool calling or

--- a/atlas/core/model_access.py
+++ b/atlas/core/model_access.py
@@ -1,0 +1,81 @@
+"""Per-model group-based access control.
+
+A model in ``llmconfig.yml`` may declare an optional ``groups`` list. When the
+list is empty (the default) the model is available to everyone, preserving the
+historical behavior. When it is non-empty, only users who belong to at least one
+of the listed groups may see or use that model.
+
+This mirrors the ``groups`` access-control convention already used for MCP
+servers (``MCPServerConfig``) and RAG sources (``RAGSourceConfig``), and funnels
+every membership decision through :func:`atlas.core.auth.is_user_in_group`.
+"""
+
+import logging
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from atlas.core.auth import is_user_in_group
+
+logger = logging.getLogger(__name__)
+
+# An async ``(user_email, group_id) -> bool`` membership check. Injectable so the
+# helpers stay unit-testable without a live authorization backend.
+AuthCheckFunc = Callable[[str, str], Awaitable[bool]]
+
+
+def _model_groups(model_config: Any) -> list:
+    """Return the configured access groups for a model, tolerating dict or model."""
+    if model_config is None:
+        return []
+    if isinstance(model_config, dict):
+        groups = model_config.get("groups")
+    else:
+        groups = getattr(model_config, "groups", None)
+    return list(groups) if groups else []
+
+
+async def is_model_allowed(
+    model_config: Any,
+    user_email: Optional[str],
+    auth_check_func: Optional[AuthCheckFunc] = None,
+) -> bool:
+    """Return True if ``user_email`` may access the model described by ``model_config``.
+
+    Access rules (identical to the MCP/RAG ``groups`` convention):
+    - No ``groups`` configured (empty/absent) -> allowed for everyone.
+    - ``groups`` configured -> allowed only if the user is a member of at least
+      one listed group. A missing user is denied when a restriction exists.
+
+    ``auth_check_func`` defaults to :func:`atlas.core.auth.is_user_in_group`;
+    it is resolved at call time so it stays injectable/patchable in tests.
+    """
+    required_groups = _model_groups(model_config)
+    if not required_groups:
+        return True
+    if not user_email:
+        return False
+    check = auth_check_func or is_user_in_group
+    for group in required_groups:
+        try:
+            if await check(user_email, group):
+                return True
+        except Exception:
+            # Fail closed on this group; a backend hiccup must not grant access.
+            logger.debug(
+                "Group membership check failed for group %s; treating as not-a-member",
+                group,
+                exc_info=True,
+            )
+    return False
+
+
+async def filter_authorized_models(
+    models: Dict[str, Any],
+    user_email: Optional[str],
+    auth_check_func: Optional[AuthCheckFunc] = None,
+) -> Dict[str, Any]:
+    """Return only the ``{name: model_config}`` entries the user may access."""
+    authorized: Dict[str, Any] = {}
+    for name, model_config in (models or {}).items():
+        if await is_model_allowed(model_config, user_email, auth_check_func):
+            authorized[name] = model_config
+    return authorized

--- a/atlas/modules/config/models.py
+++ b/atlas/modules/config/models.py
@@ -82,6 +82,11 @@ class ModelConfig(BaseModel):
     extra_headers: Optional[Dict[str, str]] = None
     # Compliance/security level (e.g., "External", "Internal", "Public")
     compliance_level: Optional[str] = None
+    # Access groups. Empty (the default) means every user may access this model,
+    # preserving the historical behavior. When non-empty, only users who are a
+    # member of at least one listed group may see or use this model. Matches the
+    # ``groups`` access-control convention used by MCPServerConfig / RAGSourceConfig.
+    groups: List[str] = Field(default_factory=list)
     # API key source: "system" uses env var resolution, "user" requires per-user key from token storage,
     # "globus" uses Globus OAuth token for the configured scope (requires globus_scope)
     api_key_source: str = "system"

--- a/atlas/routes/config_routes.py
+++ b/atlas/routes/config_routes.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 
 from atlas.core.auth import is_user_in_group
 from atlas.core.log_sanitizer import get_current_user, sanitize_for_logging
+from atlas.core.model_access import is_model_allowed
 from atlas.infrastructure.app_factory import app_factory
 from atlas.routes.files_routes import get_file_upload_limit_config
 from atlas.modules.mcp_tools.mcp_discovery import _ATLAS_RAG_TOOL_SCHEMAS
@@ -137,6 +138,9 @@ async def get_config_shell(
     # Build models list without per-user token validity checks (fast path)
     models_list = []
     for model_name, model_config in llm_config.models.items():
+        # Hide models the user is not authorized to access (per-model `groups`).
+        if not await is_model_allowed(model_config, current_user):
+            continue
         model_info = {
             "name": model_name,
             "description": model_config.description,
@@ -418,6 +422,9 @@ async def get_config(
 
     models_list = []
     for model_name, model_config in llm_config.models.items():
+        # Hide models the user is not authorized to access (per-model `groups`).
+        if not await is_model_allowed(model_config, current_user):
+            continue
         model_info = {
             "name": model_name,
             "description": model_config.description,

--- a/atlas/routes/llm_auth_routes.py
+++ b/atlas/routes/llm_auth_routes.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from atlas.core.log_sanitizer import get_current_user, sanitize_for_logging
+from atlas.core.model_access import is_model_allowed
 from atlas.infrastructure.app_factory import app_factory
 from atlas.modules.mcp_tools.token_storage import get_token_storage
 
@@ -40,6 +41,12 @@ async def get_llm_auth_status(current_user: str = Depends(get_current_user)):
         for model_name, model_config in llm_config.models.items():
             api_key_source = getattr(model_config, "api_key_source", "system")
             if api_key_source != "user":
+                continue
+
+            # Do not enumerate models the user is not authorized to access
+            # (per-model `groups`); otherwise the listing-layer hiding is
+            # bypassable via this endpoint for user-key models.
+            if not await is_model_allowed(model_config, current_user):
                 continue
 
             storage_key = f"llm:{model_name}"
@@ -82,6 +89,13 @@ async def upload_llm_token(
             raise HTTPException(status_code=404, detail=f"Model '{model_name}' not found")
 
         model_config = llm_config.models[model_name]
+
+        # Reject token uploads for models the user is not authorized to access.
+        # Return 404 (not 403) so a restricted model is indistinguishable from a
+        # nonexistent one and its name/existence is not leaked.
+        if not await is_model_allowed(model_config, current_user):
+            raise HTTPException(status_code=404, detail=f"Model '{model_name}' not found")
+
         if getattr(model_config, "api_key_source", "system") != "user":
             raise HTTPException(
                 status_code=400,

--- a/atlas/tests/test_llm_auth_routes.py
+++ b/atlas/tests/test_llm_auth_routes.py
@@ -39,6 +39,7 @@ def _mock_llm_config(models_dict):
         m = MagicMock()
         m.description = attrs.get("description", "")
         m.api_key_source = attrs.get("api_key_source", "system")
+        m.groups = attrs.get("groups", [])
         mock_models[name] = m
     mock_config.models = mock_models
     return mock_config
@@ -268,3 +269,89 @@ class TestLLMTokenUploadModel:
         expiry = time.time() + 3600
         model = LLMTokenUpload(token="sk-abc123", expires_at=expiry)
         assert model.expires_at == expiry
+
+
+class TestGroupRestrictedModels:
+    """Per-model `groups` access control must also gate the user-key auth routes.
+
+    Otherwise a restricted model that uses api_key_source=user could be
+    enumerated via /status or probed via the token routes, bypassing the
+    listing-layer hiding.
+    """
+
+    def _deps(self):
+        """Patch config + storage + auth so only admin@test.com is in `admin`."""
+        async def only_admin(user_email, group):
+            return group == "admin" and user_email == "admin@test.com"
+
+        factory_patch = patch("atlas.routes.llm_auth_routes.app_factory")
+        storage_patch = patch("atlas.routes.llm_auth_routes.get_token_storage")
+        auth_patch = patch(
+            "atlas.core.model_access.is_user_in_group", side_effect=only_admin
+        )
+        mock_factory = factory_patch.start()
+        mock_storage = storage_patch.start()
+        auth_patch.start()
+
+        llm_config = _mock_llm_config({
+            "open-user-model": {"api_key_source": "user"},
+            "admin-user-model": {"api_key_source": "user", "groups": ["admin"]},
+        })
+        mock_cm = MagicMock()
+        mock_cm.llm_config = llm_config
+        mock_factory.get_config_manager.return_value = mock_cm
+
+        mock_ts = MagicMock()
+        mock_ts.get_token.return_value = None
+        mock_stored = MagicMock()
+        mock_stored.expires_at = None
+        mock_ts.store_token.return_value = mock_stored
+        mock_storage.return_value = mock_ts
+
+        return [factory_patch, storage_patch, auth_patch], mock_ts
+
+    def test_status_hides_restricted_model_from_non_member(self):
+        patches, _ = self._deps()
+        try:
+            client = TestClient(create_test_app(user_override="user@test.com"))
+            resp = client.get("/api/llm/auth/status")
+            assert resp.status_code == 200
+            names = {m["model_name"] for m in resp.json()["models"]}
+            assert names == {"open-user-model"}
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_status_shows_restricted_model_to_member(self):
+        patches, _ = self._deps()
+        try:
+            client = TestClient(create_test_app(user_override="admin@test.com"))
+            resp = client.get("/api/llm/auth/status")
+            names = {m["model_name"] for m in resp.json()["models"]}
+            assert names == {"open-user-model", "admin-user-model"}
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_upload_rejected_for_restricted_model_non_member(self):
+        patches, mock_ts = self._deps()
+        try:
+            client = TestClient(create_test_app(user_override="user@test.com"))
+            resp = client.post("/api/llm/auth/admin-user-model/token", json={"token": "sk-x"})
+            # 404 (indistinguishable from nonexistent) and no token stored.
+            assert resp.status_code == 404
+            mock_ts.store_token.assert_not_called()
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_upload_allowed_for_restricted_model_member(self):
+        patches, mock_ts = self._deps()
+        try:
+            client = TestClient(create_test_app(user_override="admin@test.com"))
+            resp = client.post("/api/llm/auth/admin-user-model/token", json={"token": "sk-x"})
+            assert resp.status_code == 200
+            mock_ts.store_token.assert_called_once()
+        finally:
+            for p in patches:
+                p.stop()

--- a/atlas/tests/test_model_access_control.py
+++ b/atlas/tests/test_model_access_control.py
@@ -1,0 +1,271 @@
+"""Tests for per-model group-based access control.
+
+Covers the three required cases at both layers:
+- omitted/empty ``groups`` -> everyone allowed (backward compatible)
+- present ``groups`` with a matching group -> allowed
+- present ``groups`` with a non-matching group -> denied / filtered
+
+Layers exercised:
+- helper: ``is_model_allowed`` / ``filter_authorized_models``
+- execution: ``ChatOrchestrator._ensure_model_authorized`` raises for a
+  crafted request naming a restricted model the user can't access.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from atlas.application.chat.orchestrator import ChatOrchestrator
+from atlas.core.model_access import filter_authorized_models, is_model_allowed
+from atlas.domain.errors import AuthorizationError
+from atlas.domain.sessions.models import Session
+from atlas.infrastructure.sessions.in_memory_repository import InMemorySessionRepository
+from atlas.modules.config.models import LLMConfig, ModelConfig
+
+
+async def _auth_check_admin_only(user_email: str, group: str) -> bool:
+    """Mock membership: only ``admin@test.com`` is in the ``admin`` group."""
+    return group == "admin" and user_email == "admin@test.com"
+
+
+def _model(groups=None):
+    return ModelConfig(
+        model_name="m",
+        model_url="http://x/v1",
+        groups=groups or [],
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Config schema
+# --------------------------------------------------------------------------- #
+
+def test_model_config_groups_defaults_empty():
+    """Omitting ``groups`` yields an empty list (open to everyone)."""
+    m = ModelConfig(model_name="m", model_url="http://x/v1")
+    assert m.groups == []
+
+
+def test_model_config_groups_parsed_from_dict():
+    """``groups`` is parsed onto ModelConfig via LLMConfig (yaml path)."""
+    cfg = LLMConfig(models={"restricted": {
+        "model_name": "m", "model_url": "http://x/v1", "groups": ["admin"],
+    }})
+    assert cfg.models["restricted"].groups == ["admin"]
+
+
+# --------------------------------------------------------------------------- #
+# Helper layer: is_model_allowed
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_omitted_groups_allows_everyone():
+    """No groups configured -> allowed even for an anonymous user."""
+    assert await is_model_allowed(_model(), "nobody@test.com", _auth_check_admin_only)
+    assert await is_model_allowed(_model(), None, _auth_check_admin_only)
+
+
+@pytest.mark.asyncio
+async def test_matching_group_allowed():
+    """User in a listed group is allowed."""
+    assert await is_model_allowed(_model(["admin"]), "admin@test.com", _auth_check_admin_only)
+
+
+@pytest.mark.asyncio
+async def test_non_matching_group_denied():
+    """User not in any listed group is denied."""
+    assert not await is_model_allowed(_model(["admin"]), "user@test.com", _auth_check_admin_only)
+
+
+@pytest.mark.asyncio
+async def test_restricted_model_denies_anonymous():
+    """A restriction always denies a missing user."""
+    assert not await is_model_allowed(_model(["admin"]), None, _auth_check_admin_only)
+
+
+@pytest.mark.asyncio
+async def test_any_matching_group_is_sufficient():
+    """Membership in ANY one of several listed groups grants access."""
+    async def in_users(user_email, group):
+        return group == "users"
+
+    assert await is_model_allowed(_model(["admin", "users"]), "u@test.com", in_users)
+
+
+@pytest.mark.asyncio
+async def test_auth_check_error_fails_closed():
+    """A membership-check exception is treated as not-a-member (fail closed)."""
+    async def boom(user_email, group):
+        raise RuntimeError("auth backend down")
+
+    assert not await is_model_allowed(_model(["admin"]), "admin@test.com", boom)
+
+
+@pytest.mark.asyncio
+async def test_filter_authorized_models():
+    """filter_authorized_models drops restricted models the user can't access."""
+    models = {
+        "open": _model(),
+        "admin-only": _model(["admin"]),
+        "also-open": _model([]),
+    }
+    for_user = await filter_authorized_models(models, "user@test.com", _auth_check_admin_only)
+    assert set(for_user) == {"open", "also-open"}
+
+    for_admin = await filter_authorized_models(models, "admin@test.com", _auth_check_admin_only)
+    assert set(for_admin) == {"open", "admin-only", "also-open"}
+
+
+# --------------------------------------------------------------------------- #
+# Execution layer: orchestrator enforcement
+# --------------------------------------------------------------------------- #
+
+def _make_orchestrator_with_models(models: dict):
+    """Build an orchestrator whose config_manager exposes the given models."""
+    config_manager = MagicMock()
+    config_manager.llm_config = LLMConfig(models=models)
+
+    event_pub = MagicMock()
+    event_pub.publish_warning = AsyncMock()
+    repo = InMemorySessionRepository()
+
+    plain_runner = MagicMock()
+    plain_runner.run_streaming = AsyncMock(return_value={"mode": "plain"})
+    rag_runner = MagicMock()
+    rag_runner.run_streaming = AsyncMock(return_value={"mode": "rag"})
+    tools_runner = MagicMock()
+    tools_runner.run_streaming = AsyncMock(return_value={"mode": "tools"})
+    agent_runner = MagicMock()
+    agent_runner.run = AsyncMock(return_value={"mode": "agent"})
+
+    orch = ChatOrchestrator(
+        llm=MagicMock(),
+        event_publisher=event_pub,
+        session_repository=repo,
+        plain_mode=plain_runner,
+        rag_mode=rag_runner,
+        tools_mode=tools_runner,
+        agent_mode=agent_runner,
+        config_manager=config_manager,
+    )
+    return orch, repo, plain_runner.run_streaming
+
+
+async def _seed_session(repo, user_email):
+    sid = uuid.uuid4()
+    await repo.create(Session(id=sid, user_email=user_email))
+    return sid
+
+
+@pytest.mark.asyncio
+async def test_execute_denies_unauthorized_model(monkeypatch):
+    """A crafted request for a restricted model is rejected before any LLM call."""
+    monkeypatch.setattr(
+        "atlas.core.model_access.is_user_in_group", _auth_check_admin_only
+    )
+    orch, repo, plain_run = _make_orchestrator_with_models(
+        {"admin-only": {"model_name": "m", "model_url": "http://x/v1", "groups": ["admin"]}}
+    )
+    sid = await _seed_session(repo, "user@test.com")
+
+    with pytest.raises(AuthorizationError) as exc:
+        await orch.execute(
+            session_id=sid, content="hi", model="admin-only", user_email="user@test.com",
+        )
+    assert exc.value.code == "MODEL_ACCESS_DENIED"
+    plain_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_allows_authorized_model(monkeypatch):
+    """An authorized user reaches the mode runner for a restricted model."""
+    monkeypatch.setattr(
+        "atlas.core.model_access.is_user_in_group", _auth_check_admin_only
+    )
+    orch, repo, plain_run = _make_orchestrator_with_models(
+        {"admin-only": {"model_name": "m", "model_url": "http://x/v1", "groups": ["admin"]}}
+    )
+    sid = await _seed_session(repo, "admin@test.com")
+
+    await orch.execute(
+        session_id=sid, content="hi", model="admin-only", user_email="admin@test.com",
+    )
+    plain_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_allows_unrestricted_model(monkeypatch):
+    """A model without groups is reachable by everyone (backward compatible)."""
+    monkeypatch.setattr(
+        "atlas.core.model_access.is_user_in_group", _auth_check_admin_only
+    )
+    orch, repo, plain_run = _make_orchestrator_with_models(
+        {"open": {"model_name": "m", "model_url": "http://x/v1"}}
+    )
+    sid = await _seed_session(repo, "anyone@test.com")
+
+    await orch.execute(
+        session_id=sid, content="hi", model="open", user_email="anyone@test.com",
+    )
+    plain_run.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# Listing layer: /api/config and /api/config/shell filter restricted models
+# --------------------------------------------------------------------------- #
+
+@pytest.fixture
+def restricted_model_config():
+    """Inject an ``admin``-restricted model into the live config for one test."""
+    from atlas.infrastructure.app_factory import app_factory
+
+    config_manager = app_factory.get_config_manager()
+    models = config_manager.llm_config.models
+    models["admin-only-model"] = ModelConfig(
+        model_name="admin/only", model_url="http://x/v1", groups=["admin"],
+    )
+    try:
+        yield
+    finally:
+        models.pop("admin-only-model", None)
+
+
+def _model_names(resp):
+    return {m["name"] for m in resp.json()["models"]}
+
+
+def test_config_hides_restricted_model_from_non_member(restricted_model_config):
+    """A non-admin user must not see an admin-restricted model in /api/config."""
+    from main import app
+    from starlette.testclient import TestClient
+
+    client = TestClient(app)
+    # user@example.com is in {users, mcp_basic} but NOT admin (mock groups).
+    resp = client.get("/api/config", headers={"X-User-Email": "user@example.com"})
+    assert resp.status_code == 200
+    assert "admin-only-model" not in _model_names(resp)
+
+
+def test_config_shows_restricted_model_to_member(restricted_model_config):
+    """An admin user sees the admin-restricted model in both config endpoints."""
+    from main import app
+    from starlette.testclient import TestClient
+
+    client = TestClient(app)
+    # test@test.com is in the admin mock group.
+    for path in ("/api/config", "/api/config/shell"):
+        resp = client.get(path, headers={"X-User-Email": "test@test.com"})
+        assert resp.status_code == 200
+        assert "admin-only-model" in _model_names(resp), path
+
+
+def test_config_shell_hides_restricted_model_from_non_member(restricted_model_config):
+    """The fast shell endpoint applies the same filter as /api/config."""
+    from main import app
+    from starlette.testclient import TestClient
+
+    client = TestClient(app)
+    resp = client.get("/api/config/shell", headers={"X-User-Email": "user@example.com"})
+    assert resp.status_code == 200
+    assert "admin-only-model" not in _model_names(resp)

--- a/docs/admin/llm-config.md
+++ b/docs/admin/llm-config.md
@@ -152,6 +152,53 @@ models:
 - `"system"` (default) - API key resolved from environment variables using `${VAR_NAME}` syntax
 - `"user"` - API key provided per-user via the UI, stored encrypted on disk
 
+## Restricting Model Access by Group (2026-07-10)
+
+By default every model is available to every user. To restrict a model to
+specific groups, add an optional `groups` list to the model definition. This
+uses the same `groups` access-control convention as MCP servers and RAG sources.
+
+```yaml
+models:
+  # Open to everyone (default) — no `groups` line.
+  gpt-4o-mini:
+    model_name: gpt-4o-mini
+    model_url: https://api.openai.com/v1/chat/completions
+    api_key: "${OPENAI_API_KEY}"
+    compliance_level: "External"
+
+  # Restricted — only members of `research` or `admin` may see or use it.
+  internal-frontier:
+    model_name: openai/frontier-internal
+    model_url: https://llm.internal.example.com/v1
+    api_key: "${INTERNAL_LLM_API_KEY}"
+    compliance_level: "Internal"
+    groups:
+      - research
+      - admin
+```
+
+### Behavior
+
+- **Omitted / empty `groups`**: unchanged — the model is available to all users
+  (fully backward compatible).
+- **Non-empty `groups`**: a user may access the model only if they are a member
+  of **at least one** listed group. Group membership is resolved through the same
+  `is_user_in_group` check used for MCP servers and RAG sources (external
+  authorization endpoint in production, mock groups in local debug mode).
+
+### Enforcement
+
+Access is enforced in two places so it cannot be bypassed by a crafted request:
+
+1. **Listing** — restricted models are filtered out of the `/api/config` and
+   `/api/config/shell` responses for unauthorized users, so they never appear in
+   the model dropdown.
+2. **Execution** — the chat orchestrator re-checks authorization for the
+   requested model on every turn before any LLM call. An unauthorized model
+   request is rejected with an authorization error even if the client sends the
+   model name directly over the WebSocket.
+
 ## Configuration Fields Explained
 
 *   **`model_name`**: (string) The identifier for the model that will be sent to the LLM provider. For `LiteLLM`, you often need to prefix this with the provider name (e.g., `openai/`, `anthropic/`).
@@ -166,6 +213,7 @@ models:
 *   **`customer_id_strip_suffix`**: (string, optional) An email-domain suffix (e.g. `"@mydomain.com"`) to strip from the reverse-proxy-provided username before it is sent as the `x-litellm-customer-id` header — turning `user@mydomain.com` into `user`. Only applies when `pass_user_as_customer_id` is `true` and the username actually ends with the suffix (matched case-insensitively); otherwise the value is sent unchanged. See [LiteLLM Customer ID Header](#litellm-customer-id-header) below.
 *   **`supports_vision`**: (boolean, default `false`) When `true`, the model accepts image inputs. Users can upload images in the chat UI, and those images are sent as inline base64 content blocks in the user message rather than being described in the text files manifest. Only raster image formats are supported (PNG, JPEG, GIF, WebP); SVG files are excluded. See [Vision Image Support](#vision-image-support-2026-03-23) below.
 *   **`compliance_level`**: (string) The security compliance level of this model (e.g., "Public", "Internal"). This is used to filter which models can be used in certain compliance contexts.
+*   **`groups`**: (list of strings, optional) Access-control groups for this model. When omitted or empty (the default), the model is available to everyone. When set, only users who belong to at least one listed group can see or use the model. Enforced at both the model-listing and chat-execution layers. See [Restricting Model Access by Group](#restricting-model-access-by-group-2026-07-10) above.
 
 ## LiteLLM Customer ID Header
 


### PR DESCRIPTION
## Summary

Adds an **optional** per-model access-control field so admins can restrict specific LLM endpoints/models to particular groups. Default behavior is unchanged: a model with no restriction remains available to everyone.

- New optional `groups` field on each model in `llmconfig.yml`, matching the existing `groups` access-control convention already used by MCP servers (`MCPServerConfig`) and RAG sources (`RAGSourceConfig`).
- **Backward compatible**: absent/empty `groups` → available to all users. Non-empty → user must belong to at least one listed group. All membership checks funnel through the existing `is_user_in_group`.

## Enforcement (defense in depth)

So a crafted request cannot bypass restrictions, access is enforced at two layers:

1. **Listing** — `/api/config` and `/api/config/shell` filter restricted models out of the model list for unauthorized users, so they never appear in the dropdown.
2. **Execution** — `ChatOrchestrator.execute` re-checks the requested model on every turn *before any LLM call* and raises `AuthorizationError` (`MODEL_ACCESS_DENIED`) otherwise. The WebSocket layer already turns this into a clean `authorization` error frame.

## Files changed

| File | Change |
|------|--------|
| `atlas/core/model_access.py` | **New** helper: `is_model_allowed` / `filter_authorized_models` (fail-closed, injectable auth func) |
| `atlas/modules/config/models.py` | Added `groups` field to `ModelConfig` |
| `atlas/routes/config_routes.py` | Filter models in both listing endpoints |
| `atlas/application/chat/orchestrator.py` | `_ensure_model_authorized` check at request time |
| `atlas/config/llmconfig.yml` | Commented example of `groups:` |
| `docs/admin/llm-config.md` | New "Restricting Model Access by Group" section + field reference |
| `atlas/tests/test_model_access_control.py` | **New** 15 tests |

## Tests

- `test_model_access_control.py`: 15 passed — covers omitted-field (everyone allowed), matching-group (allowed), and non-matching-group (denied/filtered) at the helper, execution, and listing/route layers, plus fail-closed on auth-backend errors.
- Broad related sweep (`-k "config or orchestrator or auth or model or access"`): 458 passed, 9 skipped, 0 failures.

## Example

```yaml
models:
  internal-frontier:
    model_name: openai/frontier-internal
    model_url: https://llm.internal.example.com/v1
    api_key: "${INTERNAL_LLM_API_KEY}"
    groups:
      - research
      - admin
```