### PR TITLE
Enforce MCP tool group ACLs at execution time; make filter fail closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### PR #TBD - 2026-07-14
+### PR #723 - 2026-07-14
 - **Fail-closed MCP tool ACL enforcement at execution time**: Fixed agent mode bypassing the tool authorization filter by enforcing group ACL checks inside `MCPToolManager.execute_tool` at the single execution choke point, keyed on the trusted `context["user_email"]`. Missing user context, disabled servers, group-check exceptions, and unauthorized membership now deny execution rather than fall back to allowing the call. Also made `ToolAuthorizationService.filter_authorized_tools` fail closed: it returns an empty list whenever the ACL check cannot complete instead of returning the unfiltered selection.
 
 ### PR #717 - 2026-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### PR #723 - 2026-07-14
 - **Fail-closed MCP tool ACL enforcement at execution time**: Fixed agent mode bypassing the tool authorization filter by enforcing group ACL checks inside `MCPToolManager.execute_tool` at the single execution choke point, keyed on the trusted `context["user_email"]`. Missing user context, disabled servers, group-check exceptions, and unauthorized membership now deny execution rather than fall back to allowing the call. Also made `ToolAuthorizationService.filter_authorized_tools` fail closed: it returns an empty list whenever the ACL check cannot complete instead of returning the unfiltered selection.
+- **Runtime-only container compatibility**: Enable the PyO3 stable-ABI compatibility mode while installing LiteLLM so the rolling Chainguard Python 3.14 image does not fail its native extension build.
 
 ### PR #717 - 2026-07-08
 - **Agent-mode narration persisted**: Intermediate assistant text in agent mode now finalizes its live stream bubble even on tool-call turns, is saved with the conversation before the corresponding tool row, and agent-mode prompts now ask for concise narration before tool calls. The persisted narration is a display-only `agent_intermediate` row (excluded from `get_messages_for_llm()`) so reloaded conversations re-render it without replaying back-to-back assistant turns that strict-alternation providers reject.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #TBD - 2026-07-14
+- **Fail-closed MCP tool ACL enforcement at execution time**: Fixed agent mode bypassing the tool authorization filter by enforcing group ACL checks inside `MCPToolManager.execute_tool` at the single execution choke point, keyed on the trusted `context["user_email"]`. Missing user context, disabled servers, group-check exceptions, and unauthorized membership now deny execution rather than fall back to allowing the call. Also made `ToolAuthorizationService.filter_authorized_tools` fail closed: it returns an empty list whenever the ACL check cannot complete instead of returning the unfiltered selection.
+
 ### PR #717 - 2026-07-08
 - **Agent-mode narration persisted**: Intermediate assistant text in agent mode now finalizes its live stream bubble even on tool-call turns, is saved with the conversation before the corresponding tool row, and agent-mode prompts now ask for concise narration before tool calls. The persisted narration is a display-only `agent_intermediate` row (excluded from `get_messages_for_llm()`) so reloaded conversations re-render it without replaying back-to-back assistant turns that strict-alternation providers reject.
 

--- a/Dockerfile.runtimeonly
+++ b/Dockerfile.runtimeonly
@@ -77,6 +77,7 @@ RUN python3 -m venv /app/.venv
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 RUN pip install --no-cache-dir --upgrade pip && \
+    PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
     pip install --no-cache-dir --ignore-requires-python ".[mcp-demos]"
 
 RUN chown -R nonroot:nonroot /app

--- a/atlas/application/chat/policies/tool_authorization.py
+++ b/atlas/application/chat/policies/tool_authorization.py
@@ -50,8 +50,13 @@ class ToolAuthorizationService:
         Returns:
             Filtered list of authorized tool names
         """
-        if not selected_tools or not self.tool_manager:
-            return selected_tools or []
+        if not selected_tools:
+            return []
+        if not self.tool_manager:
+            logger.warning(
+                "Tool ACL filtering requested but no tool manager available; dropping tools"
+            )
+            return []
 
         try:
             user = user_email or ""
@@ -94,11 +99,11 @@ class ToolAuthorizationService:
             return filtered_tools
 
         except Exception:
-            logger.debug(
-                "Tool ACL filtering failed; proceeding with original selection",
+            logger.warning(
+                "Tool ACL filtering failed; dropping all selected tools",
                 exc_info=True
             )
-            return selected_tools
+            return []
 
     async def _get_authorized_servers(self, user: str) -> List[str]:
         """

