### PR TITLE
Ignore node_modules directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ atlas/.env.example
 .claude
 
 .pytest_cache
+# Node
+node_modules/
+**/node_modules/
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Adds `node_modules/` and `**/node_modules/` to `.gitignore`.

The repo had no Node ignore rule, so `node_modules/` (root) and `frontend/node_modules/` showed up as untracked. This ignores both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)