--- a/atlas/modules/mcp_tools/mcp_execution.py
+++ b/atlas/modules/mcp_tools/mcp_execution.py
@@ -77,7 +77,14 @@ class ExecutionMixin:
         identity from the request context. Missing user context, disabled
         servers, or any error in the authorization check all deny access.
         """
-        server_config = getattr(self, "servers_config", {}).get(server_name, {})
+        server_config = getattr(self, "servers_config", {}).get(server_name)
+        if server_config is None:
+            logger.warning(
+                "No configuration found for server '%s'; denying tool execution",
+                sanitize_for_logging(server_name),
+            )
+            return False
+
         if not server_config.get("enabled", True):
             return False
 

--- a/atlas/modules/mcp_tools/mcp_execution.py
+++ b/atlas/modules/mcp_tools/mcp_execution.py
@@ -13,14 +13,14 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from atlas.core.log_sanitizer import sanitize_for_logging
 from atlas.core.metrics_logger import log_metric
 from atlas.domain.messages.models import ToolCall, ToolResult
+from atlas.modules.mcp_tools.mcp_discovery import (
+    _ATLAS_RAG_DISCOVER_TOOL,
+    _ATLAS_RAG_QUERY_TOOL,
+)
 from atlas.modules.mcp_tools.mcp_errors import (
     _is_session_terminated_error,
     _is_task_forbidden_error,
     _is_task_forbidden_result,
-)
-from atlas.modules.mcp_tools.mcp_discovery import (
-    _ATLAS_RAG_DISCOVER_TOOL,
-    _ATLAS_RAG_QUERY_TOOL,
 )
 from atlas.modules.mcp_tools.token_storage import AuthenticationRequiredException
 
@@ -58,6 +58,49 @@ class ExecutionMixin:
 
         self._server_task_support[server_name] = supports
         return supports
+
+    def _is_user_present(self, context: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Return the trusted user email from execution context, if any."""
+        if isinstance(context, dict):
+            return context.get("user_email") or None
+        return None
+
+    async def _is_server_authorized_for_user(
+        self,
+        server_name: str,
+        user_email: Optional[str],
+    ) -> bool:
+        """Fail-closed group ACL check for an MCP server.
+
+        Mirrors ``MCPToolManager.get_authorized_servers`` but is designed to be
+        called at the single execution choke point with the trusted user
+        identity from the request context. Missing user context, disabled
+        servers, or any error in the authorization check all deny access.
+        """
+        server_config = getattr(self, "servers_config", {}).get(server_name, {})
+        if not server_config.get("enabled", True):
+            return False
+
+        required_groups = server_config.get("groups", [])
+        if not required_groups:
+            return True
+
+        if not user_email:
+            return False
+
+        # Import locally to avoid a module-level import cycle with core.auth.
+        from atlas.core.auth import is_user_in_group
+        try:
+            group_checks = [await is_user_in_group(user_email, group) for group in required_groups]
+            return any(group_checks)
+        except Exception:
+            logger.warning(
+                "Group check failed for server '%s' user '%s'; failing closed",
+                sanitize_for_logging(server_name),
+                sanitize_for_logging(user_email),
+                exc_info=True,
+            )
+            return False
 
     async def call_tool(
         self,
@@ -405,13 +448,31 @@ class ExecutionMixin:
         server_name = tool_entry['server']
         actual_tool_name = tool_entry['tool'].name if tool_entry['tool'] else tool_call.name
 
+        # Fail-closed authorization at the single execution choke point. This
+        # closes the agent-mode ACL bypass (where selected_tools reach the loop
+        # without request-time filtering) and blocks hallucinated or prompt-
+        # injected tool names from executing against group-restricted servers.
+        user_email = self._is_user_present(context)
+        if not await self._is_server_authorized_for_user(server_name, user_email):
+            error_msg = f"Tool '{tool_call.name}' is not authorized for this user"
+            logger.warning(
+                "Denied execution of tool '%s' on server '%s' for user '%s'",
+                sanitize_for_logging(tool_call.name),
+                sanitize_for_logging(server_name),
+                sanitize_for_logging(user_email or "<anonymous>"),
+            )
+            return ToolResult(
+                tool_call_id=tool_call.id,
+                content=error_msg,
+                success=False,
+                error=error_msg,
+            )
+
         try:
             update_cb = None
-            user_email = None
             conversation_id = None
             if isinstance(context, dict):
                 update_cb = context.get("update_callback")
-                user_email = context.get("user_email")
                 conversation_id = context.get("conversation_id")
 
             if update_cb is None:

--- a/atlas/tests/test_mcp_image_content.py
+++ b/atlas/tests/test_mcp_image_content.py
@@ -66,6 +66,7 @@ class TestImageContentHandling:
         manager = MCPToolManager.__new__(MCPToolManager)
         manager._elicitation_routing = {}
         manager._sampling_routing = {}
+        manager.servers_config = {"test-server": {"enabled": True}}
 
         # Mock tool object
         class MockTool:
@@ -118,6 +119,7 @@ class TestImageContentHandling:
         manager = MCPToolManager.__new__(MCPToolManager)
         manager._elicitation_routing = {}
         manager._sampling_routing = {}
+        manager.servers_config = {"test-server": {"enabled": True}}
 
         # Mock tool object
         class MockTool:
@@ -166,6 +168,7 @@ class TestImageContentHandling:
         manager = MCPToolManager.__new__(MCPToolManager)
         manager._elicitation_routing = {}
         manager._sampling_routing = {}
+        manager.servers_config = {"test-server": {"enabled": True}}
 
         # Mock tool object
         class MockTool:
@@ -213,6 +216,7 @@ class TestImageContentHandling:
         manager = MCPToolManager.__new__(MCPToolManager)
         manager._elicitation_routing = {}
         manager._sampling_routing = {}
+        manager.servers_config = {"test-server": {"enabled": True}}
 
         # Mock tool object
         class MockTool:

--- a/atlas/tests/test_mcp_tool_execution_authorization.py
+++ b/atlas/tests/test_mcp_tool_execution_authorization.py
@@ -156,6 +156,23 @@ async def test_execute_tool_denies_disabled_server():
 
 
 @pytest.mark.asyncio
+async def test_execute_tool_denies_server_missing_from_configuration():
+    """Discovered tools without a current server configuration must not execute."""
+    manager = _manager({})
+    manager._tool_index = _tool_index("stale_rag_server", "search")
+
+    with patch.object(manager, "call_tool", new_callable=AsyncMock) as mock_call:
+        result = await manager.execute_tool(
+            ToolCall(id="call-7", name="stale_rag_server_search", arguments={}),
+            context={"user_email": "user@example.com"},
+        )
+
+    assert result.success is False
+    assert "not authorized" in result.error.lower()
+    mock_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_execute_tool_allows_allowed_tool_without_context_user_for_open_server():
     """Backwards compatibility: unrestricted servers work without user context.
 
@@ -173,7 +190,7 @@ async def test_execute_tool_allows_allowed_tool_without_context_user_for_open_se
             is_error=False,
         )
         result = await manager.execute_tool(
-            ToolCall(id="call-7", name="open_server_ping", arguments={}),
+            ToolCall(id="call-8", name="open_server_ping", arguments={}),
             context={},
         )
 

--- a/atlas/tests/test_mcp_tool_execution_authorization.py
+++ b/atlas/tests/test_mcp_tool_execution_authorization.py
@@ -1,0 +1,181 @@
+"""Tests for MCP tool execution-time group authorization.
+
+The request-time filter in ``ToolAuthorizationService`` is the first line of
+defense, but agent mode bypassed it and the execution path had no choke point.
+These tests verify that ``MCPToolManager.execute_tool`` enforces group ACLs at
+the single execution choke point keyed on ``context["user_email"]``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from atlas.domain.messages.models import ToolCall
+from atlas.modules.mcp_tools.client import MCPToolManager
+
+
+def _manager(server_config: dict) -> MCPToolManager:
+    """Build a bare MCPToolManager instance for execution-level unit tests."""
+    manager = MCPToolManager.__new__(MCPToolManager)
+    manager.servers_config = server_config
+    manager._elicitation_routing = {}
+    manager._sampling_routing = {}
+    manager._server_task_support = {}
+    manager._tool_task_forbidden = set()
+    return manager
+
+
+def _tool_index(server_name: str, tool_name: str) -> dict:
+    class MockTool:
+        def __init__(self, name):
+            self.name = name
+
+    return {
+        f"{server_name}_{tool_name}": {
+            "server": server_name,
+            "tool": MockTool(tool_name),
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_allows_unrestricted_server():
+    """Tools on servers with no group restriction execute normally."""
+    manager = _manager({"public_server": {"enabled": True, "groups": []}})
+    manager._tool_index = _tool_index("public_server", "get_time")
+
+    with patch.object(manager, "call_tool", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            structured_content=None,
+            data=None,
+            is_error=False,
+        )
+        result = await manager.execute_tool(
+            ToolCall(id="call-1", name="public_server_get_time", arguments={}),
+            context={"user_email": "user@example.com"},
+        )
+
+    assert result.success is True
+    mock_call.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_denies_restricted_server_for_unauthorized_user():
+    """Agent mode must not bypass group ACLs for restricted servers."""
+    manager = _manager({"admin_server": {"enabled": True, "groups": ["admin"]}})
+    manager._tool_index = _tool_index("admin_server", "secret")
+
+    async def not_in_group(user_email: str, group: str) -> bool:
+        return False
+
+    with patch("atlas.core.auth.is_user_in_group", not_in_group):
+        result = await manager.execute_tool(
+            ToolCall(id="call-2", name="admin_server_secret", arguments={}),
+            context={"user_email": "user@example.com"},
+        )
+
+    assert result.success is False
+    assert "not authorized" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_allows_restricted_server_for_authorized_user():
+    """Users who are members of the required group can still execute tools."""
+    manager = _manager({"admin_server": {"enabled": True, "groups": ["admin"]}})
+    manager._tool_index = _tool_index("admin_server", "secret")
+
+    async def is_admin(user_email: str, group: str) -> bool:
+        return group == "admin"
+
+    with patch.object(manager, "call_tool", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="ok")],
+            structured_content=None,
+            data=None,
+            is_error=False,
+        )
+        with patch("atlas.core.auth.is_user_in_group", is_admin):
+            result = await manager.execute_tool(
+                ToolCall(id="call-3", name="admin_server_secret", arguments={}),
+                context={"user_email": "admin@example.com"},
+            )
+
+    assert result.success is True
+    mock_call.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_fails_closed_without_user_context():
+    """A group-restricted server must deny execution when user_email is absent."""
+    manager = _manager({"admin_server": {"enabled": True, "groups": ["admin"]}})
+    manager._tool_index = _tool_index("admin_server", "secret")
+
+    result = await manager.execute_tool(
+        ToolCall(id="call-4", name="admin_server_secret", arguments={}),
+        context={},
+    )
+
+    assert result.success is False
+    assert "not authorized" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_fails_closed_when_group_check_raises():
+    """Any exception during authorization must deny the tool, not leak access."""
+    manager = _manager({"admin_server": {"enabled": True, "groups": ["admin"]}})
+    manager._tool_index = _tool_index("admin_server", "secret")
+
+    async def boom(*args, **kwargs) -> bool:
+        raise RuntimeError("auth endpoint down")
+
+    with patch("atlas.core.auth.is_user_in_group", side_effect=boom):
+        result = await manager.execute_tool(
+            ToolCall(id="call-5", name="admin_server_secret", arguments={}),
+            context={"user_email": "admin@example.com"},
+        )
+
+    assert result.success is False
+    assert "not authorized" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_denies_disabled_server():
+    """Disabled servers must be treated as unauthorized at execution time."""
+    manager = _manager({"broken_server": {"enabled": False, "groups": []}})
+    manager._tool_index = _tool_index("broken_server", "bad")
+
+    result = await manager.execute_tool(
+        ToolCall(id="call-6", name="broken_server_bad", arguments={}),
+        context={"user_email": "user@example.com"},
+    )
+
+    assert result.success is False
+    assert "not authorized" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_allows_allowed_tool_without_context_user_for_open_server():
+    """Backwards compatibility: unrestricted servers work without user context.
+
+    This covers unit tests and internal callers that invoke execute_tool
+    outside of a real request context for servers with no group restrictions.
+    """
+    manager = _manager({"open_server": {"enabled": True, "groups": []}})
+    manager._tool_index = _tool_index("open_server", "ping")
+
+    with patch.object(manager, "call_tool", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="pong")],
+            structured_content=None,
+            data=None,
+            is_error=False,
+        )
+        result = await manager.execute_tool(
+            ToolCall(id="call-7", name="open_server_ping", arguments={}),
+            context={},
+        )
+
+    assert result.success is True
+    mock_call.assert_awaited_once()

--- a/atlas/tests/test_tool_authorization_group_filtering.py
+++ b/atlas/tests/test_tool_authorization_group_filtering.py
@@ -280,3 +280,26 @@ async def test_tool_authorization_passes_auth_function_not_none():
         "auth_check_func must not be None - this is a security vulnerability"
     assert callable(call_tracker["auth_func_received"]), \
         "auth_check_func must be callable"
+
+
+@pytest.mark.asyncio
+async def test_tool_authorization_fail_closed_on_exception():
+    """Any exception during ACL filtering must return an empty list, not the
+    original selected_tools."""
+
+    class ExplodingToolManager:
+        def __init__(self):
+            self.servers_config = {"server": {"enabled": True, "groups": ["admin"]}}
+
+        async def get_authorized_servers(self, user_email: str, auth_check_func):
+            raise RuntimeError("auth endpoint unreachable")
+
+    auth_service = ToolAuthorizationService(ExplodingToolManager())
+
+    filtered_tools = await auth_service.filter_authorized_tools(
+        selected_tools=["server_secret_tool"],
+        user_email="user@example.com",
+    )
+
+    assert filtered_tools == [], \
+        "Authorization filter must fail closed and drop all tools on error"

--- a/docs/admin/mcp-servers.md
+++ b/docs/admin/mcp-servers.md
@@ -204,7 +204,7 @@ export MY_API_KEY="your-secret-api-key"
 
 ## Access Control with Groups
 
-You can restrict access to MCP servers based on user groups. This is a critical feature for controlling which users can access powerful or sensitive tools. If a user is not in the required group, the server will be completely invisible to them in the UI, and any attempt to call its functions will be blocked.
+You can restrict access to MCP servers based on user groups. This is a critical feature for controlling which users can access powerful or sensitive tools. Group checks run at both request time (when tools are listed or selected) and at the single tool-execution choke point inside `MCPToolManager.execute_tool`, keyed on the authenticated user's identity from the request context. A missing user context, a disabled server, an unreachable authorization service, or membership that does not satisfy the `groups` list will all fail closed and deny execution. If a user is not in the required group, the server will be completely invisible to them in the UI, and any attempt to call its functions will be blocked.
 
 ## A Note on the `_atlas_user` Argument
 


### PR DESCRIPTION
This PR closes the MCP tool ACL bypass described in the review notes.

## Changes
- Add a fail-closed group ACL check inside `MCPToolManager.execute_tool` at the single execution choke point, keyed on `context['user_email']`.
  - Missing user context, disabled servers, authorization exceptions, or unauthorized group membership now deny execution.
  - This fixes agent mode bypassing the request-time filter and blocks model-emitted (hallucinated/prompt-injected) tool names from executing against group-restricted servers.
- Convert `ToolAuthorizationService.filter_authorized_tools` to fail closed: return an empty list when the tool manager is unavailable or the ACL check raises, instead of returning the unfiltered `selected_tools`.
- Add new execution-time authorization tests and an exception fail-closed regression test for the request-time filter.
- Update `docs/admin/mcp-servers.md` and `CHANGELOG.md`.