### PR TITLE
feat(hooks): config-driven lifecycle hook system

### DIFF
--- a/atlas/application/chat/agent/agentic_loop.py
+++ b/atlas/application/chat/agent/agentic_loop.py
@@ -263,7 +263,12 @@ class AgenticLoop(AgentLoopProtocol):
                     "session_id": context.session_id,
                     "user_email": context.user_email,
                     "files": context.files,
-                    "selected_data_sources": data_sources or [],
+                    # None and [] mean different things downstream: None is "the
+                    # user made no selection" (atlas_rag_query falls back to every
+                    # authorized source), [] is "explicitly no sources" (query
+                    # nothing). Collapsing None to [] would break RAG for every
+                    # agent turn where the user picked no sources.
+                    "selected_data_sources": data_sources,
                     # Trusted compliance level so RAG tools enforce the boundary;
                     # the model cannot set or change this.
                     "compliance_level": context.compliance_level,

--- a/atlas/application/chat/modes/tools.py
+++ b/atlas/application/chat/modes/tools.py
@@ -126,7 +126,11 @@ class ToolsModeRunner:
         # they do in agent mode, instead of falling back to all authorized
         # sources. build_session_context() only reflects session state, not this
         # per-request selection.
-        if selected_data_sources:
+        # ``is not None``, not truthiness: an explicitly empty list means "no
+        # sources" (e.g. a UserPromptSubmit hook narrowed the turn to nothing).
+        # Dropping it would leave mcp_execution reading None and widening the
+        # query back to every source the user is authorized for.
+        if selected_data_sources is not None:
             session_context["selected_data_sources"] = selected_data_sources
 
         # Ensure update_callback is never None (critical for elicitation)
@@ -289,8 +293,9 @@ class ToolsModeRunner:
 
         session_context = build_session_context(session)
         # See note above: propagate the per-request RAG selection so atlas_rag
-        # tools behave consistently with agent mode in the streaming path too.
-        if selected_data_sources:
+        # tools behave consistently with agent mode in the streaming path too,
+        # preserving an explicit empty selection.
+        if selected_data_sources is not None:
             session_context["selected_data_sources"] = selected_data_sources
         effective_callback = update_callback
         if effective_callback is None:

--- a/atlas/application/chat/orchestrator.py
+++ b/atlas/application/chat/orchestrator.py
@@ -290,6 +290,10 @@ class ChatOrchestrator:
                 reason = outcome.reason or "Prompt blocked by policy hook."
                 block_msg = Message(role=MessageRole.ASSISTANT, content=reason, metadata={"blocked_by_hook": True})
                 session.history.add_message(block_msg)
+                # Publish the reason before completing the turn: a streaming
+                # client renders what it receives, so completing without a
+                # message would end the turn silently and look like a hang.
+                await self.event_publisher.publish_chat_response(reason)
                 await self.event_publisher.publish_response_complete()
                 return event_notifier.create_chat_response(reason)
             if outcome.verdict == "modify":
@@ -298,12 +302,20 @@ class ChatOrchestrator:
                     content = new_prompt
                     # Reflect the (possibly redacted) prompt in the stored user message
                     user_message.content = content
+                # Tools/sources may only be *narrowed*: intersect the hook's list
+                # with what the user actually selected so a hook cannot grant
+                # access to a tool or source the user never chose. An explicitly
+                # empty list is preserved (it means "none"), not treated as
+                # "unset" -- collapsing [] to None would widen the turn back to
+                # the caller's full selection.
                 new_tools = outcome.payload.get("selected_tools")
                 if isinstance(new_tools, list):
-                    selected_tools = new_tools or None
+                    allowed_tools = set(selected_tools or [])
+                    selected_tools = [t for t in new_tools if t in allowed_tools]
                 new_sources = outcome.payload.get("selected_data_sources")
                 if isinstance(new_sources, list):
-                    selected_data_sources = new_sources or None
+                    allowed_sources = set(selected_data_sources or [])
+                    selected_data_sources = [s for s in new_sources if s in allowed_sources]
                 new_agent = outcome.payload.get("agent_mode")
                 if isinstance(new_agent, bool):
                     agent_mode = new_agent

--- a/atlas/application/chat/orchestrator.py
+++ b/atlas/application/chat/orchestrator.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from atlas.core.model_access import ModelAccessDecision, check_model_access
 from atlas.domain.errors import AuthorizationError, SessionNotFoundError
 from atlas.domain.messages.models import Message, MessageRole
+from atlas.hooks import HookEvent, get_hook_manager
 from atlas.interfaces.events import EventPublisher
 from atlas.interfaces.llm import LLMProtocol
 from atlas.interfaces.sessions import SessionRepository
@@ -20,7 +21,7 @@ from .modes.tools import ToolsModeRunner
 from .policies.tool_authorization import ToolAuthorizationService
 from .preprocessors.message_builder import MessageBuilder
 from .preprocessors.prompt_override_service import PromptOverrideService
-from .utilities import file_processor
+from .utilities import event_notifier, file_processor
 
 logger = logging.getLogger(__name__)
 
@@ -262,6 +263,50 @@ class ChatOrchestrator:
         )
         session.history.add_message(user_message)
         session.update_timestamp()
+
+        # UserPromptSubmit hook (GH #713): fires after the user message is added,
+        # before file ingestion and mode dispatch. A hook may rewrite/redact the
+        # prompt text, narrow selected_tools/data_sources, disable agent_mode,
+        # or block the turn with a message. Opt-in; zero overhead without
+        # config/hooks.json.
+        hook_mgr = get_hook_manager()
+        if hook_mgr is not None and hook_mgr.has_hooks(HookEvent.USER_PROMPT_SUBMIT):
+            payload = {
+                "prompt": content,
+                "selected_tools": list(selected_tools) if selected_tools else [],
+                "selected_data_sources": list(selected_data_sources) if selected_data_sources else [],
+                "agent_mode": bool(agent_mode),
+            }
+            outcome = await hook_mgr.run_event(
+                HookEvent.USER_PROMPT_SUBMIT,
+                payload,
+                session_context={
+                    "session_id": str(session_id),
+                    "user_email": user_email,
+                    "compliance_level": session.context.get("compliance_level"),
+                },
+            )
+            if outcome.verdict == "deny":
+                reason = outcome.reason or "Prompt blocked by policy hook."
+                block_msg = Message(role=MessageRole.ASSISTANT, content=reason, metadata={"blocked_by_hook": True})
+                session.history.add_message(block_msg)
+                await self.event_publisher.publish_response_complete()
+                return event_notifier.create_chat_response(reason)
+            if outcome.verdict == "modify":
+                new_prompt = outcome.payload.get("prompt")
+                if isinstance(new_prompt, str) and new_prompt:
+                    content = new_prompt
+                    # Reflect the (possibly redacted) prompt in the stored user message
+                    user_message.content = content
+                new_tools = outcome.payload.get("selected_tools")
+                if isinstance(new_tools, list):
+                    selected_tools = new_tools or None
+                new_sources = outcome.payload.get("selected_data_sources")
+                if isinstance(new_sources, list):
+                    selected_data_sources = new_sources or None
+                new_agent = outcome.payload.get("agent_mode")
+                if isinstance(new_agent, bool):
+                    agent_mode = new_agent
 
         # Handle file ingestion
         update_callback = kwargs.get("update_callback")

--- a/atlas/application/chat/orchestrator.py
+++ b/atlas/application/chat/orchestrator.py
@@ -296,7 +296,7 @@ class ChatOrchestrator:
                 await self.event_publisher.publish_chat_response(reason)
                 await self.event_publisher.publish_response_complete()
                 return event_notifier.create_chat_response(reason)
-            if outcome.verdict == "modify":
+            if outcome.modified:
                 new_prompt = outcome.payload.get("prompt")
                 if isinstance(new_prompt, str) and new_prompt:
                     content = new_prompt

--- a/atlas/application/chat/service.py
+++ b/atlas/application/chat/service.py
@@ -20,6 +20,7 @@ from atlas.core.user_identity import normalize_user_email
 from atlas.domain.errors import AuthorizationError, DomainError
 from atlas.domain.messages.models import Message, MessageRole, MessageType, ToolResult
 from atlas.domain.sessions.models import Session
+from atlas.hooks import HookEvent, get_hook_manager
 from atlas.interfaces.events import EventPublisher
 from atlas.interfaces.llm import LLMProtocol
 from atlas.interfaces.sessions import SessionRepository
@@ -242,6 +243,21 @@ class ChatService:
         await self.session_repository.create(session)
 
         logger.info(f"Created session {sanitize_for_logging(str(session_id))} for user {sanitize_for_logging(user_email)}")
+
+        # SessionStart hook (GH #713): opt-in, zero overhead when no hooks.json.
+        # Fires on every session creation including restore; a hook can reject
+        # the session (deny) or attach metadata to session.context (modify).
+        mgr = get_hook_manager()
+        if mgr is not None and mgr.has_hooks(HookEvent.SESSION_START):
+            outcome = await mgr.run_event(
+                HookEvent.SESSION_START,
+                {"session_id": str(session_id)},
+                session_context={"session_id": str(session_id), "user_email": user_email},
+            )
+            if outcome.verdict == "deny":
+                raise DomainError(f"Session creation blocked by hook: {outcome.reason}")
+            if outcome.verdict == "modify" and isinstance(outcome.payload, dict):
+                session.context.update(outcome.payload)
         return session
 
     async def handle_chat_message(
@@ -1068,3 +1084,21 @@ class ChatService:
         self._incognito_save_floor.pop(session_id, None)
         self._save_floor_locked.discard(session_id)
         logger.info(f"Ended session {sanitize_for_logging(str(session_id))}")
+
+        # SessionEnd hook (GH #713): observability/lifecycle. Cannot block (a
+        # session already ended); deny is treated as continue with a log so a
+        # misconfigured audit hook cannot wedge the teardown path.
+        mgr = get_hook_manager()
+        if mgr is not None and mgr.has_hooks(HookEvent.SESSION_END):
+            try:
+                await mgr.run_event(
+                    HookEvent.SESSION_END,
+                    {"session_id": str(session_id), "user_email": session.user_email},
+                    session_context={
+                        "session_id": str(session_id),
+                        "user_email": session.user_email,
+                        "compliance_level": session.context.get("compliance_level"),
+                    },
+                )
+            except Exception as e:
+                logger.warning("SessionEnd hook failed for %s: %s", session_id, e)

--- a/atlas/application/chat/service.py
+++ b/atlas/application/chat/service.py
@@ -263,7 +263,7 @@ class ChatService:
                     sanitize_for_logging(user_email),
                 )
                 raise DomainError(f"Session creation blocked by hook: {outcome.reason}")
-            if outcome.verdict == "modify" and isinstance(outcome.payload, dict):
+            if outcome.modified and isinstance(outcome.payload, dict):
                 session.context.update(outcome.payload)
 
         await self.session_repository.create(session)

--- a/atlas/application/chat/service.py
+++ b/atlas/application/chat/service.py
@@ -240,13 +240,15 @@ class ChatService:
     ) -> Session:
         """Create a new chat session."""
         session = Session(id=session_id, user_email=user_email)
-        await self.session_repository.create(session)
-
-        logger.info(f"Created session {sanitize_for_logging(str(session_id))} for user {sanitize_for_logging(user_email)}")
 
         # SessionStart hook (GH #713): opt-in, zero overhead when no hooks.json.
         # Fires on every session creation including restore; a hook can reject
         # the session (deny) or attach metadata to session.context (modify).
+        #
+        # This runs *before* session_repository.create(). Persisting first would
+        # make deny a one-message speed bump: the row would already exist, so the
+        # caller's next message would find it via session_repository.get() and be
+        # answered normally. Nothing is written until the hook allows the session.
         mgr = get_hook_manager()
         if mgr is not None and mgr.has_hooks(HookEvent.SESSION_START):
             outcome = await mgr.run_event(
@@ -255,9 +257,18 @@ class ChatService:
                 session_context={"session_id": str(session_id), "user_email": user_email},
             )
             if outcome.verdict == "deny":
+                logger.warning(
+                    "Session %s for user %s blocked by SessionStart hook",
+                    sanitize_for_logging(str(session_id)),
+                    sanitize_for_logging(user_email),
+                )
                 raise DomainError(f"Session creation blocked by hook: {outcome.reason}")
             if outcome.verdict == "modify" and isinstance(outcome.payload, dict):
                 session.context.update(outcome.payload)
+
+        await self.session_repository.create(session)
+
+        logger.info(f"Created session {sanitize_for_logging(str(session_id))} for user {sanitize_for_logging(user_email)}")
         return session
 
     async def handle_chat_message(

--- a/atlas/application/chat/utilities/tool_executor.py
+++ b/atlas/application/chat/utilities/tool_executor.py
@@ -12,6 +12,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from atlas.core.capabilities import create_download_url
 from atlas.domain.messages.models import ToolCall, ToolResult
+from atlas.hooks import HookEvent, get_hook_manager
 from atlas.interfaces.llm import LLMResponse
 from atlas.modules.mcp_tools.token_storage import AuthenticationRequiredException
 
@@ -442,6 +443,96 @@ async def execute_single_tool(
             arguments_were_edited = False
             original_display_args = dict(display_args) if isinstance(display_args, dict) else display_args
 
+            # --- Hook system (GH #713) -----------------------------------------
+            # PermissionRequest fires at the approval gate: a hook may
+            # auto-approve (modify with needs_approval=False), auto-deny, or
+            # escalate (require_approval forces the human gate even when
+            # skip_approval or the default would not). PreToolUse fires next:
+            # it may mutate args (re-injected with security-critical params
+            # afterward) or deny, and can escalate to approval but NOT
+            # auto-approve (a hook may tighten but never widen a boundary).
+            # Both are opt-in; zero overhead without config/hooks.json.
+            hook_mgr = get_hook_manager()
+            _hook_denied_result: Optional[ToolResult] = None
+            if hook_mgr is not None:
+                _sc = {
+                    "session_id": session_context.get("session_id"),
+                    "user_email": session_context.get("user_email"),
+                    "compliance_level": session_context.get("compliance_level"),
+                }
+                if hook_mgr.has_hooks(HookEvent.PERMISSION_REQUEST):
+                    perm_outcome = await hook_mgr.run_event(
+                        HookEvent.PERMISSION_REQUEST,
+                        {
+                            "tool_name": tool_call.function.name,
+                            "tool_args": dict(filtered_args),
+                            "tool_call_id": tool_call.id,
+                            "needs_approval": bool(needs_approval),
+                            "allow_edit": allow_edit,
+                            "admin_required": admin_required,
+                        },
+                        session_context=_sc,
+                        matcher_value=tool_call.function.name,
+                    )
+                    if perm_outcome.verdict == "deny":
+                        _hook_denied_result = ToolResult(
+                            tool_call_id=tool_call.id,
+                            content=f"Tool blocked by policy hook: {perm_outcome.reason}",
+                            success=False, error=perm_outcome.reason,
+                        )
+                    else:
+                        if perm_outcome.verdict == "modify" and isinstance(perm_outcome.payload.get("tool_args"), dict):
+                            filtered_args = _filter_args_to_schema(
+                                inject_context_into_args(
+                                    perm_outcome.payload["tool_args"], session_context,
+                                    tool_call.function.name, tool_manager,
+                                ),
+                                tool_call.function.name, tool_manager,
+                            )
+                            display_args = _sanitize_args_for_ui(dict(filtered_args))
+                            arguments_were_edited = True
+                        if perm_outcome.verdict == "require_approval":
+                            needs_approval = True
+                            admin_required = True
+                        elif perm_outcome.verdict == "modify" and perm_outcome.payload.get("needs_approval") is False:
+                            needs_approval = False
+
+                if _hook_denied_result is None and hook_mgr.has_hooks(HookEvent.PRE_TOOL_USE):
+                    pre_outcome = await hook_mgr.run_event(
+                        HookEvent.PRE_TOOL_USE,
+                        {
+                            "tool_name": tool_call.function.name,
+                            "tool_args": dict(filtered_args),
+                            "tool_call_id": tool_call.id,
+                        },
+                        session_context=_sc,
+                        matcher_value=tool_call.function.name,
+                    )
+                    if pre_outcome.verdict == "deny":
+                        _hook_denied_result = ToolResult(
+                            tool_call_id=tool_call.id,
+                            content=f"Tool blocked by policy hook: {pre_outcome.reason}",
+                            success=False, error=pre_outcome.reason,
+                        )
+                    else:
+                        if pre_outcome.verdict == "modify" and isinstance(pre_outcome.payload.get("tool_args"), dict):
+                            filtered_args = _filter_args_to_schema(
+                                inject_context_into_args(
+                                    pre_outcome.payload["tool_args"], session_context,
+                                    tool_call.function.name, tool_manager,
+                                ),
+                                tool_call.function.name, tool_manager,
+                            )
+                            display_args = _sanitize_args_for_ui(dict(filtered_args))
+                            arguments_were_edited = True
+                        if pre_outcome.verdict == "require_approval":
+                            needs_approval = True
+                            admin_required = True
+
+            if _hook_denied_result is not None:
+                await event_notifier.notify_tool_error(tool_call, _hook_denied_result.error or "blocked", update_callback)
+                return _finalize_span(_hook_denied_result)
+
             # If approval is required, request it from the user
             if needs_approval:
                 logger.info(f"Tool {tool_call.function.name} requires approval (admin_required={admin_required})")
@@ -559,6 +650,46 @@ async def execute_single_tool(
             raw_output_for_telemetry = (
                 result.content if isinstance(result.content, str) else str(result.content)
             )
+
+            # PostToolUse hook (GH #713): a hook may transform/redact the result
+            # before it reaches the model/UI, or deny (replace with an error
+            # result). Observability-default fail-open so a broken audit hook
+            # does not kill the turn. Security-critical result fields are not
+            # re-injected (results have none); a hook can only narrow content.
+            if hook_mgr is not None and hook_mgr.has_hooks(HookEvent.POST_TOOL_USE):
+                post_outcome = await hook_mgr.run_event(
+                    HookEvent.POST_TOOL_USE,
+                    {
+                        "tool_name": tool_call.function.name,
+                        "tool_args": dict(filtered_args),
+                        "tool_call_id": tool_call.id,
+                        "result_content": result.content if isinstance(result.content, str) else str(result.content),
+                        "result_success": bool(result.success),
+                        "result_error": result.error,
+                    },
+                    session_context={
+                        "session_id": session_context.get("session_id"),
+                        "user_email": session_context.get("user_email"),
+                        "compliance_level": session_context.get("compliance_level"),
+                    },
+                    matcher_value=tool_call.function.name,
+                )
+                if post_outcome.verdict == "deny":
+                    result = ToolResult(
+                        tool_call_id=tool_call.id,
+                        content=f"Tool result blocked by policy hook: {post_outcome.reason}",
+                        success=False, error=post_outcome.reason,
+                    )
+                    raw_output_for_telemetry = result.content
+                elif post_outcome.verdict == "modify":
+                    new_content = post_outcome.payload.get("result_content")
+                    if isinstance(new_content, str):
+                        result.content = new_content
+                        raw_output_for_telemetry = new_content
+                    new_success = post_outcome.payload.get("result_success")
+                    if isinstance(new_success, bool):
+                        result.success = new_success
+
             # If arguments were edited, prepend a note to the result for LLM context
             if arguments_were_edited:
                 edit_note = (

--- a/atlas/application/chat/utilities/tool_executor.py
+++ b/atlas/application/chat/utilities/tool_executor.py
@@ -454,6 +454,12 @@ async def execute_single_tool(
             # Both are opt-in; zero overhead without config/hooks.json.
             hook_mgr = get_hook_manager()
             _hook_denied_result: Optional[ToolResult] = None
+            # A PermissionRequest auto-approval is scoped to the arguments that hook
+            # inspected. If a later PreToolUse hook rewrites those arguments, the
+            # approval no longer covers what will actually run, so it is revoked and
+            # the gate falls back to the pre-hook decision.
+            _perm_auto_approved = False
+            _needs_approval_before_hooks = bool(needs_approval)
             if hook_mgr is not None:
                 _sc = {
                     "session_id": session_context.get("session_id"),
@@ -492,10 +498,14 @@ async def execute_single_tool(
                             display_args = _sanitize_args_for_ui(dict(filtered_args))
                             arguments_were_edited = True
                         if perm_outcome.verdict == "require_approval":
+                            # Force the gate, but do NOT raise admin_required: that
+                            # would turn "ask the user" into "only an admin may
+                            # approve", which a non-admin user cannot satisfy. The
+                            # tool's own admin_required stays authoritative.
                             needs_approval = True
-                            admin_required = True
                         elif perm_outcome.verdict == "modify" and perm_outcome.payload.get("needs_approval") is False:
                             needs_approval = False
+                            _perm_auto_approved = True
 
                 if _hook_denied_result is None and hook_mgr.has_hooks(HookEvent.PRE_TOOL_USE):
                     pre_outcome = await hook_mgr.run_event(
@@ -525,9 +535,21 @@ async def execute_single_tool(
                             )
                             display_args = _sanitize_args_for_ui(dict(filtered_args))
                             arguments_were_edited = True
+                            if _perm_auto_approved:
+                                # The arguments the PermissionRequest hook approved
+                                # are not the arguments that will run; revoke the
+                                # auto-approval rather than let rewritten args
+                                # inherit it.
+                                logger.info(
+                                    "Tool %s: PreToolUse rewrote arguments after a "
+                                    "PermissionRequest auto-approval; revoking it",
+                                    tool_call.function.name,
+                                )
+                                needs_approval = _needs_approval_before_hooks
                         if pre_outcome.verdict == "require_approval":
+                            # As above: escalate to the gate without escalating to
+                            # admin-only.
                             needs_approval = True
-                            admin_required = True
 
             if _hook_denied_result is not None:
                 await event_notifier.notify_tool_error(tool_call, _hook_denied_result.error or "blocked", update_callback)

--- a/atlas/application/chat/utilities/tool_executor.py
+++ b/atlas/application/chat/utilities/tool_executor.py
@@ -487,7 +487,7 @@ async def execute_single_tool(
                             success=False, error=perm_outcome.reason,
                         )
                     else:
-                        if perm_outcome.verdict == "modify" and isinstance(perm_outcome.payload.get("tool_args"), dict):
+                        if perm_outcome.modified and isinstance(perm_outcome.payload.get("tool_args"), dict):
                             filtered_args = _filter_args_to_schema(
                                 inject_context_into_args(
                                     perm_outcome.payload["tool_args"], session_context,
@@ -503,7 +503,7 @@ async def execute_single_tool(
                             # approve", which a non-admin user cannot satisfy. The
                             # tool's own admin_required stays authoritative.
                             needs_approval = True
-                        elif perm_outcome.verdict == "modify" and perm_outcome.payload.get("needs_approval") is False:
+                        elif perm_outcome.modified and perm_outcome.payload.get("needs_approval") is False:
                             needs_approval = False
                             _perm_auto_approved = True
 
@@ -525,7 +525,7 @@ async def execute_single_tool(
                             success=False, error=pre_outcome.reason,
                         )
                     else:
-                        if pre_outcome.verdict == "modify" and isinstance(pre_outcome.payload.get("tool_args"), dict):
+                        if pre_outcome.modified and isinstance(pre_outcome.payload.get("tool_args"), dict):
                             filtered_args = _filter_args_to_schema(
                                 inject_context_into_args(
                                     pre_outcome.payload["tool_args"], session_context,
@@ -703,7 +703,7 @@ async def execute_single_tool(
                         success=False, error=post_outcome.reason,
                     )
                     raw_output_for_telemetry = result.content
-                elif post_outcome.verdict == "modify":
+                elif post_outcome.modified:
                     new_content = post_outcome.payload.get("result_content")
                     if isinstance(new_content, str):
                         result.content = new_content

--- a/atlas/config/hooks-example/audit_tool.sh
+++ b/atlas/config/hooks-example/audit_tool.sh
@@ -1,8 +1,38 @@
 #!/usr/bin/env bash
-# Example PostToolUse hook (GH #713): append every tool call to an audit log.
+# Example PostToolUse hook (GH #713): append an audit record for every tool call.
 # Fire-and-forget style; on_error: allow so a broken audit hook never kills a turn.
+#
+# NOTE: the envelope is secret-bearing. `tool_args` can contain tokenized
+# download URLs (HMAC capability tokens), file paths, and prompt text, and
+# `result_content` carries retrieved document text. This example therefore logs
+# a *projection* -- tool name, argument key names, and sizes -- rather than the
+# raw envelope. If you need full payloads for an investigation, treat the log
+# as a secret store (restricted mode, rotation, no shipping to a general index).
 set -eu
 envelope="$(cat)"
 mkdir -p "${ATLAS_PROJECT_DIR:-.}/logs"
-printf '%s\n' "$envelope" >> "${ATLAS_PROJECT_DIR:-.}/logs/tool-audit.jsonl"
+
+python3 -c '
+import json, sys
+
+env = json.load(sys.stdin)
+payload = env.get("payload") or {}
+args = payload.get("tool_args") or {}
+content = payload.get("result_content")
+
+json.dump({
+    "session_id": env.get("session_id"),
+    "user_email": env.get("user_email"),
+    "compliance_level": env.get("compliance_level"),
+    "event": env.get("event"),
+    "tool_name": payload.get("tool_name"),
+    "tool_call_id": payload.get("tool_call_id"),
+    # Key names only -- values are omitted deliberately (see note above).
+    "arg_keys": sorted(args) if isinstance(args, dict) else None,
+    "result_success": payload.get("result_success"),
+    "result_len": len(content) if isinstance(content, str) else None,
+}, sys.stdout)
+sys.stdout.write("\n")
+' <<<"$envelope" >> "${ATLAS_PROJECT_DIR:-.}/logs/tool-audit.jsonl"
+
 exit 0

--- a/atlas/config/hooks-example/audit_tool.sh
+++ b/atlas/config/hooks-example/audit_tool.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Example PostToolUse hook (GH #713): append every tool call to an audit log.
+# Fire-and-forget style; on_error: allow so a broken audit hook never kills a turn.
+set -eu
+envelope="$(cat)"
+mkdir -p "${ATLAS_PROJECT_DIR:-.}/logs"
+printf '%s\n' "$envelope" >> "${ATLAS_PROJECT_DIR:-.}/logs/tool-audit.jsonl"
+exit 0

--- a/atlas/config/hooks-example/block_destructive.sh
+++ b/atlas/config/hooks-example/block_destructive.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Example PreToolUse hook (GH #713): block writes to sensitive OS paths.
+# Reads the event envelope (JSON) on stdin; exit 2 = block with stderr as reason.
+set -eu
+envelope="$(cat)"
+path="$(printf '%s' "$envelope" | python3 -c 'import json,sys; print(json.load(sys.stdin)["payload"]["tool_args"].get("path",""))' 2>/dev/null || true)"
+case "$path" in
+  /etc/*|/var/*|/usr/*|/root/*|/boot/*|/sys/*|/proc/*)
+    echo "Writes to $path are blocked by policy" >&2
+    exit 2
+    ;;
+esac
+exit 0

--- a/atlas/config/hooks-example/hooks.json
+++ b/atlas/config/hooks-example/hooks.json
@@ -1,0 +1,35 @@
+{
+  "_comment": "Example hooks.json (GH #713). Copy to config/hooks.json to enable. This file is NOT auto-loaded -- the loader searches for 'hooks.json' directly, so this example under hooks-example/ is purely illustrative.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "name": "block-destructive-fs",
+        "matcher": "filesystem__.*",
+        "command": ["${ATLAS_CONFIG_DIR}/hooks-example/block_destructive.sh"],
+        "timeout_ms": 2000,
+        "on_error": "deny"
+      },
+      {
+        "name": "require-approval-network",
+        "matcher": "(http_|fetch_).*",
+        "command": ["${ATLAS_CONFIG_DIR}/hooks-example/require_approval_network.py"],
+        "timeout_ms": 1000
+      }
+    ],
+    "PostToolUse": [
+      {
+        "name": "audit-log",
+        "command": ["${ATLAS_CONFIG_DIR}/hooks-example/audit_tool.sh"],
+        "timeout_ms": 1000,
+        "on_error": "allow"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "name": "redact-pii",
+        "command": ["python3", "${ATLAS_CONFIG_DIR}/hooks-example/redact_pii.py"],
+        "timeout_ms": 3000
+      }
+    ]
+  }
+}

--- a/atlas/config/hooks-example/hooks.json
+++ b/atlas/config/hooks-example/hooks.json
@@ -1,25 +1,25 @@
 {
-  "_comment": "Example hooks.json (GH #713). Copy to config/hooks.json to enable. This file is NOT auto-loaded -- the loader searches for 'hooks.json' directly, so this example under hooks-example/ is purely illustrative.",
+  "_comment": "Example hooks.json (GH #713). This file is NOT auto-loaded. To enable it: (1) copy this file to <APP_CONFIG_DIR>/hooks.json, and (2) copy the scripts in this directory to <APP_CONFIG_DIR>/hooks/ and make them executable -- the commands below resolve to ${ATLAS_CONFIG_DIR}/hooks/, not to this example directory. Skipping step 2 leaves the PreToolUse hooks unable to spawn, and because PreToolUse fails closed that would deny every matching tool call.",
   "hooks": {
     "PreToolUse": [
       {
         "name": "block-destructive-fs",
         "matcher": "filesystem__.*",
-        "command": ["${ATLAS_CONFIG_DIR}/hooks-example/block_destructive.sh"],
+        "command": ["${ATLAS_CONFIG_DIR}/hooks/block_destructive.sh"],
         "timeout_ms": 2000,
         "on_error": "deny"
       },
       {
         "name": "require-approval-network",
         "matcher": "(http_|fetch_).*",
-        "command": ["${ATLAS_CONFIG_DIR}/hooks-example/require_approval_network.py"],
+        "command": ["${ATLAS_CONFIG_DIR}/hooks/require_approval_network.py"],
         "timeout_ms": 1000
       }
     ],
     "PostToolUse": [
       {
         "name": "audit-log",
-        "command": ["${ATLAS_CONFIG_DIR}/hooks-example/audit_tool.sh"],
+        "command": ["${ATLAS_CONFIG_DIR}/hooks/audit_tool.sh"],
         "timeout_ms": 1000,
         "on_error": "allow"
       }
@@ -27,7 +27,7 @@
     "UserPromptSubmit": [
       {
         "name": "redact-pii",
-        "command": ["python3", "${ATLAS_CONFIG_DIR}/hooks-example/redact_pii.py"],
+        "command": ["python3", "${ATLAS_CONFIG_DIR}/hooks/redact_pii.py"],
         "timeout_ms": 3000
       }
     ]

--- a/atlas/config/hooks-example/redact_pii.py
+++ b/atlas/config/hooks-example/redact_pii.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Example UserPromptSubmit hook (GH #713): redact US Social Security numbers
+from the user's prompt before it reaches the LLM. Emits a modify decision only
+when the prompt actually changed.
+"""
+import json
+import re
+import sys
+
+env = json.load(sys.stdin)
+prompt = env.get("payload", {}).get("prompt", "")
+redacted = re.sub(r"\b\d{3}-\d{2}-\d{4}\b", "[REDACTED-SSN]", prompt)
+if redacted != prompt:
+    print(json.dumps({"decision": "modify", "payload": {"prompt": redacted}}))
+sys.exit(0)

--- a/atlas/config/hooks-example/require_approval_network.py
+++ b/atlas/config/hooks-example/require_approval_network.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Example PreToolUse hook (GH #713): force approval for cross-domain network tools.
+
+Reads the event envelope (JSON) on stdin. Emits a JSON decision on stdout:
+  - require_approval -> escalate to the human approval gate even when not
+    normally required (e.g. agent mode with skip_approval).
+  - continue (no output, exit 0) -> proceed.
+"""
+import json
+import sys
+
+env = json.load(sys.stdin)
+tool_name = env.get("payload", {}).get("tool_name", "")
+if tool_name.startswith(("http_", "fetch_", "url_")):
+    print(json.dumps({
+        "decision": "require_approval",
+        "reason": "Cross-domain network call requires approval",
+    }))
+sys.exit(0)

--- a/atlas/domain/unified_rag_service.py
+++ b/atlas/domain/unified_rag_service.py
@@ -206,7 +206,7 @@ class UnifiedRAGService:
         )
         if outcome.verdict == "deny":
             return RAGResponse(content="", metadata=None)
-        if outcome.verdict == "modify":
+        if outcome.modified:
             new_content = outcome.payload.get("content")
             if isinstance(new_content, str):
                 response.content = new_content
@@ -532,7 +532,7 @@ class UnifiedRAGService:
                 if call_outcome is not None and call_outcome.verdict == "deny":
                     set_attrs(span, {"rag.blocked_by_hook": True})
                     return RAGResponse(content="", metadata=None)
-                if call_outcome is not None and call_outcome.verdict == "modify":
+                if call_outcome is not None and call_outcome.modified:
                     new_q = call_outcome.payload.get("query")
                     if isinstance(new_q, str) and new_q:
                         messages = self._rewrite_query_messages(messages, new_q)
@@ -743,7 +743,7 @@ class UnifiedRAGService:
                 if call_outcome is not None and call_outcome.verdict == "deny":
                     set_attrs(span, {"rag.blocked_by_hook": True})
                     return RAGResponse(content="", metadata=None)
-                if call_outcome is not None and call_outcome.verdict == "modify":
+                if call_outcome is not None and call_outcome.modified:
                     new_q = call_outcome.payload.get("query")
                     if isinstance(new_q, str) and new_q:
                         messages = self._rewrite_query_messages(messages, new_q)

--- a/atlas/domain/unified_rag_service.py
+++ b/atlas/domain/unified_rag_service.py
@@ -26,6 +26,7 @@ from atlas.core.telemetry import (
     start_span,
 )
 from atlas.domain.errors import DataSourcePermissionError
+from atlas.hooks import HookEvent, get_hook_manager
 from atlas.modules.config.config_manager import ConfigManager, RAGSourceConfig, resolve_env_var
 from atlas.modules.rag.atlas_rag_client import AtlasRAGClient
 from atlas.modules.rag.client import RAGResponse
@@ -142,6 +143,87 @@ class UnifiedRAGService:
 
         # Cache of HTTP RAG clients by source name
         self._http_clients: Dict[str, AtlasRAGClient] = {}
+
+    # ----------------------------------------------------- RAG hooks (GH #713)
+
+    @staticmethod
+    def _rag_session_context(username: str) -> Dict[str, Any]:
+        cl, _ = get_active_compliance_context()
+        return {"user_email": username, "compliance_level": cl}
+
+    async def _fire_rag_call_hook(
+        self,
+        query_text: str,
+        sources: List[str],
+        username: str,
+    ) -> Optional[Any]:
+        """RagCall hook: rewrite the query, narrow sources (batch), or block.
+
+        Returns the ``HookOutcome`` or ``None`` when no hooks fired. Call sites
+        apply: ``deny`` -> empty RAGResponse; ``modify`` with ``query`` rewrites
+        the last user message; ``modify`` with ``qualified_data_sources`` narrows
+        a batch to a subset (sources outside the original allow-list are dropped;
+        a hook can never widen). ``require_approval`` is a no-op at the RAG layer.
+        """
+        mgr = get_hook_manager()
+        if mgr is None or not mgr.has_hooks(HookEvent.RAG_CALL):
+            return None
+        return await mgr.run_event(
+            HookEvent.RAG_CALL,
+            {"query": query_text, "qualified_data_sources": list(sources), "username": username},
+            session_context=self._rag_session_context(username),
+            matcher_value=",".join(sources) if sources else None,
+        )
+
+    async def _fire_rag_response_hook(
+        self,
+        query_text: str,
+        sources: List[str],
+        username: str,
+        response: "RAGResponse",
+    ) -> "RAGResponse":
+        """RagResponse hook: redact/filter chunks or replace synthesized content.
+
+        Returns the (possibly modified) ``RAGResponse``. ``deny`` returns an empty
+        response (retrieval blocked). Observability-default fail-open so a broken
+        audit hook does not discard results. Source narrowing is NOT honored
+        here (retrieval already happened); use RagCall for that.
+        """
+        mgr = get_hook_manager()
+        if mgr is None or not mgr.has_hooks(HookEvent.RAG_RESPONSE):
+            return response
+        outcome = await mgr.run_event(
+            HookEvent.RAG_RESPONSE,
+            {
+                "query": query_text,
+                "qualified_data_sources": list(sources),
+                "username": username,
+                "content": response.content,
+                "metadata": response.metadata.model_dump() if response.metadata else None,
+            },
+            session_context=self._rag_session_context(username),
+            matcher_value=",".join(sources) if sources else None,
+        )
+        if outcome.verdict == "deny":
+            return RAGResponse(content="", metadata=None)
+        if outcome.verdict == "modify":
+            new_content = outcome.payload.get("content")
+            if isinstance(new_content, str):
+                response.content = new_content
+        return response
+
+    @staticmethod
+    def _rewrite_query_messages(messages: List[Dict], new_query: str) -> List[Dict]:
+        """Return a shallow-copied messages list with the last user message
+        content replaced by ``new_query`` (so the backend extracts the rewritten
+        query). Non-mutating; if no user message is present, appends one."""
+        out = list(messages)
+        for i in range(len(out) - 1, -1, -1):
+            if out[i].get("role") == "user":
+                out[i] = {**out[i], "content": new_query}
+                return out
+        out.append({"role": "user", "content": new_query})
+        return out
 
     def _get_http_client(self, source_name: str, config: RAGSourceConfig) -> AtlasRAGClient:
         """Get or create an HTTP RAG client for a source."""
@@ -403,12 +485,13 @@ class UnifiedRAGService:
         qualified_data_source: str,
         messages: List[Dict],
         enforced_compliance_level: Optional[str] = None,
+        _skip_hooks: bool = False,
     ) -> RAGResponse:
         """Query a RAG source.
 
         Args:
             username: The user making the query.
-            qualified_data_source: Data source in format "server:source_id" (e.g., "atlas_rag:technical-docs").
+            qualified_data_source: Data source in format "server:source_id" (e.g. "atlas_rag:technical-docs").
             messages: List of message dictionaries.
             enforced_compliance_level: Overrides the ambient compliance context
                 for this call. This must be a **trusted, server-derived** level
@@ -416,6 +499,10 @@ class UnifiedRAGService:
                 filter. Production callers leave this ``None`` and let
                 ``ChatService`` establish the context for the whole turn; it
                 exists for callers that run outside a chat turn, and for tests.
+            _skip_hooks: When True, skip the RagCall/RagResponse hooks. Used by
+                the agentic atlas_rag_query path, which fires its own single
+                RagCall/RagResponse over all sources to avoid double-firing for
+                HTTP sources that route through this method (GH #713).
 
         Returns:
             RAGResponse with content and metadata.
@@ -438,7 +525,26 @@ class UnifiedRAGService:
             token = set_active_compliance_context(enforced_compliance_level, enforce=True)
         try:
             with start_span("rag.query", span_attrs) as span:
+                # RagCall hook (GH #713): rewrite query / block retrieval.
+                call_outcome = None if _skip_hooks else await self._fire_rag_call_hook(
+                    query_text, [qualified_data_source], username
+                )
+                if call_outcome is not None and call_outcome.verdict == "deny":
+                    set_attrs(span, {"rag.blocked_by_hook": True})
+                    return RAGResponse(content="", metadata=None)
+                if call_outcome is not None and call_outcome.verdict == "modify":
+                    new_q = call_outcome.payload.get("query")
+                    if isinstance(new_q, str) and new_q:
+                        messages = self._rewrite_query_messages(messages, new_q)
+                        query_text = new_q
+
                 response = await self._query_rag_impl(username, qualified_data_source, messages)
+
+                # RagResponse hook (GH #713): redact/filter before injection.
+                if not _skip_hooks:
+                    response = await self._fire_rag_response_hook(
+                        query_text, [qualified_data_source], username, response
+                    )
                 set_attrs(span, _rag_response_attrs(response))
                 return response
         finally:
@@ -584,6 +690,7 @@ class UnifiedRAGService:
         qualified_data_sources: List[str],
         messages: List[Dict],
         enforced_compliance_level: Optional[str] = None,
+        _skip_hooks: bool = False,
     ) -> RAGResponse:
         """Query multiple RAG sources on the same server in a single request.
 
@@ -600,6 +707,8 @@ class UnifiedRAGService:
             enforced_compliance_level: Overrides the ambient compliance context
                 for this call. Must be a **trusted, server-derived** level, never
                 a client-supplied filter. See :meth:`query_rag`.
+            _skip_hooks: When True, skip the RagCall/RagResponse hooks (agentic
+                path fires its own; see :meth:`query_rag`).
 
         Returns:
             RAGResponse with content and metadata from the batched query.
@@ -624,7 +733,37 @@ class UnifiedRAGService:
             token = set_active_compliance_context(enforced_compliance_level, enforce=True)
         try:
             with start_span("rag.query", span_attrs) as span:
+                # RagCall hook (GH #713): rewrite query / narrow sources / block.
+                # A hook may only NARROW the source list (drop entries); sources
+                # it adds that were not in the original request are discarded so
+                # a hook can never widen the retrieval boundary.
+                call_outcome = None if _skip_hooks else await self._fire_rag_call_hook(
+                    query_text, qualified_data_sources, username
+                )
+                if call_outcome is not None and call_outcome.verdict == "deny":
+                    set_attrs(span, {"rag.blocked_by_hook": True})
+                    return RAGResponse(content="", metadata=None)
+                if call_outcome is not None and call_outcome.verdict == "modify":
+                    new_q = call_outcome.payload.get("query")
+                    if isinstance(new_q, str) and new_q:
+                        messages = self._rewrite_query_messages(messages, new_q)
+                        query_text = new_q
+                    new_sources = call_outcome.payload.get("qualified_data_sources")
+                    if isinstance(new_sources, list):
+                        allowed = set(qualified_data_sources)
+                        narrowed = [s for s in new_sources if s in allowed]
+                        if not narrowed:
+                            set_attrs(span, {"rag.blocked_by_hook": True})
+                            return RAGResponse(content="", metadata=None)
+                        qualified_data_sources = narrowed
+
                 response = await self._query_rag_batch_impl(username, qualified_data_sources, messages)
+
+                # RagResponse hook (GH #713)
+                if not _skip_hooks:
+                    response = await self._fire_rag_response_hook(
+                        query_text, qualified_data_sources, username, response
+                    )
                 set_attrs(span, _rag_response_attrs(response))
                 return response
         finally:

--- a/atlas/hooks/__init__.py
+++ b/atlas/hooks/__init__.py
@@ -1,0 +1,37 @@
+"""Config-driven hook system (GH #713).
+
+Operator-installed executables (bash, Python, anything) registered in
+``config/hooks.json`` run as subprocesses at chat lifecycle chokepoints. The
+event payload arrives as JSON on stdin; the hook's JSON on stdout (plus exit
+code) can allow, modify, block, or escalate the operation. See ``docs/hooks.md``.
+
+Public API:
+    HookEvent          -- lifecycle event enum (also the config key / wire name)
+    HookOutcome        -- aggregated result of running all hooks for an event
+    HookManager        -- loads config and dispatches events (rarely used directly)
+    get_hook_manager() -- process-wide singleton accessor (call sites use this)
+    HookBlockedError   -- raised when a hook denies an operation with no graceful
+                           in-band return value (e.g. PreLlmCall)
+"""
+
+from .manager import (
+    HookBlockedError,
+    HookManager,
+    HookOutcome,
+    get_hook_manager,
+    set_hook_manager_for_testing,
+)
+from .models import HookConfig, HookDecision, HookEvent, HooksConfig, default_on_error
+
+__all__ = [
+    "HookBlockedError",
+    "HookConfig",
+    "HookDecision",
+    "HooksConfig",
+    "HookEvent",
+    "HookManager",
+    "HookOutcome",
+    "default_on_error",
+    "get_hook_manager",
+    "set_hook_manager_for_testing",
+]

--- a/atlas/hooks/__init__.py
+++ b/atlas/hooks/__init__.py
@@ -3,7 +3,7 @@
 Operator-installed executables (bash, Python, anything) registered in
 ``config/hooks.json`` run as subprocesses at chat lifecycle chokepoints. The
 event payload arrives as JSON on stdin; the hook's JSON on stdout (plus exit
-code) can allow, modify, block, or escalate the operation. See ``docs/hooks.md``.
+code) can allow, modify, block, or escalate the operation. See ``docs/admin/hooks.md``.
 
 Public API:
     HookEvent          -- lifecycle event enum (also the config key / wire name)

--- a/atlas/hooks/manager.py
+++ b/atlas/hooks/manager.py
@@ -1,0 +1,459 @@
+"""HookManager: loads hook config and runs hooks at lifecycle events.
+
+The manager is the single entry point for the hook system. It:
+
+* reads ``HooksConfig`` from the ``ConfigManager`` (cached there, reloaded via
+  the existing ``reload_configs`` path);
+* short-circuits with zero overhead when no hooks are registered for an event
+  (no subprocess, no payload build -- the common case);
+* spawns each matching hook via ``asyncio.create_subprocess_exec`` (argv, never
+  ``shell=True``) inside the active async turn, with a per-hook timeout, a
+  minimal environment allow-list, and bounded stdout/stderr;
+* implements the composition rules (sequential, ``deny`` short-circuits,
+  ``require_approval`` sticky) and returns a single ``HookOutcome`` the call
+  site translates into local action.
+
+Security model (per GH #713): a hook may *tighten* but never *widen* a boundary.
+Trusted envelope fields (``session_id``, ``user_email``, ``compliance_level``)
+are always re-asserted server-side and never taken from hook output. The
+mutable ``payload`` is the only part a hook may replace, and call sites
+re-apply security-critical invariants (e.g. re-inject ``_atlas_user`` into tool
+args) after applying a ``modify``. See ``docs/hooks.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from atlas.core.telemetry import set_attrs, start_span
+
+from .models import HookConfig, HookDecision, HookEvent, HooksConfig
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on hook stdout/stderr so a chatty hook cannot balloon memory. Overflow
+# is treated as a hook error (handled per ``on_error``) and logged.
+_MAX_OUTPUT_BYTES = 1 * 1024 * 1024  # 1 MB
+
+# Verdict severity ordering for the "most-restrictive-wins" composition rule.
+# deny > require_approval > modify > continue. A later hook can raise the
+# severity but never lower it (a ``require_approval`` cannot be downgraded).
+_VERDICT_RANK = {"continue": 0, "modify": 1, "require_approval": 2, "deny": 3}
+_VERDICT_NAMES = {v: k for k, v in _VERDICT_RANK.items()}
+
+
+class HookBlockedError(Exception):
+    """Raised by call sites when a hook returns ``deny`` and the operation has
+    no graceful in-band return value (e.g. PreLlmCall inside the LLM caller).
+
+    Carries the human-readable ``reason`` so upper layers can surface it to the
+    user. It deliberately is NOT a subclass of any LLM/domain error so the RAG
+    fallback ``except Exception`` path can re-raise it cleanly (see
+    ``call_with_rag``).
+    """
+
+    def __init__(self, event: HookEvent, reason: str):
+        self.event = event
+        self.reason = reason
+        super().__init__(f"Hook {event.value} blocked: {reason}")
+
+
+@dataclass
+class HookOutcome:
+    """The aggregated result of running all hooks for one event.
+
+    Call sites branch on ``verdict``:
+        * ``continue``   -- proceed with the original payload (no hooks fired,
+                            or every hook returned continue).
+        * ``modify``      -- proceed, but apply ``payload`` (the mutable part
+                            after all modify decisions), then re-apply
+                            security-critical invariants.
+        * ``require_approval`` -- escalate to the approval gate (PreToolUse /
+                            PermissionRequest) before proceeding; ``payload`` is
+                            still the (possibly modified) mutable state.
+        * ``deny``       -- block the operation; surface ``reason`` to the
+                            model/user.
+
+    ``fired`` is False when no hook ran at all (no config / no match), which lets
+    call sites skip downstream translation cheaply.
+    """
+
+    verdict: str = "continue"
+    reason: Optional[str] = None
+    payload: Dict[str, Any] = field(default_factory=dict)
+    fired: bool = False
+    hook_names: List[str] = field(default_factory=list)
+
+
+class HookManager:
+    """Loads hook config and dispatches events to subprocess hooks."""
+
+    def __init__(self, config_manager: Any):
+        self.config_manager = config_manager
+
+    # ------------------------------------------------------------------ config
+
+    @property
+    def hooks_config(self) -> HooksConfig:
+        """Return the cached ``HooksConfig`` from the ConfigManager.
+
+        Delegating (rather than caching here) means ``reload_configs`` and the
+        conftest ``_isolate_config_cache`` fixture transparently cover hooks.
+        """
+        return self.config_manager.hooks_config
+
+    def has_hooks(self, event: HookEvent) -> bool:
+        """True if at least one hook is registered for ``event``.
+
+        This is the zero-overhead gate call sites check before building a
+        payload. When no ``config/hooks.json`` exists this is False and the
+        hot path pays only a cached-property lookup.
+        """
+        try:
+            return bool(self.hooks_config.hooks_for(event.value))
+        except Exception:
+            # A broken config must not take down the chat turn; treat as empty.
+            return False
+
+    # -------------------------------------------------------------- directories
+
+    def _dirs(self) -> Tuple[str, str]:
+        """Resolve ``(config_dir, project_dir)`` for env injection/interpolation.
+
+        ``ATLAS_CONFIG_DIR`` is the user config dir (where ``hooks.json`` and
+        operator scripts live); ``ATLAS_PROJECT_DIR`` is the project root. Both
+        are derived from the ConfigManager so they track the same path logic as
+        every other config file.
+        """
+        try:
+            atlas_root = Path(self.config_manager._atlas_root)
+            project_dir = str(atlas_root.parent)
+            app_config_dir = Path(self.config_manager.app_settings.app_config_dir)
+            if not app_config_dir.is_absolute():
+                app_config_dir = atlas_root.parent / app_config_dir
+            return str(app_config_dir), project_dir
+        except Exception:
+            return os.environ.get("ATLAS_CONFIG_DIR", ""), os.environ.get("ATLAS_PROJECT_DIR", "")
+
+    # ------------------------------------------------------------------- run
+
+    async def run_event(
+        self,
+        event: HookEvent,
+        payload: Dict[str, Any],
+        *,
+        session_context: Optional[Dict[str, Any]] = None,
+        matcher_value: Optional[str] = None,
+        config_dir: Optional[str] = None,
+        project_dir: Optional[str] = None,
+    ) -> HookOutcome:
+        """Run all matching hooks for ``event`` and return the aggregated outcome.
+
+        Zero-overhead when no hooks are registered: returns a ``continue``
+        outcome with ``fired=False`` without spawning any process.
+        """
+        # Resolve hooks (failure-tolerant: empty config -> no-op).
+        try:
+            hooks = self.hooks_config.hooks_for(event.value)
+        except Exception as e:
+            logger.warning("hooks: failed to load hooks config for %s: %s", event.value, e)
+            return HookOutcome(payload=dict(payload))
+
+        if not hooks:
+            return HookOutcome(payload=dict(payload))
+
+        # Resolve dirs once (env interpolation + subprocess env).
+        if config_dir is None or project_dir is None:
+            d_config, d_project = self._dirs()
+            config_dir = config_dir or d_config
+            project_dir = project_dir or d_project
+
+        sc = session_context or {}
+        # Trusted envelope fields are stamped server-side and re-asserted after
+        # every modify: a hook can never widen or spoof identity/compliance.
+        envelope = {
+            "hook_event_name": event.value,
+            "session_id": sc.get("session_id"),
+            "user_email": sc.get("user_email"),
+            "compliance_level": sc.get("compliance_level"),
+            "payload": dict(payload),
+        }
+
+        verdict_rank = 0  # continue
+        reason: Optional[str] = None
+        fired = False
+        hook_names: List[str] = []
+
+        with start_span("hook.event", {
+            "hook_event": event.value,
+            "hook_count": len(hooks),
+            "matcher_value": matcher_value,
+        }) as span:
+            for hook in hooks:
+                if not hook.matches(matcher_value):
+                    continue
+                fired = True
+                hook_names.append(hook.name)
+                decision = await self._run_one(
+                    hook, event, envelope, config_dir, project_dir, span
+                )
+                # --- apply decision to the running state ---
+                d = decision.decision
+                if d == "deny":
+                    verdict_rank = _VERDICT_RANK["deny"]
+                    reason = decision.reason or f"Hook '{hook.name}' denied the operation"
+                    set_attrs(span, {
+                        "hook.denied_by": hook.name,
+                        "hook.deny_reason_present": reason is not None,
+                    })
+                    break  # first deny short-circuits the chain
+                if d == "require_approval":
+                    if verdict_rank < _VERDICT_RANK["require_approval"]:
+                        verdict_rank = _VERDICT_RANK["require_approval"]
+                        reason = decision.reason
+                if d == "modify":
+                    if self._apply_modify(envelope, decision, hook):
+                        if verdict_rank < _VERDICT_RANK["modify"]:
+                            verdict_rank = _VERDICT_RANK["modify"]
+                # continue: no state change
+            set_attrs(span, {
+                "hook.verdict": _VERDICT_NAMES[verdict_rank],
+                "hook.fired_count": len(hook_names),
+            })
+
+        outcome = HookOutcome(
+            verdict=_VERDICT_NAMES[verdict_rank],
+            reason=reason,
+            payload=envelope["payload"],
+            fired=fired,
+            hook_names=hook_names,
+        )
+        # Re-assert trusted fields: even though we only ever read them from the
+        # server-stamped envelope, defend-in-depth in case a modify payload tried
+        # to include spoofed identity/compliance keys.
+        outcome.payload.pop("session_id", None)
+        outcome.payload.pop("user_email", None)
+        outcome.payload.pop("compliance_level", None)
+        return outcome
+
+    # ------------------------------------------------------------- internals
+
+    def _apply_modify(self, envelope: Dict[str, Any], decision: HookDecision, hook: HookConfig) -> bool:
+        """Merge a ``modify`` decision's payload into the running envelope.
+
+        Full-replacement semantics (GH #713 open question #2): the hook returns
+        the mutable part it wants; we replace the keys it specifies. Trusted
+        envelope fields are never taken from hook output. Unknown payload keys
+        are accepted -- the call site validates against the event schema.
+
+        Returns True if any mutable field was actually changed (so the verdict
+        is only bumped to ``modify`` when something really changed).
+        """
+        new_payload = decision.payload
+        if not isinstance(new_payload, dict) or not new_payload:
+            logger.debug("hooks: hook %s returned modify with no payload; ignoring", hook.name)
+            return False
+        # Strip any attempt to overwrite trusted identity/compliance via payload.
+        for k in ("session_id", "user_email", "compliance_level"):
+            new_payload.pop(k, None)
+        if not new_payload:
+            return False
+        envelope["payload"].update(new_payload)
+        return True
+
+    async def _run_one(
+        self,
+        hook: HookConfig,
+        event: HookEvent,
+        envelope: Dict[str, Any],
+        config_dir: str,
+        project_dir: str,
+        span: Any,
+    ) -> HookDecision:
+        """Spawn one hook subprocess and parse its decision.
+
+        Failure modes (timeout, crash, malformed output) map to ``on_error``:
+        ``deny`` -> a deny decision; ``allow`` -> a continue decision. Always
+        logged and recorded on the span so the audit trail is intact.
+        """
+        timeout_s = hook.timeout_ms / 1000.0
+        argv = self._interpolate_command(hook.command, config_dir, project_dir)
+        env = self._build_env(config_dir, project_dir)
+        stdin_bytes = (json.dumps(envelope) + "\n").encode("utf-8")
+
+        t0 = asyncio.get_event_loop().time()
+        hook_attrs = {"hook.name": hook.name, "hook.timeout_ms": hook.timeout_ms}
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+        except FileNotFoundError:
+            logger.error("hooks: hook %s executable not found: %s", hook.name, argv[0])
+            set_attrs(span, {**hook_attrs, "hook.error": "executable_not_found"})
+            return self._error_decision(hook, event, "executable not found")
+        except Exception as e:
+            logger.error("hooks: hook %s failed to spawn: %s", hook.name, e, exc_info=True)
+            set_attrs(span, {**hook_attrs, "hook.error": f"spawn_error:{type(e).__name__}"})
+            return self._error_decision(hook, event, f"spawn error: {e}")
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(stdin_bytes), timeout=timeout_s
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.wait()
+            logger.warning("hooks: hook %s timed out after %dms", hook.name, hook.timeout_ms)
+            set_attrs(span, {**hook_attrs, "hook.error": "timeout", "hook.timed_out": True})
+            return self._error_decision(hook, event, "timeout")
+        except Exception as e:
+            logger.error("hooks: hook %s I/O error: %s", hook.name, e, exc_info=True)
+            set_attrs(span, {**hook_attrs, "hook.error": f"io_error:{type(e).__name__}"})
+            return self._error_decision(hook, event, f"io error: {e}")
+
+        duration_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
+        stdout_s = self._truncate(stdout.decode("utf-8", "replace"))
+        stderr_s = self._truncate(stderr.decode("utf-8", "replace"))
+        set_attrs(span, {
+            **hook_attrs,
+            "hook.exit_code": proc.returncode,
+            "hook.duration_ms": duration_ms,
+            "hook.stdout_size": len(stdout_s),
+            "hook.stderr_size": len(stderr_s),
+        })
+
+        return self._parse_decision(hook, event, proc.returncode, stdout_s, stderr_s)
+
+    def _parse_decision(
+        self,
+        hook: HookConfig,
+        event: HookEvent,
+        returncode: Optional[int],
+        stdout_s: str,
+        stderr_s: str,
+    ) -> HookDecision:
+        """Translate (exit code, stdout, stderr) into a ``HookDecision``.
+
+        Fast path (no JSON needed):
+            0  -> continue (apply stdout JSON if present, else no-op)
+            2  -> deny, reason = stderr
+            other -> error -> on_error
+        """
+        if returncode == 0:
+            if not stdout_s.strip():
+                return HookDecision(decision="continue")
+            try:
+                data = json.loads(stdout_s)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "hooks: hook %s exited 0 but emitted non-JSON stdout; treating as error",
+                    hook.name,
+                )
+                return self._error_decision(hook, event, "non-JSON stdout on exit 0")
+            try:
+                return HookDecision(**data) if isinstance(data, dict) else HookDecision(decision="continue")
+            except Exception as e:
+                logger.warning("hooks: hook %s emitted invalid decision JSON: %s", hook.name, e)
+                return self._error_decision(hook, event, f"invalid decision JSON: {e}")
+
+        if returncode == 2:
+            reason = (stderr_s.strip() or f"Hook '{hook.name}' blocked the operation")
+            return HookDecision(decision="deny", reason=reason[:1000])
+
+        logger.warning(
+            "hooks: hook %s exited with code %s (stderr: %s)",
+            hook.name, returncode, stderr_s.strip()[:200] or "<empty>",
+        )
+        return self._error_decision(hook, event, f"exit code {returncode}")
+
+    def _error_decision(self, hook: HookConfig, event: HookEvent, detail: str) -> HookDecision:
+        """Map a hook failure to its ``on_error`` outcome."""
+        on_error = hook.effective_on_error(event)
+        if on_error == "deny":
+            return HookDecision(decision="deny", reason=f"Hook '{hook.name}' errored: {detail}")
+        return HookDecision(decision="continue")
+
+    @staticmethod
+    def _truncate(s: str) -> str:
+        if len(s.encode("utf-8", "replace")) <= _MAX_OUTPUT_BYTES:
+            return s
+        # Truncate on a UTF-8 boundary to avoid producing surrogate pairs.
+        encoded = s.encode("utf-8", "replace")[:_MAX_OUTPUT_BYTES]
+        return encoded.decode("utf-8", "replace")
+
+    @staticmethod
+    def _interpolate_command(command: List[str], config_dir: str, project_dir: str) -> List[str]:
+        """Expand ``${ATLAS_CONFIG_DIR}`` / ``${ATLAS_PROJECT_DIR}`` in argv.
+
+        Only these two names are expanded -- never arbitrary env vars -- so a
+        hook config cannot exfiltrate the server's environment into its own
+        command line.
+        """
+        mapping = {"ATLAS_CONFIG_DIR": config_dir, "ATLAS_PROJECT_DIR": project_dir}
+        out = []
+        for arg in command:
+            for name, val in mapping.items():
+                arg = arg.replace(f"${{{name}}}", val)
+            out.append(arg)
+        return out
+
+    @staticmethod
+    def _build_env(config_dir: str, project_dir: str) -> Dict[str, str]:
+        """Minimal environment for hook subprocesses.
+
+        Hooks get a small allow-list (``PATH``/``HOME`` so interpreters resolve)
+        plus ``ATLAS_CONFIG_DIR`` / ``ATLAS_PROJECT_DIR``. They do NOT inherit the
+        server's full environment, which holds provider API keys and other
+        secrets -- mirroring the boundary Claude Code applies.
+        """
+        env: Dict[str, str] = {}
+        for key in ("PATH", "HOME", "SYSTEMROOT", "LANG", "LC_ALL", "USER"):
+            val = os.environ.get(key)
+            if val is not None:
+                env[key] = val
+        env["ATLAS_CONFIG_DIR"] = config_dir
+        env["ATLAS_PROJECT_DIR"] = project_dir
+        return env
+
+
+# ----------------------------------------------------------------- singleton
+
+_hook_manager: Optional[HookManager] = None
+
+
+def get_hook_manager() -> Optional[HookManager]:
+    """Return the process-wide ``HookManager`` singleton, or None on init failure.
+
+    Mirrors ``get_approval_manager`` / ``get_compliance_manager``. Lazily binds
+    to the module-level ``config_manager`` singleton so hook config follows the
+    same load/reload story as the rest of Atlas config.
+    """
+    global _hook_manager
+    if _hook_manager is None:
+        try:
+            from atlas.modules.config.config_manager import config_manager as _cm
+
+            _hook_manager = HookManager(_cm)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("hooks: could not initialize hook manager: %s", e)
+            return None
+    return _hook_manager
+
+
+def set_hook_manager_for_testing(mgr: Optional[HookManager]) -> None:
+    """Replace the singleton hook manager for tests. Restore with ``None``."""
+    global _hook_manager
+    _hook_manager = mgr

--- a/atlas/hooks/manager.py
+++ b/atlas/hooks/manager.py
@@ -82,12 +82,20 @@ class HookOutcome:
 
     ``fired`` is False when no hook ran at all (no config / no match), which lets
     call sites skip downstream translation cheaply.
+
+    ``modified`` is the flag call sites must check before applying ``payload``.
+    It is independent of ``verdict``: verdicts are ranked (deny >
+    require_approval > modify), so a chain where one hook redacts and a later
+    hook escalates reports ``verdict == "require_approval"`` while still
+    carrying a rewritten payload. Gating payload application on
+    ``verdict == "modify"`` would silently drop that redaction.
     """
 
     verdict: str = "continue"
     reason: Optional[str] = None
     payload: Dict[str, Any] = field(default_factory=dict)
     fired: bool = False
+    modified: bool = False
     hook_names: List[str] = field(default_factory=list)
 
 
@@ -119,6 +127,14 @@ class HookManager:
             return bool(self.hooks_config.hooks_for(event.value))
         except Exception:
             # A broken config must not take down the chat turn; treat as empty.
+            # Log it, though: this silently disables the fail-closed events too,
+            # and without a diagnostic that is indistinguishable from "no hooks
+            # configured".
+            logger.exception(
+                "Failed to read hooks config for event %s; treating as no hooks "
+                "(fail-closed controls for this event are NOT in effect)",
+                event.value,
+            )
             return False
 
     # -------------------------------------------------------------- directories
@@ -188,6 +204,7 @@ class HookManager:
         verdict_rank = 0  # continue
         reason: Optional[str] = None
         fired = False
+        modified = False
         hook_names: List[str] = []
 
         with start_span("hook.event", {
@@ -219,6 +236,10 @@ class HookManager:
                         reason = decision.reason
                 if d == "modify":
                     if self._apply_modify(envelope, decision, hook):
+                        # Track the mutation separately from the verdict rank: a
+                        # later require_approval outranks "modify" and would
+                        # otherwise hide that the payload was rewritten.
+                        modified = True
                         if verdict_rank < _VERDICT_RANK["modify"]:
                             verdict_rank = _VERDICT_RANK["modify"]
                 # continue: no state change
@@ -232,6 +253,7 @@ class HookManager:
             reason=reason,
             payload=envelope["payload"],
             fired=fired,
+            modified=modified,
             hook_names=hook_names,
         )
         # Re-assert trusted fields: even though we only ever read them from the

--- a/atlas/hooks/manager.py
+++ b/atlas/hooks/manager.py
@@ -18,7 +18,7 @@ Trusted envelope fields (``session_id``, ``user_email``, ``compliance_level``)
 are always re-asserted server-side and never taken from hook output. The
 mutable ``payload`` is the only part a hook may replace, and call sites
 re-apply security-critical invariants (e.g. re-inject ``_atlas_user`` into tool
-args) after applying a ``modify``. See ``docs/hooks.md``.
+args) after applying a ``modify``. See ``docs/admin/hooks.md``.
 """
 
 from __future__ import annotations
@@ -287,7 +287,7 @@ class HookManager:
         env = self._build_env(config_dir, project_dir)
         stdin_bytes = (json.dumps(envelope) + "\n").encode("utf-8")
 
-        t0 = asyncio.get_event_loop().time()
+        t0 = asyncio.get_running_loop().time()
         hook_attrs = {"hook.name": hook.name, "hook.timeout_ms": hook.timeout_ms}
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -307,26 +307,34 @@ class HookManager:
             return self._error_decision(hook, event, f"spawn error: {e}")
 
         try:
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(stdin_bytes), timeout=timeout_s
+            stdout, stderr, overflowed = await asyncio.wait_for(
+                self._communicate_bounded(proc, stdin_bytes), timeout=timeout_s
             )
         except asyncio.TimeoutError:
-            try:
-                proc.kill()
-            except ProcessLookupError:
-                pass
-            await proc.wait()
+            await self._kill(proc)
             logger.warning("hooks: hook %s timed out after %dms", hook.name, hook.timeout_ms)
             set_attrs(span, {**hook_attrs, "hook.error": "timeout", "hook.timed_out": True})
             return self._error_decision(hook, event, "timeout")
         except Exception as e:
+            await self._kill(proc)
             logger.error("hooks: hook %s I/O error: %s", hook.name, e, exc_info=True)
             set_attrs(span, {**hook_attrs, "hook.error": f"io_error:{type(e).__name__}"})
             return self._error_decision(hook, event, f"io error: {e}")
 
-        duration_ms = int((asyncio.get_event_loop().time() - t0) * 1000)
-        stdout_s = self._truncate(stdout.decode("utf-8", "replace"))
-        stderr_s = self._truncate(stderr.decode("utf-8", "replace"))
+        if overflowed:
+            # The child was killed mid-stream, so what we hold is a prefix. Parsing
+            # it would risk misreading truncated JSON as a decision (or as non-JSON
+            # garbage); treat overflow as a hook error and let on_error decide.
+            logger.warning(
+                "hooks: hook %s exceeded the %d-byte output cap; killed and treated as error",
+                hook.name, _MAX_OUTPUT_BYTES,
+            )
+            set_attrs(span, {**hook_attrs, "hook.error": "output_overflow"})
+            return self._error_decision(hook, event, "output exceeded 1 MB cap")
+
+        duration_ms = int((asyncio.get_running_loop().time() - t0) * 1000)
+        stdout_s = stdout.decode("utf-8", "replace")
+        stderr_s = stderr.decode("utf-8", "replace")
         set_attrs(span, {
             **hook_attrs,
             "hook.exit_code": proc.returncode,
@@ -387,12 +395,73 @@ class HookManager:
         return HookDecision(decision="continue")
 
     @staticmethod
-    def _truncate(s: str) -> str:
-        if len(s.encode("utf-8", "replace")) <= _MAX_OUTPUT_BYTES:
-            return s
-        # Truncate on a UTF-8 boundary to avoid producing surrogate pairs.
-        encoded = s.encode("utf-8", "replace")[:_MAX_OUTPUT_BYTES]
-        return encoded.decode("utf-8", "replace")
+    async def _kill(proc: Any) -> None:
+        """Kill a hook subprocess and reap it, tolerating an already-dead child."""
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            # Already exited between the check and the signal -- nothing to kill.
+            pass
+        try:
+            await proc.wait()
+        except Exception:  # pragma: no cover - defensive
+            # Reaping is best-effort; a failure here must not mask the original
+            # timeout/IO error the caller is about to report.
+            logger.debug("hooks: failed to reap killed hook process", exc_info=True)
+
+    @classmethod
+    async def _communicate_bounded(
+        cls, proc: Any, stdin_bytes: bytes
+    ) -> Tuple[bytes, bytes, bool]:
+        """Feed stdin and read stdout/stderr with the cap enforced *at read time*.
+
+        ``proc.communicate()`` buffers the entire stream before returning, so a
+        hook emitting hundreds of megabytes would exhaust server memory no matter
+        what we truncated afterwards. Here each stream is read in chunks and the
+        child is killed as soon as their combined size crosses
+        ``_MAX_OUTPUT_BYTES``. Returns ``(stdout, stderr, overflowed)``.
+        """
+        total = 0
+        overflowed = False
+
+        async def _feed() -> None:
+            if proc.stdin is None:
+                return
+            try:
+                proc.stdin.write(stdin_bytes)
+                await proc.stdin.drain()
+            except (BrokenPipeError, ConnectionResetError):
+                # A hook that ignores stdin and exits early is legitimate (e.g. an
+                # unconditional allow); its exit code still decides the outcome.
+                pass
+            finally:
+                try:
+                    proc.stdin.close()
+                except Exception:  # pragma: no cover - defensive
+                    logger.debug("hooks: failed to close hook stdin", exc_info=True)
+
+        async def _drain(stream: Any) -> bytes:
+            nonlocal total, overflowed
+            if stream is None:
+                return b""
+            buf = bytearray()
+            while True:
+                chunk = await stream.read(65536)
+                if not chunk:
+                    return bytes(buf)
+                total += len(chunk)
+                if total > _MAX_OUTPUT_BYTES:
+                    overflowed = True
+                    await cls._kill(proc)
+                    return bytes(buf)
+                buf += chunk
+
+        _, stdout, stderr = await asyncio.gather(
+            _feed(), _drain(proc.stdout), _drain(proc.stderr)
+        )
+        if not overflowed:
+            await proc.wait()
+        return stdout, stderr, overflowed
 
     @staticmethod
     def _interpolate_command(command: List[str], config_dir: str, project_dir: str) -> List[str]:
@@ -417,7 +486,7 @@ class HookManager:
         Hooks get a small allow-list (``PATH``/``HOME`` so interpreters resolve)
         plus ``ATLAS_CONFIG_DIR`` / ``ATLAS_PROJECT_DIR``. They do NOT inherit the
         server's full environment, which holds provider API keys and other
-        secrets -- mirroring the boundary Claude Code applies.
+        secrets.
         """
         env: Dict[str, str] = {}
         for key in ("PATH", "HOME", "SYSTEMROOT", "LANG", "LC_ALL", "USER"):

--- a/atlas/hooks/models.py
+++ b/atlas/hooks/models.py
@@ -4,7 +4,7 @@ A "hook" is an arbitrary executable (bash, Python, anything) registered in
 ``config/hooks.json`` against a chat lifecycle event. Atlas spawns it as a
 subprocess at the event's chokepoint, sends the event payload as JSON on stdin,
 and reads a decision (exit code + optional JSON on stdout) that can allow,
-modify, block, or escalate the operation. See ``docs/hooks.md`` and GH #713.
+modify, block, or escalate the operation. See ``docs/admin/hooks.md`` and GH #713.
 
 This module holds only data models + the event enumeration -- no I/O -- so it
 can be imported without pulling in the subprocess machinery.
@@ -12,10 +12,14 @@ can be imported without pulling in the subprocess machinery.
 
 from __future__ import annotations
 
+import logging
+import re
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class HookEvent(str, Enum):
@@ -56,6 +60,15 @@ _EVENT_DEFAULT_ON_ERROR: Dict[HookEvent, Literal["deny", "allow"]] = {
 }
 
 
+# Events that carry no natural matcher value. A hook registered against one of
+# these with an explicit ``matcher`` can never fire (see ``HookConfig.matches``).
+_MATCHERLESS_EVENTS = frozenset({
+    HookEvent.SESSION_START.value,
+    HookEvent.SESSION_END.value,
+    HookEvent.USER_PROMPT_SUBMIT.value,
+})
+
+
 def default_on_error(event: HookEvent) -> Literal["deny", "allow"]:
     """Return the fail-closed/fail-open default for an event."""
     return _EVENT_DEFAULT_ON_ERROR.get(event, "allow")
@@ -64,15 +77,19 @@ def default_on_error(event: HookEvent) -> Literal["deny", "allow"]:
 class HookConfig(BaseModel):
     """A single hook registration (one entry under ``hooks.<EventName>``).
 
-    Mirrors the Claude Code ``settings.json`` hook entry shape so operators
-    familiar with that system can reuse muscle memory.
+    Mirrors the settings-file hook entry shape used by agent CLIs, so operators
+    familiar with that pattern can reuse muscle memory.
 
     Fields:
         name: Human-readable identifier used in logs/audit spans.
         matcher: Optional regex over the event's "matcher value" (the tool name
             for tool events, the qualified data source for RAG events). Omit or
-            set to ``"*"`` to match everything. Ignored for events without a
-            natural matcher value (SessionStart/SessionEnd/UserPromptSubmit).
+            set to ``"*"`` to match everything. Events without a natural matcher
+            value (SessionStart/SessionEnd/UserPromptSubmit) supply no value, so
+            an explicit matcher on those events matches *nothing* and the hook
+            never fires -- ``HooksConfig`` logs a warning at load time rather
+            than letting the hook silently do nothing. The pattern is compiled
+            at config-load time; an invalid regex is a config error.
         command: argv array spawned with ``asyncio.create_subprocess_exec`` --
             **never** ``shell=True``. Supports ``${ATLAS_CONFIG_DIR}`` and
             ``${ATLAS_PROJECT_DIR}`` interpolation so config-relative script
@@ -105,28 +122,46 @@ class HookConfig(BaseModel):
             raise ValueError("hook name must be non-empty")
         return v
 
+    @field_validator("matcher")
+    @classmethod
+    def _matcher_is_valid_regex(cls, v: Optional[str]) -> Optional[str]:
+        """Reject a malformed matcher at config-load time.
+
+        Silently treating an uncompilable pattern as a non-match would disable
+        a fail-closed hook (PreToolUse/PermissionRequest) while leaving the rest
+        of the config working -- a typo in a regex would quietly remove a
+        security control. Failing validation instead surfaces it where every
+        other config error surfaces.
+        """
+        if v is None or v in ("", "*"):
+            return v
+        try:
+            re.compile(v)
+        except re.error as e:
+            raise ValueError(f"hook matcher is not a valid regex: {e}") from e
+        return v
+
     def matches(self, matcher_value: Optional[str]) -> bool:
         """Return True if ``matcher_value`` satisfies this hook's matcher.
 
-        ``None``/``"*"`` matcher = match all. A missing ``matcher_value`` (event
-        has no natural value) only matches a wildcard matcher, so a hook that
-        set an explicit matcher on e.g. SessionStart simply never fires -- the
-        operator gets a clear signal rather than silent over-firing.
+        ``None``/``"*"``/``""`` matcher = match all. A missing ``matcher_value``
+        (the event has no natural value) matches only a wildcard matcher, so an
+        explicit matcher on SessionStart/SessionEnd/UserPromptSubmit means the
+        hook never fires; ``HooksConfig`` warns about that at load time.
         """
         pattern = self.matcher
         if pattern is None or pattern == "*" or pattern == "":
             return True
         if matcher_value is None:
             return False
-        import re
-
         try:
             return re.search(pattern, matcher_value) is not None
         except re.error:
-            # Treat an invalid matcher as a non-match rather than crashing the
-            # turn; the misconfiguration is surfaced via the validate_config
-            # path and the startup log.
-            return False
+            # Unreachable via config load (the validator compiles the pattern),
+            # but if a hook is constructed directly with a bad pattern, fire it
+            # rather than skip it: over-firing a policy hook is the safe
+            # direction, silently disabling one is not.
+            return True
 
     def effective_on_error(self, event: HookEvent) -> Literal["deny", "allow"]:
         return self.on_error if self.on_error is not None else default_on_error(event)
@@ -141,6 +176,25 @@ class HooksConfig(BaseModel):
     """
 
     hooks: Dict[str, List[HookConfig]] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _warn_on_inert_matchers(self) -> "HooksConfig":
+        """Warn about matchers that can never match.
+
+        SessionStart/SessionEnd/UserPromptSubmit carry no matcher value, so a
+        hook that sets one never fires. That is a misconfiguration an operator
+        would otherwise only discover by noticing their policy is not running.
+        """
+        for event_name in _MATCHERLESS_EVENTS:
+            for hook in self.hooks.get(event_name, []) or []:
+                if hook.matcher not in (None, "", "*"):
+                    logger.warning(
+                        "hooks: hook %r on %s sets matcher %r, but %s supplies no "
+                        "matcher value -- this hook will never fire. Remove the "
+                        "matcher to run it on every %s event.",
+                        hook.name, event_name, hook.matcher, event_name, event_name,
+                    )
+        return self
 
     def hooks_for(self, event_name: str) -> List[HookConfig]:
         """Return the ordered hook list for an event name (empty if none)."""

--- a/atlas/hooks/models.py
+++ b/atlas/hooks/models.py
@@ -1,0 +1,160 @@
+"""Pydantic models and event definitions for the config-driven hook system.
+
+A "hook" is an arbitrary executable (bash, Python, anything) registered in
+``config/hooks.json`` against a chat lifecycle event. Atlas spawns it as a
+subprocess at the event's chokepoint, sends the event payload as JSON on stdin,
+and reads a decision (exit code + optional JSON on stdout) that can allow,
+modify, block, or escalate the operation. See ``docs/hooks.md`` and GH #713.
+
+This module holds only data models + the event enumeration -- no I/O -- so it
+can be imported without pulling in the subprocess machinery.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class HookEvent(str, Enum):
+    """Lifecycle events at which operator-installed hooks may fire.
+
+    Each value is the stable ``hook_event_name`` string used in the stdin
+    envelope and in ``config/hooks.json`` keys. Keeping the enum values == the
+    JSON keys means config and wire format can never drift apart.
+    """
+
+    SESSION_START = "SessionStart"
+    USER_PROMPT_SUBMIT = "UserPromptSubmit"
+    PRE_LLM_CALL = "PreLlmCall"
+    PRE_TOOL_USE = "PreToolUse"
+    POST_TOOL_USE = "PostToolUse"
+    PERMISSION_REQUEST = "PermissionRequest"
+    RAG_CALL = "RagCall"
+    RAG_RESPONSE = "RagResponse"
+    SESSION_END = "SessionEnd"
+
+
+# Per-event ``on_error`` defaults. Security/interceptor events that guard a
+# boundary (PreToolUse, PermissionRequest, PreLlmCall, RagCall) fail *closed*
+# (``deny``): a crashing/hanging hook must not silently weaken the boundary.
+# Observability/lifecycle events (SessionStart, SessionEnd, UserPromptSubmit,
+# PostToolUse, RagResponse) fail *open* (``allow``): a broken audit hook should
+# not take down the chat turn. Operators override per-hook in ``hooks.json``.
+_EVENT_DEFAULT_ON_ERROR: Dict[HookEvent, Literal["deny", "allow"]] = {
+    HookEvent.PRE_TOOL_USE: "deny",
+    HookEvent.PERMISSION_REQUEST: "deny",
+    HookEvent.PRE_LLM_CALL: "deny",
+    HookEvent.RAG_CALL: "deny",
+    HookEvent.SESSION_START: "allow",
+    HookEvent.SESSION_END: "allow",
+    HookEvent.USER_PROMPT_SUBMIT: "allow",
+    HookEvent.POST_TOOL_USE: "allow",
+    HookEvent.RAG_RESPONSE: "allow",
+}
+
+
+def default_on_error(event: HookEvent) -> Literal["deny", "allow"]:
+    """Return the fail-closed/fail-open default for an event."""
+    return _EVENT_DEFAULT_ON_ERROR.get(event, "allow")
+
+
+class HookConfig(BaseModel):
+    """A single hook registration (one entry under ``hooks.<EventName>``).
+
+    Mirrors the Claude Code ``settings.json`` hook entry shape so operators
+    familiar with that system can reuse muscle memory.
+
+    Fields:
+        name: Human-readable identifier used in logs/audit spans.
+        matcher: Optional regex over the event's "matcher value" (the tool name
+            for tool events, the qualified data source for RAG events). Omit or
+            set to ``"*"`` to match everything. Ignored for events without a
+            natural matcher value (SessionStart/SessionEnd/UserPromptSubmit).
+        command: argv array spawned with ``asyncio.create_subprocess_exec`` --
+            **never** ``shell=True``. Supports ``${ATLAS_CONFIG_DIR}`` and
+            ``${ATLAS_PROJECT_DIR}`` interpolation so config-relative script
+            paths are portable without leaking the server's full environment.
+        timeout_ms: Wall-clock budget for the subprocess. On expiry the process
+            is killed and ``on_error`` decides the outcome.
+        on_error: Outcome when the hook crashes, times out, or emits malformed
+            output. ``deny`` short-circuits the operation as blocked;
+            ``allow`` continues as if the hook returned ``continue``. When
+            omitted, the per-event default (see ``default_on_error``) applies.
+    """
+
+    name: str
+    matcher: Optional[str] = None
+    command: List[str]
+    timeout_ms: int = Field(default=2000, ge=1)
+    on_error: Optional[Literal["deny", "allow"]] = None
+
+    @field_validator("command")
+    @classmethod
+    def _command_non_empty(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise ValueError("hook command must be a non-empty argv array")
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def _name_non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("hook name must be non-empty")
+        return v
+
+    def matches(self, matcher_value: Optional[str]) -> bool:
+        """Return True if ``matcher_value`` satisfies this hook's matcher.
+
+        ``None``/``"*"`` matcher = match all. A missing ``matcher_value`` (event
+        has no natural value) only matches a wildcard matcher, so a hook that
+        set an explicit matcher on e.g. SessionStart simply never fires -- the
+        operator gets a clear signal rather than silent over-firing.
+        """
+        pattern = self.matcher
+        if pattern is None or pattern == "*" or pattern == "":
+            return True
+        if matcher_value is None:
+            return False
+        import re
+
+        try:
+            return re.search(pattern, matcher_value) is not None
+        except re.error:
+            # Treat an invalid matcher as a non-match rather than crashing the
+            # turn; the misconfiguration is surfaced via the validate_config
+            # path and the startup log.
+            return False
+
+    def effective_on_error(self, event: HookEvent) -> Literal["deny", "allow"]:
+        return self.on_error if self.on_error is not None else default_on_error(event)
+
+
+class HooksConfig(BaseModel):
+    """Top-level ``config/hooks.json`` model: event name -> list of hooks.
+
+    Hooks for an event run sequentially in config order; each sees the previous
+    hook's ``modify`` output. ``deny`` short-circuits; ``require_approval`` is
+    sticky (cannot be downgraded by a later hook). See ``HookManager.run_event``.
+    """
+
+    hooks: Dict[str, List[HookConfig]] = Field(default_factory=dict)
+
+    def hooks_for(self, event_name: str) -> List[HookConfig]:
+        """Return the ordered hook list for an event name (empty if none)."""
+        return self.hooks.get(event_name, []) or []
+
+
+class HookDecision(BaseModel):
+    """Parsed stdout JSON from a hook (the structured path).
+
+    The fast path is the exit code: 0 = continue (apply stdout if non-empty
+    JSON), 2 = block (stderr is the reason), other = error. When a hook emits
+    stdout JSON on exit 0, this model validates it.
+    """
+
+    decision: Literal["continue", "modify", "deny", "require_approval"] = "continue"
+    reason: Optional[str] = None
+    payload: Optional[Dict[str, Any]] = None

--- a/atlas/modules/config/config_loader.py
+++ b/atlas/modules/config/config_loader.py
@@ -406,6 +406,7 @@ class ConfigManager:
                 file_paths = self._search_paths(hooks_filename)
                 data = self._load_file_with_error_handling(file_paths, "JSON")
 
+                self._hooks_config_load_failed = False
                 if data:
                     self._hooks_config = HooksConfig(**data)
                     total = sum(len(v) for v in self._hooks_config.hooks.values())
@@ -419,6 +420,10 @@ class ConfigManager:
                     self._hooks_config = HooksConfig()
                     logger.info("No hooks.json found; hook system disabled (zero overhead)")
             except Exception as e:
+                # Degrading to an empty config disables every hook, including the
+                # fail-closed ones. Record it so validate_config can report the
+                # controls are off rather than leaving it to a single log line.
+                self._hooks_config_load_failed = True
                 logger.error(f"Failed to parse hooks configuration: {e}", exc_info=True)
                 from atlas.hooks.models import HooksConfig
                 self._hooks_config = HooksConfig()
@@ -546,5 +551,22 @@ class ConfigManager:
         except Exception as e:
             logger.error(f"MCP config validation failed: {e}", exc_info=True)
             status["mcp_config"] = False
+
+        # Hooks are security controls, so a malformed hooks.json must be visible
+        # here and not only as a line in the startup log: the load path degrades
+        # to an empty config, which disables every fail-closed hook.
+        try:
+            hooks_config = self.hooks_config
+            status["hooks_config"] = not getattr(self, "_hooks_config_load_failed", False)
+            if not status["hooks_config"]:
+                logger.error(
+                    "hooks.json failed to load; ALL hooks are disabled, including "
+                    "fail-closed policy hooks. Fix the file or remove it deliberately."
+                )
+            elif not hooks_config.hooks:
+                logger.info("No hooks configured (hook system disabled)")
+        except Exception as e:
+            logger.error(f"Hooks config validation failed: {e}", exc_info=True)
+            status["hooks_config"] = False
 
         return status

--- a/atlas/modules/config/config_loader.py
+++ b/atlas/modules/config/config_loader.py
@@ -418,7 +418,22 @@ class ConfigManager:
                     )
                 else:
                     self._hooks_config = HooksConfig()
-                    logger.info("No hooks.json found; hook system disabled (zero overhead)")
+                    # _load_file_with_error_handling() returns None both when the
+                    # file is absent and when it exists but failed to parse -- it
+                    # logs and continues. Those cases are not equivalent here: a
+                    # typo in hooks.json silently disables every fail-closed
+                    # control, so distinguish them by checking whether any
+                    # candidate path actually exists on disk.
+                    if any(p.exists() for p in file_paths):
+                        self._hooks_config_load_failed = True
+                        logger.error(
+                            "hooks.json exists but could not be parsed; ALL hooks are "
+                            "disabled, including fail-closed policy hooks. "
+                            "Searched: %s",
+                            [str(p) for p in file_paths],
+                        )
+                    else:
+                        logger.info("No hooks.json found; hook system disabled (zero overhead)")
             except Exception as e:
                 # Degrading to an empty config disables every hook, including the
                 # fail-closed ones. Record it so validate_config can report the

--- a/atlas/modules/config/config_loader.py
+++ b/atlas/modules/config/config_loader.py
@@ -42,6 +42,7 @@ class ConfigManager:
         self._rag_sources_config: Optional[RAGSourcesConfig] = None
         self._tool_approvals_config: Optional[ToolApprovalsConfig] = None
         self._file_extractors_config: Optional[FileExtractorsConfig] = None
+        self._hooks_config: Optional[Any] = None
 
     def _search_paths(self, file_name: str) -> List[Path]:
         """Generate search paths for a configuration file.
@@ -386,6 +387,44 @@ class ConfigManager:
 
         return self._file_extractors_config
 
+    @property
+    def hooks_config(self):
+        """Get hook configuration (cached) from hooks.json.
+
+        Follows the same two-layer lookup (user ``config/`` overrides packaged
+        ``atlas/config/``) and error tolerance as the other file-backed configs.
+        Hooks are opt-in: a missing file yields an empty config, which means the
+        hook manager short-circuits with zero overhead on the hot path (GH #713).
+        """
+        if self._hooks_config is None:
+            try:
+                # Lazy import avoids a config -> hooks package init cycle at
+                # module load time; the model itself has no I/O or config deps.
+                from atlas.hooks.models import HooksConfig
+
+                hooks_filename = self.app_settings.hooks_config_file
+                file_paths = self._search_paths(hooks_filename)
+                data = self._load_file_with_error_handling(file_paths, "JSON")
+
+                if data:
+                    self._hooks_config = HooksConfig(**data)
+                    total = sum(len(v) for v in self._hooks_config.hooks.values())
+                    logger.info(
+                        "Loaded hooks config with %d hook(s) across %d event(s): %s",
+                        total,
+                        len(self._hooks_config.hooks),
+                        list(self._hooks_config.hooks.keys()),
+                    )
+                else:
+                    self._hooks_config = HooksConfig()
+                    logger.info("No hooks.json found; hook system disabled (zero overhead)")
+            except Exception as e:
+                logger.error(f"Failed to parse hooks configuration: {e}", exc_info=True)
+                from atlas.hooks.models import HooksConfig
+                self._hooks_config = HooksConfig()
+
+        return self._hooks_config
+
     def _resolve_file_extractor_env_vars(self) -> None:
         """Resolve environment variables in file extractor configurations.
 
@@ -462,6 +501,7 @@ class ConfigManager:
         self._rag_sources_config = None
         self._tool_approvals_config = None
         self._file_extractors_config = None
+        self._hooks_config = None
         logger.info("Configuration cache cleared, will reload on next access")
 
     def reload_mcp_config(self) -> MCPConfig:

--- a/atlas/modules/config/settings.py
+++ b/atlas/modules/config/settings.py
@@ -523,6 +523,7 @@ class AppSettings(BaseSettings):
     splash_config_file: str = Field(default="splash-config.json", validation_alias="SPLASH_CONFIG_FILE")
     splash_screen_file: str = Field(default="splash-screen.md", validation_alias="SPLASH_SCREEN_FILE")
     file_extractors_config_file: str = Field(default="file-extractors.json", validation_alias="FILE_EXTRACTORS_CONFIG_FILE")
+    hooks_config_file: str = Field(default="hooks.json", validation_alias="HOOKS_CONFIG_FILE")
 
     # Config directory path (user customizations; falls back to atlas/config/ for defaults)
     app_config_dir: str = Field(default="config", validation_alias="APP_CONFIG_DIR")

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -36,7 +36,9 @@ except ImportError:
 import litellm
 from litellm import acompletion
 
+from atlas.core.log_sanitizer import sanitize_for_logging
 from atlas.core.metrics_logger import log_metric
+from atlas.core.model_access import ModelAccessDecision, check_model_access
 from atlas.core.telemetry import set_attrs, start_span
 from atlas.domain.errors import (
     CONTEXT_WINDOW_KEYWORDS,
@@ -180,7 +182,10 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             from atlas.core.compliance import get_active_compliance_context
             compliance_level, _ = get_active_compliance_context()
         except Exception:
-            pass
+            # Compliance context is informational in the hook envelope; when it is
+            # unavailable (no active request context) the hook still runs with
+            # compliance_level=None rather than failing the LLM call.
+            logger.debug("hooks: no active compliance context for PreLlmCall", exc_info=True)
         payload: Dict[str, Any] = {
             "model": model_name,
             "messages": messages,
@@ -205,18 +210,33 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
         model_name: str,
         messages: List[Dict[str, str]],
         tools_schema: Optional[List[Dict]] = None,
+        *,
+        user_email: Optional[str] = None,
     ):
-        """Apply a PreLlmCall modify payload and re-resolve the litellm model.
+        """Apply a PreLlmCall modify payload.
 
-        Returns ``(model_name, litellm_model, messages, tools_schema)`` after a
-        hook may have swapped the model or rewritten messages/tools. Model swaps
-        re-resolve the provider-qualified name and kwargs upstream callers reuse.
+        Returns ``(model_name, messages, tools_schema)`` after a hook may have
+        swapped the model or rewritten messages/tools.
+
+        A model swap is re-authorized against the same per-model group check
+        ``ChatOrchestrator`` ran for the originally selected model. Without that,
+        a hook could route a turn to a model the user is not cleared for, since
+        the orchestrator's check only ever saw the original name. An unauthorized
+        swap is refused and the original model is kept.
         """
         if mod is None:
             return model_name, messages, tools_schema
         new_model = mod.get("model")
         if isinstance(new_model, str) and new_model and new_model != model_name:
-            model_name = new_model
+            if await self._hook_model_swap_allowed(new_model, user_email):
+                model_name = new_model
+            else:
+                logger.warning(
+                    "hooks: PreLlmCall model swap to %s refused (user not authorized); "
+                    "keeping %s",
+                    sanitize_for_logging(new_model),
+                    sanitize_for_logging(model_name),
+                )
         new_messages = mod.get("messages")
         if isinstance(new_messages, list):
             messages = new_messages
@@ -225,6 +245,23 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             if isinstance(new_tools, list):
                 tools_schema = new_tools
         return model_name, messages, tools_schema
+
+    async def _hook_model_swap_allowed(self, model_name: str, user_email: Optional[str]) -> bool:
+        """Re-run the per-model group check for a hook-supplied model name.
+
+        Mirrors ``ChatOrchestrator``'s gate. An unknown model is left to the
+        downstream caller (same policy as chat), but a model the user's groups do
+        not cover is refused here.
+        """
+        try:
+            models = self.llm_config.models
+        except Exception:
+            # Without a model registry there is nothing to check against; refuse
+            # the swap rather than assume the replacement is authorized.
+            logger.warning("hooks: cannot verify PreLlmCall model swap (no llm_config); refusing")
+            return False
+        decision = await check_model_access(models, model_name, user_email, context="PreLlmCall hook")
+        return decision is not ModelAccessDecision.DENIED
 
     @staticmethod
     def _tools_implicated_by(error_str: str, tools_schema: Optional[List[Dict]]) -> List[str]:
@@ -950,7 +987,7 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             # or block the call. Zero-overhead when no hooks registered.
             mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email)
             if mod is not None:
-                model_name, messages, _ = await self._apply_pre_llm_modify(mod, model_name, messages)
+                model_name, messages, _ = await self._apply_pre_llm_modify(mod, model_name, messages, user_email=user_email)
                 litellm_model = self._get_litellm_model_name(model_name)
                 model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
                 if max_tokens is not None:
@@ -1154,7 +1191,7 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email, tools_schema=tools_schema)
             if mod is not None:
                 model_name, messages, tools_schema = await self._apply_pre_llm_modify(
-                    mod, model_name, messages, tools_schema
+                    mod, model_name, messages, tools_schema, user_email=user_email
                 )
                 litellm_model = self._get_litellm_model_name(model_name)
                 model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -200,7 +200,7 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
         )
         if outcome.verdict == "deny":
             raise HookBlockedError(HookEvent.PRE_LLM_CALL, outcome.reason or "LLM call blocked by policy hook")
-        if outcome.verdict == "modify":
+        if outcome.modified:
             return outcome.payload
         return None
 

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -20,6 +20,8 @@ import warnings
 from collections import defaultdict
 from typing import Any, Dict, List, NoReturn, Optional, Tuple
 
+from atlas.hooks import HookBlockedError, HookEvent, get_hook_manager
+
 # Suppress Pydantic deprecation warnings from litellm's response processing.
 # litellm accesses Pydantic v2.11+ deprecated instance attributes
 # (model_fields, model_computed_fields) on every streaming chunk, generating
@@ -150,6 +152,79 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             litellm.set_verbose = False
         else:
             litellm.set_verbose = debug_mode
+
+    async def _fire_pre_llm_hook(
+        self,
+        model_name: str,
+        messages: List[Dict[str, str]],
+        user_email: Optional[str] = None,
+        tools_schema: Optional[List[Dict]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """PreLlmCall hook (GH #713).
+
+        Returns a dict of modified fields (``model``, ``messages``, ``tools``)
+        when a hook made a ``modify`` decision; returns ``None`` when no hooks
+        fired or the verdict was continue/require_approval (no change). Raises
+        ``HookBlockedError`` on ``deny`` so the call surfaces the reason rather
+        than silently proceeding. Opt-in; zero overhead without hooks.json.
+
+        ``require_approval`` has no approval gate at the LLM layer, so it is
+        treated as continue (audited only) -- a hook that needs to block an LLM
+        call should use ``deny``.
+        """
+        mgr = get_hook_manager()
+        if mgr is None or not mgr.has_hooks(HookEvent.PRE_LLM_CALL):
+            return None
+        compliance_level = None
+        try:
+            from atlas.core.compliance import get_active_compliance_context
+            compliance_level, _ = get_active_compliance_context()
+        except Exception:
+            pass
+        payload: Dict[str, Any] = {
+            "model": model_name,
+            "messages": messages,
+            "user_email": user_email,
+        }
+        if tools_schema is not None:
+            payload["tools"] = tools_schema
+        outcome = await mgr.run_event(
+            HookEvent.PRE_LLM_CALL,
+            payload,
+            session_context={"user_email": user_email, "compliance_level": compliance_level},
+        )
+        if outcome.verdict == "deny":
+            raise HookBlockedError(HookEvent.PRE_LLM_CALL, outcome.reason or "LLM call blocked by policy hook")
+        if outcome.verdict == "modify":
+            return outcome.payload
+        return None
+
+    async def _apply_pre_llm_modify(
+        self,
+        mod: Optional[Dict[str, Any]],
+        model_name: str,
+        messages: List[Dict[str, str]],
+        tools_schema: Optional[List[Dict]] = None,
+    ):
+        """Apply a PreLlmCall modify payload and re-resolve the litellm model.
+
+        Returns ``(model_name, litellm_model, messages, tools_schema)`` after a
+        hook may have swapped the model or rewritten messages/tools. Model swaps
+        re-resolve the provider-qualified name and kwargs upstream callers reuse.
+        """
+        if mod is None:
+            return model_name, messages, tools_schema
+        new_model = mod.get("model")
+        if isinstance(new_model, str) and new_model and new_model != model_name:
+            model_name = new_model
+        new_messages = mod.get("messages")
+        if isinstance(new_messages, list):
+            messages = new_messages
+        if tools_schema is not None:
+            new_tools = mod.get("tools")
+            if isinstance(new_tools, list):
+                tools_schema = new_tools
+        return model_name, messages, tools_schema
 
     @staticmethod
     def _tools_implicated_by(error_str: str, tools_schema: Optional[List[Dict]]) -> List[str]:
@@ -871,6 +946,16 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             total_chars = sum(len(str(msg.get('content', ''))) for msg in messages)
             logger.info(f"Plain LLM call: {len(messages)} messages, {total_chars} chars")
 
+            # PreLlmCall hook (GH #713): inspect/redact messages, swap/veto model,
+            # or block the call. Zero-overhead when no hooks registered.
+            mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email)
+            if mod is not None:
+                model_name, messages, _ = await self._apply_pre_llm_modify(mod, model_name, messages)
+                litellm_model = self._get_litellm_model_name(model_name)
+                model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
+                if max_tokens is not None:
+                    model_kwargs["max_tokens"] = max_tokens
+
             response = await self._acompletion_with_retry(
                 model=litellm_model,
                 messages=self._prepare_messages(model_name, messages),
@@ -888,6 +973,10 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
 
             return content
 
+        except HookBlockedError:
+            # A PreLlmCall hook blocked the call: surface the reason, do not
+            # wrap as a generic LLMServiceError.
+            raise
         except Exception as exc:
             logger.error("Error calling LLM: %s", exc, exc_info=True)
             self._raise_llm_domain_error(exc)
@@ -1031,6 +1120,10 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             DataSourcePermissionError,
         ):
             raise  # Don't mask LLM errors with a fallback retry
+        except HookBlockedError:
+            # A PreLlmCall hook blocked the call: do NOT fall back to plain LLM
+            # (the hook's decision applies to the LLM step regardless of RAG).
+            raise
         except Exception as exc:
             logger.error("[LLM+RAG] Error in RAG-integrated query: %s", exc, exc_info=True)
             logger.warning("[LLM+RAG] Falling back to plain LLM call due to RAG error")
@@ -1057,6 +1150,15 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             total_chars = sum(len(str(msg.get('content', ''))) for msg in messages)
             logger.info(f"LLM call with tools: {len(messages)} messages, {total_chars} chars, {len(tools_schema)} tools")
 
+            # PreLlmCall hook (GH #713)
+            mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email, tools_schema=tools_schema)
+            if mod is not None:
+                model_name, messages, tools_schema = await self._apply_pre_llm_modify(
+                    mod, model_name, messages, tools_schema
+                )
+                litellm_model = self._get_litellm_model_name(model_name)
+                model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
+
             response = await self._acompletion_with_retry(
                 model=litellm_model,
                 messages=self._prepare_messages(model_name, messages),
@@ -1077,6 +1179,8 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
                 model_used=model_name
             )
 
+        except HookBlockedError:
+            raise
         except Exception as exc:
             logger.error("Error calling LLM with tools: %s", exc, exc_info=True)
             self._raise_llm_domain_error(exc, tools_schema=tools_schema)
@@ -1222,6 +1326,8 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             DataSourcePermissionError,
         ):
             raise  # Don't mask LLM errors with a fallback retry
+        except HookBlockedError:
+            raise
         except Exception as exc:
             logger.error("[LLM+RAG+Tools] Error in RAG+tools integrated query: %s", exc, exc_info=True)
             logger.warning("[LLM+RAG+Tools] Falling back to tools-only call due to RAG error")

--- a/atlas/modules/llm/litellm_streaming.py
+++ b/atlas/modules/llm/litellm_streaming.py
@@ -57,7 +57,7 @@ class LiteLLMStreamingMixin:
         # Deny raises HookBlockedError which propagates through the generator.
         mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email)
         if mod is not None:
-            model_name, messages, _ = await self._apply_pre_llm_modify(mod, model_name, messages)
+            model_name, messages, _ = await self._apply_pre_llm_modify(mod, model_name, messages, user_email=user_email)
             litellm_model = self._get_litellm_model_name(model_name)
             model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
             if max_tokens is not None:
@@ -162,7 +162,7 @@ class LiteLLMStreamingMixin:
         mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email, tools_schema=tools_schema)
         if mod is not None:
             model_name, messages, tools_schema = await self._apply_pre_llm_modify(
-                mod, model_name, messages, tools_schema
+                mod, model_name, messages, tools_schema, user_email=user_email
             )
             litellm_model = self._get_litellm_model_name(model_name)
             model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)

--- a/atlas/modules/llm/litellm_streaming.py
+++ b/atlas/modules/llm/litellm_streaming.py
@@ -53,6 +53,16 @@ class LiteLLMStreamingMixin:
         if max_tokens is not None:
             model_kwargs["max_tokens"] = max_tokens
 
+        # PreLlmCall hook (GH #713): zero-overhead when no hooks registered.
+        # Deny raises HookBlockedError which propagates through the generator.
+        mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email)
+        if mod is not None:
+            model_name, messages, _ = await self._apply_pre_llm_modify(mod, model_name, messages)
+            litellm_model = self._get_litellm_model_name(model_name)
+            model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
+            if max_tokens is not None:
+                model_kwargs["max_tokens"] = max_tokens
+
         provider, model_suffix = split_provider(litellm_model)
         span_attrs = {
             "model": litellm_model,
@@ -147,6 +157,15 @@ class LiteLLMStreamingMixin:
 
         litellm_model = self._get_litellm_model_name(model_name)
         model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
+
+        # PreLlmCall hook (GH #713)
+        mod = await self._fire_pre_llm_hook(model_name, messages, user_email=user_email, tools_schema=tools_schema)
+        if mod is not None:
+            model_name, messages, tools_schema = await self._apply_pre_llm_modify(
+                mod, model_name, messages, tools_schema
+            )
+            litellm_model = self._get_litellm_model_name(model_name)
+            model_kwargs = self._get_model_kwargs(model_name, temperature, user_email=user_email)
 
         provider, model_suffix = split_provider(litellm_model)
         span_attrs = {

--- a/atlas/modules/mcp_tools/mcp_execution.py
+++ b/atlas/modules/mcp_tools/mcp_execution.py
@@ -834,7 +834,7 @@ class ExecutionMixin:
                 )
                 if rag_call.verdict == "deny":
                     _rag_blocked = rag_call.reason or "RAG query blocked by policy hook"
-                elif rag_call.verdict == "modify":
+                elif rag_call.modified:
                     new_q = rag_call.payload.get("query")
                     if isinstance(new_q, str) and new_q and new_q != query:
                         query = new_q
@@ -910,7 +910,7 @@ class ExecutionMixin:
                 )
                 if rag_resp.verdict == "deny":
                     answers = []
-                elif rag_resp.verdict == "modify":
+                elif rag_resp.modified:
                     new_combined = rag_resp.payload.get("content")
                     if isinstance(new_combined, str):
                         # Replace the combined answer by collapsing to a single answer entry.

--- a/atlas/modules/mcp_tools/mcp_execution.py
+++ b/atlas/modules/mcp_tools/mcp_execution.py
@@ -13,6 +13,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from atlas.core.log_sanitizer import sanitize_for_logging
 from atlas.core.metrics_logger import log_metric
 from atlas.domain.messages.models import ToolCall, ToolResult
+from atlas.hooks import HookEvent, get_hook_manager
 from atlas.modules.mcp_tools.mcp_discovery import (
     _ATLAS_RAG_DISCOVER_TOOL,
     _ATLAS_RAG_QUERY_TOOL,
@@ -778,9 +779,9 @@ class ExecutionMixin:
                 if not unified_rag:
                     raise RuntimeError("Unified RAG service is not configured")
                 if len(group) == 1:
-                    resp = await unified_rag.query_rag(user_email, group[0], messages)
+                    resp = await unified_rag.query_rag(user_email, group[0], messages, _skip_hooks=True)
                 else:
-                    resp = await unified_rag.query_rag_batch(user_email, group, messages)
+                    resp = await unified_rag.query_rag_batch(user_email, group, messages, _skip_hooks=True)
                 return {
                     "data_sources": group,
                     "content": resp.content,
@@ -805,6 +806,61 @@ class ExecutionMixin:
             group_lists = list(http_groups.values()) + list(mcp_groups.values())
             coros = [_query_http(g) for g in http_groups.values()]
             coros += [_query_mcp(g) for g in mcp_groups.values()]
+
+            # RagCall hook (GH #713): fires once for the whole agentic atlas_rag_query
+            # call (covering both HTTP and MCP sources). HTTP sources skip the
+            # per-source hooks inside unified_rag (_skip_hooks=True) to avoid
+            # double-firing. A hook may rewrite the query or narrow sources; it
+            # can never widen (only entries from the authorized set survive).
+            rag_mgr = get_hook_manager()
+            _rag_blocked: Optional[str] = None
+            if rag_mgr is not None and rag_mgr.has_hooks(HookEvent.RAG_CALL):
+                rag_call = await rag_mgr.run_event(
+                    HookEvent.RAG_CALL,
+                    {"query": query, "qualified_data_sources": list(sources), "username": user_email},
+                    session_context={
+                        "user_email": user_email,
+                        "compliance_level": compliance_level,
+                        "session_id": context.get("session_id") if isinstance(context, dict) else None,
+                    },
+                    matcher_value=",".join(sources),
+                )
+                if rag_call.verdict == "deny":
+                    _rag_blocked = rag_call.reason or "RAG query blocked by policy hook"
+                elif rag_call.verdict == "modify":
+                    new_q = rag_call.payload.get("query")
+                    if isinstance(new_q, str) and new_q and new_q != query:
+                        query = new_q
+                        messages = [{"role": "user", "content": query}]
+                    new_sources = rag_call.payload.get("qualified_data_sources")
+                    if isinstance(new_sources, list):
+                        allowed = set(sources)
+                        narrowed = [s for s in new_sources if s in allowed]
+                        if not narrowed:
+                            _rag_blocked = rag_call.payload.get("reason") or "RAG query narrowed to no sources by hook"
+                        else:
+                            sources = narrowed
+                            # Rebuild groups for the narrowed source set
+                            http_groups = {}
+                            mcp_groups = {}
+                            for source in sources:
+                                server_name = source.split(":", 1)[0]
+                                if source_origin.get(source) == "mcp":
+                                    mcp_groups.setdefault(server_name, []).append(source)
+                                else:
+                                    http_groups.setdefault(server_name, []).append(source)
+                            group_lists = list(http_groups.values()) + list(mcp_groups.values())
+                            coros = [_query_http(g) for g in http_groups.values()]
+                            coros += [_query_mcp(g) for g in mcp_groups.values()]
+
+            if _rag_blocked is not None:
+                return ToolResult(
+                    tool_call_id=tool_call.id,
+                    content=f"RAG query blocked by policy hook: {_rag_blocked}",
+                    success=False,
+                    error=_rag_blocked,
+                )
+
             settled = await asyncio.gather(*coros, return_exceptions=True)
 
             answers: List[Dict[str, Any]] = []
@@ -820,6 +876,39 @@ class ExecutionMixin:
                     errors.append({"data_sources": group_sources, "error": str(outcome)})
                 else:
                     answers.append(outcome)
+
+            # RagResponse hook (GH #713): redact/replace the combined answer before
+            # it is returned to the model. The agentic path reduces per-source
+            # RAGResponse objects to {data_sources, content} dicts (metadata is
+            # dropped), so the hook operates on the combined content. Observability
+            # default fail-open; deny yields an empty combined answer.
+            if rag_mgr is not None and rag_mgr.has_hooks(HookEvent.RAG_RESPONSE):
+                combined_answer = "\n\n".join(
+                    a["content"] for a in answers if a.get("content")
+                )
+                rag_resp = await rag_mgr.run_event(
+                    HookEvent.RAG_RESPONSE,
+                    {
+                        "query": query,
+                        "qualified_data_sources": list(sources),
+                        "username": user_email,
+                        "content": combined_answer,
+                        "answers": answers,
+                    },
+                    session_context={
+                        "user_email": user_email,
+                        "compliance_level": compliance_level,
+                        "session_id": context.get("session_id") if isinstance(context, dict) else None,
+                    },
+                    matcher_value=",".join(sources),
+                )
+                if rag_resp.verdict == "deny":
+                    answers = []
+                elif rag_resp.verdict == "modify":
+                    new_combined = rag_resp.payload.get("content")
+                    if isinstance(new_combined, str):
+                        # Replace the combined answer by collapsing to a single answer entry.
+                        answers = [{"data_sources": sources, "content": new_combined, "is_completion": False}] if new_combined else []
 
             results_payload: Dict[str, Any] = {
                 "query": query,

--- a/atlas/modules/mcp_tools/mcp_execution.py
+++ b/atlas/modules/mcp_tools/mcp_execution.py
@@ -8,7 +8,7 @@ referenced via the client module to preserve test patch targets.
 import asyncio
 import json
 import logging
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from atlas.core.log_sanitizer import sanitize_for_logging
 from atlas.core.metrics_logger import log_metric
@@ -633,11 +633,16 @@ class ExecutionMixin:
         # fail closed if the trusted context has no user.
         args.pop("_atlas_user", None)
         user_email = None
-        selected_data_sources: List[str] = []
+        # ``None`` means "no selection was made for this turn"; ``[]`` means "an
+        # explicit selection of nothing" (e.g. a UserPromptSubmit hook narrowed the
+        # sources away). Collapsing the two would let a narrow-to-nothing decision
+        # fall through to the every-authorized-source default below.
+        selected_data_sources: Optional[List[str]] = None
         compliance_level = None
         if isinstance(context, dict):
             user_email = context.get("user_email")
-            selected_data_sources = list(context.get("selected_data_sources") or [])
+            _ctx_sources = context.get("selected_data_sources")
+            selected_data_sources = list(_ctx_sources) if isinstance(_ctx_sources, list) else None
             compliance_level = context.get("compliance_level")
 
         if not user_email:
@@ -727,9 +732,15 @@ class ExecutionMixin:
             else:
                 sources = []
             if not sources:
-                sources = [s for s in selected_data_sources if isinstance(s, str) and ":" in s]
-            if not sources:
-                sources = deduped_sources
+                if selected_data_sources is None:
+                    # No selection at all for this turn: default to everything the
+                    # user is authorized for.
+                    sources = deduped_sources
+                else:
+                    # An explicit selection is a ceiling, not a hint. An empty list
+                    # means "no sources" -- widening it back to every authorized
+                    # source would undo a hook that narrowed the turn to nothing.
+                    sources = [s for s in selected_data_sources if isinstance(s, str) and ":" in s]
 
             # Authorization gate: only query sources in the user's discovered
             # (group/compliance-authorized) set. ``data_sources`` may be filled
@@ -766,14 +777,16 @@ class ExecutionMixin:
             # MCP sources via rag_mcp.synthesize. Without this split, MCP sources
             # (which live in rag_mcp_config, not rag_sources_config) pass the auth
             # gate but fail unified_rag.query_rag with "RAG source not found".
-            http_groups: Dict[str, List[str]] = {}
-            mcp_groups: Dict[str, List[str]] = {}
-            for source in sources:
-                server_name = source.split(":", 1)[0]
-                if source_origin.get(source) == "mcp":
-                    mcp_groups.setdefault(server_name, []).append(source)
-                else:
-                    http_groups.setdefault(server_name, []).append(source)
+            def _group_sources(srcs: List[str]) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+                http_groups: Dict[str, List[str]] = {}
+                mcp_groups: Dict[str, List[str]] = {}
+                for source in srcs:
+                    server_name = source.split(":", 1)[0]
+                    if source_origin.get(source) == "mcp":
+                        mcp_groups.setdefault(server_name, []).append(source)
+                    else:
+                        http_groups.setdefault(server_name, []).append(source)
+                return http_groups, mcp_groups
 
             async def _query_http(group: List[str]) -> Dict[str, Any]:
                 if not unified_rag:
@@ -800,12 +813,6 @@ class ExecutionMixin:
                     "content": results.get("answer", ""),
                     "is_completion": False,
                 }
-
-            # Run per-server queries concurrently; isolate failures so one backend
-            # error does not discard every other source's answer.
-            group_lists = list(http_groups.values()) + list(mcp_groups.values())
-            coros = [_query_http(g) for g in http_groups.values()]
-            coros += [_query_mcp(g) for g in mcp_groups.values()]
 
             # RagCall hook (GH #713): fires once for the whole agentic atlas_rag_query
             # call (covering both HTTP and MCP sources). HTTP sources skip the
@@ -840,18 +847,6 @@ class ExecutionMixin:
                             _rag_blocked = rag_call.payload.get("reason") or "RAG query narrowed to no sources by hook"
                         else:
                             sources = narrowed
-                            # Rebuild groups for the narrowed source set
-                            http_groups = {}
-                            mcp_groups = {}
-                            for source in sources:
-                                server_name = source.split(":", 1)[0]
-                                if source_origin.get(source) == "mcp":
-                                    mcp_groups.setdefault(server_name, []).append(source)
-                                else:
-                                    http_groups.setdefault(server_name, []).append(source)
-                            group_lists = list(http_groups.values()) + list(mcp_groups.values())
-                            coros = [_query_http(g) for g in http_groups.values()]
-                            coros += [_query_mcp(g) for g in mcp_groups.values()]
 
             if _rag_blocked is not None:
                 return ToolResult(
@@ -860,6 +855,17 @@ class ExecutionMixin:
                     success=False,
                     error=_rag_blocked,
                 )
+
+            # Build the query coroutines only once the RagCall hook has settled the
+            # source set. Constructing them earlier means the deny and narrow paths
+            # discard un-awaited coroutines (a RuntimeWarning on every retrieval)
+            # and force the grouping block to be duplicated for the narrowed set.
+            # Run per-server queries concurrently; isolate failures so one backend
+            # error does not discard every other source's answer.
+            http_groups, mcp_groups = _group_sources(sources)
+            group_lists = list(http_groups.values()) + list(mcp_groups.values())
+            coros = [_query_http(g) for g in http_groups.values()]
+            coros += [_query_mcp(g) for g in mcp_groups.values()]
 
             settled = await asyncio.gather(*coros, return_exceptions=True)
 

--- a/atlas/tests/test_atlas_rag_agent_tools.py
+++ b/atlas/tests/test_atlas_rag_agent_tools.py
@@ -465,3 +465,46 @@ async def test_execute_atlas_rag_query_no_sources_available(monkeypatch):
     assert result.success is False
     assert unified.query_calls == []
     assert unified.batch_calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_atlas_rag_query_falls_back_when_no_selection(monkeypatch):
+    """No ``selected_data_sources`` key at all means "the user chose nothing
+    specific" -- query everything they are authorized for.
+
+    This is the common agent-mode case; collapsing it to ``[]`` upstream would
+    take the "explicitly no sources" branch and break RAG for every such turn.
+    """
+    manager = _manager()
+    unified = FakeUnifiedRAG(discovered=["technical-docs", "policies"])
+    _patch_app_factory(monkeypatch, unified_rag=unified)
+
+    result = await manager.execute_tool(
+        ToolCall(id="call-fb", name="atlas_rag_query", arguments={"query": "q"}),
+        context={"user_email": "test@example.com"},
+    )
+
+    assert result.success is True
+    queried = sorted(unified.query_calls + [s for c in unified.batch_calls for s in c])
+    assert queried == ["atlas_rag:policies", "atlas_rag:technical-docs"]
+
+
+@pytest.mark.asyncio
+async def test_execute_atlas_rag_query_honors_explicit_empty_selection(monkeypatch):
+    """An explicit empty list is a ceiling of zero, not "unset".
+
+    A UserPromptSubmit hook narrowing the turn to no sources must not be
+    widened back to the user's full authorized set.
+    """
+    manager = _manager()
+    unified = FakeUnifiedRAG(discovered=["technical-docs", "policies"])
+    _patch_app_factory(monkeypatch, unified_rag=unified)
+
+    result = await manager.execute_tool(
+        ToolCall(id="call-empty", name="atlas_rag_query", arguments={"query": "q"}),
+        context={"user_email": "test@example.com", "selected_data_sources": []},
+    )
+
+    assert result.success is False
+    assert unified.query_calls == []
+    assert unified.batch_calls == []

--- a/atlas/tests/test_atlas_rag_agent_tools.py
+++ b/atlas/tests/test_atlas_rag_agent_tools.py
@@ -42,13 +42,13 @@ class FakeUnifiedRAG:
             }
         ]
 
-    async def query_rag(self, username, qualified_data_source, messages):
+    async def query_rag(self, username, qualified_data_source, messages, _skip_hooks=False):
         self.query_calls.append(qualified_data_source)
         return SimpleNamespace(
             content=f"Result from {qualified_data_source}", is_completion=False
         )
 
-    async def query_rag_batch(self, username, qualified_data_sources, messages):
+    async def query_rag_batch(self, username, qualified_data_sources, messages, _skip_hooks=False):
         self.batch_calls.append(list(qualified_data_sources))
         return SimpleNamespace(
             content=f"Batched {','.join(qualified_data_sources)}", is_completion=True
@@ -270,11 +270,11 @@ class ComplianceAwareRAG:
         ids = self.by_level.get(user_compliance_level, [])
         return [{"server": "atlas_rag", "sources": [{"id": i} for i in ids]}]
 
-    async def query_rag(self, username, qualified_data_source, messages):
+    async def query_rag(self, username, qualified_data_source, messages, _skip_hooks=False):
         self.query_calls.append(qualified_data_source)
         return SimpleNamespace(content=f"ok {qualified_data_source}", is_completion=False)
 
-    async def query_rag_batch(self, username, qualified_data_sources, messages):
+    async def query_rag_batch(self, username, qualified_data_sources, messages, _skip_hooks=False):
         raise AssertionError("batch not expected in this test")
 
 
@@ -398,12 +398,12 @@ async def test_execute_atlas_rag_query_isolates_partial_failures(monkeypatch):
                 {"server": "srvB", "sources": [{"id": "broken"}]},
             ]
 
-        async def query_rag(self, username, qualified_data_source, messages):
+        async def query_rag(self, username, qualified_data_source, messages, _skip_hooks=False):
             if qualified_data_source == "srvB:broken":
                 raise RuntimeError("backend down")
             return SimpleNamespace(content=f"ok {qualified_data_source}", is_completion=False)
 
-        async def query_rag_batch(self, username, qualified_data_sources, messages):
+        async def query_rag_batch(self, username, qualified_data_sources, messages, _skip_hooks=False):
             raise AssertionError("each server has a single source; batch not expected")
 
     _patch_app_factory(monkeypatch, unified_rag=TwoServerRAG())
@@ -435,7 +435,7 @@ async def test_execute_atlas_rag_query_all_failures_reports_failure(monkeypatch)
     manager = _manager()
 
     class BrokenUnifiedRAG(FakeUnifiedRAG):
-        async def query_rag(self, username, qualified_data_source, messages):
+        async def query_rag(self, username, qualified_data_source, messages, _skip_hooks=False):
             raise RuntimeError("total outage")
 
     unified = BrokenUnifiedRAG(discovered=["technical-docs"])

--- a/atlas/tests/test_hooks_engine.py
+++ b/atlas/tests/test_hooks_engine.py
@@ -652,3 +652,103 @@ class TestHookBlockedError:
         assert err.reason == "policy says no"
         assert "PreLlmCall" in str(err)
         assert "policy says no" in str(err)
+
+
+# ------------------------------------- modify survives a verdict escalation
+
+
+class TestModifiedFlag:
+    """``modified`` must be independent of the ranked verdict.
+
+    Verdicts are ranked (deny > require_approval > modify), so a chain where one
+    hook redacts and a later hook escalates reports ``require_approval``. Call
+    sites gate payload application on ``modified``; gating on
+    ``verdict == "modify"`` would silently drop the redaction.
+    """
+
+    async def test_modify_then_require_approval_keeps_payload(self, tmp_path):
+        redact = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["tool_args"]["secret"] = "[REDACTED]"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        escalate = f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval"}})); sys.exit(0)'
+        s1 = _write_hook(tmp_path, "redact", redact)
+        s2 = _write_hook(tmp_path, "escalate", escalate)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="redact", command=[s1]),
+            HookConfig(name="escalate", command=[s2]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE,
+            {"tool_name": "t", "tool_args": {"secret": "hunter2"}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        # The escalation outranks modify...
+        assert outcome.verdict == "require_approval"
+        # ...but the redaction must not be lost.
+        assert outcome.modified is True
+        assert outcome.payload["tool_args"]["secret"] == "[REDACTED]"
+
+    async def test_modified_false_when_nothing_rewritten(self, tmp_path):
+        noop = f'#!{sys.executable}\nimport sys; sys.exit(0)'
+        s = _write_hook(tmp_path, "noop", noop)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="n", command=[s])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {"a": 1}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.modified is False
+        assert outcome.verdict == "continue"
+
+    async def test_modified_true_on_plain_modify(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["tool_args"]["path"] = "/tmp/safe.txt"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        s = _write_hook(tmp_path, "m", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="m", command=[s])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {"path": "/etc/passwd"}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "modify"
+        assert outcome.modified is True
+
+
+# --------------------------------------------- malformed hooks.json is loud
+
+
+class TestMalformedConfigIsDetected:
+    """A hooks.json that exists but does not parse disables every hook, including
+    the fail-closed ones. That must be reported, not silently equated with
+    "no hooks configured"."""
+
+    def _cm_with_config_dir(self, tmp_path: Path) -> ConfigManager:
+        cm = ConfigManager(atlas_root=Path(__file__).resolve().parents[1])
+        cm._search_paths = lambda filename: [tmp_path / filename]
+        return cm
+
+    def test_malformed_hooks_json_sets_load_failed(self, tmp_path):
+        (tmp_path / "hooks.json").write_text('{"hooks": {,,, broken}')
+        cm = self._cm_with_config_dir(tmp_path)
+        config = cm.hooks_config
+        # Degrades to empty so a broken file cannot take the server down...
+        assert config.hooks == {}
+        # ...but the failure is recorded.
+        assert cm._hooks_config_load_failed is True
+        assert cm.validate_config()["hooks_config"] is False
+
+    def test_absent_hooks_json_is_not_a_failure(self, tmp_path):
+        cm = self._cm_with_config_dir(tmp_path)  # no file written
+        config = cm.hooks_config
+        assert config.hooks == {}
+        assert cm._hooks_config_load_failed is False
+        assert cm.validate_config()["hooks_config"] is True

--- a/atlas/tests/test_hooks_engine.py
+++ b/atlas/tests/test_hooks_engine.py
@@ -1,0 +1,582 @@
+"""Unit tests for the core hook engine (GH #713).
+
+Covers config models, the subprocess contract (stdin envelope, exit codes,
+stdout JSON), composition rules (deny short-circuits, require_approval sticky,
+modify chains), the security model (trusted fields re-asserted, env
+allow-list, no shell), timeout/crash/malformed-output handling, and the
+zero-overhead no-config path.
+
+Hooks here are real tiny executables written into a tmp dir so we exercise the
+actual asyncio subprocess path. They are language-agnostic by construction
+(scripts use the host's python) -- this is the contract operators rely on.
+"""
+
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from atlas.hooks import (
+    HookBlockedError,
+    HookConfig,
+    HookEvent,
+    HookManager,
+    HooksConfig,
+    default_on_error,
+    set_hook_manager_for_testing,
+)
+from atlas.modules.config.config_loader import ConfigManager
+
+# ----------------------------------------------------------- helpers/fixtures
+
+
+def _write_hook(tmp_path: Path, name: str, body: str) -> str:
+    """Write a python hook script and return its absolute path."""
+    p = tmp_path / f"{name}.py"
+    p.write_text(textwrap.dedent(body))
+    p.chmod(0o755)
+    return str(p)
+
+
+def _make_manager(tmp_path: Path, hooks: dict) -> HookManager:
+    """Build a HookManager backed by a ConfigManager whose hooks_config returns
+    the given ``{event_name: [HookConfig, ...]}`` mapping."""
+    cm = ConfigManager(atlas_root=Path(__file__).resolve().parents[1])
+    cm._hooks_config = HooksConfig(hooks=hooks)
+    return HookManager(cm)
+
+
+def _session_ctx(**kw):
+    base = {
+        "session_id": "sess-123",
+        "user_email": "user@example.gov",
+        "compliance_level": 3,
+    }
+    base.update(kw)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    yield
+    set_hook_manager_for_testing(None)
+
+
+# ----------------------------------------------------------------- models
+
+
+class TestHookConfig:
+    def test_matches_wildcard(self):
+        h = HookConfig(name="a", command=["true"])
+        assert h.matches("anything")
+        assert h.matches(None)
+        assert h.matches("")
+
+    def test_matches_regex(self):
+        h = HookConfig(name="a", command=["true"], matcher="filesystem__.*")
+        assert h.matches("filesystem__write_file")
+        assert not h.matches("calc__add")
+        assert not h.matches(None)
+
+    def test_matches_star_literal(self):
+        h = HookConfig(name="a", command=["true"], matcher="*")
+        assert h.matches("anything")
+        assert h.matches(None)
+
+    def test_invalid_regex_does_not_crash(self):
+        h = HookConfig(name="a", command=["true"], matcher="(unclosed")
+        assert h.matches("x") is False  # invalid matcher -> non-match, no raise
+
+    def test_effective_on_error_uses_event_default(self):
+        h = HookConfig(name="a", command=["true"])
+        assert h.effective_on_error(HookEvent.PRE_TOOL_USE) == "deny"
+        assert h.effective_on_error(HookEvent.POST_TOOL_USE) == "allow"
+
+    def test_effective_on_error_explicit_overrides(self):
+        h = HookConfig(name="a", command=["true"], on_error="allow")
+        assert h.effective_on_error(HookEvent.PRE_TOOL_USE) == "allow"
+
+    def test_command_must_be_non_empty(self):
+        with pytest.raises(Exception):
+            HookConfig(name="a", command=[])
+
+    def test_name_must_be_non_empty(self):
+        with pytest.raises(Exception):
+            HookConfig(name=" ", command=["true"])
+
+
+class TestDefaults:
+    def test_security_events_fail_closed(self):
+        for e in (HookEvent.PRE_TOOL_USE, HookEvent.PERMISSION_REQUEST, HookEvent.PRE_LLM_CALL, HookEvent.RAG_CALL):
+            assert default_on_error(e) == "deny", f"{e} should default deny"
+
+    def test_observability_events_fail_open(self):
+        for e in (HookEvent.SESSION_START, HookEvent.SESSION_END, HookEvent.USER_PROMPT_SUBMIT, HookEvent.POST_TOOL_USE, HookEvent.RAG_RESPONSE):
+            assert default_on_error(e) == "allow", f"{e} should default allow"
+
+
+# -------------------------------------------------------------- no-op path
+
+
+class TestZeroOverhead:
+    async def test_no_config_returns_continue_not_fired(self):
+        mgr = _make_manager(Path("/tmp"), hooks={})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE,
+            {"tool_name": "x", "tool_args": {}},
+            session_context=_session_ctx(),
+            matcher_value="x",
+        )
+        assert outcome.verdict == "continue"
+        assert outcome.fired is False
+        assert outcome.hook_names == []
+
+    async def test_has_hooks_false_when_empty(self):
+        mgr = _make_manager(Path("/tmp"), hooks={})
+        assert mgr.has_hooks(HookEvent.PRE_TOOL_USE) is False
+
+    async def test_has_hooks_true_when_registered(self):
+        mgr = _make_manager(Path("/tmp"), hooks={"PreToolUse": [HookConfig(name="a", command=["true"])]})
+        assert mgr.has_hooks(HookEvent.PRE_TOOL_USE) is True
+
+    async def test_config_load_error_treated_as_empty(self):
+        cm = MagicMock()
+        cm.hooks_config = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+        # property on a MagicMock is awkward; instead make the attribute raise
+        cm2 = MagicMock()
+        type(cm2).hooks_config = property(lambda self: 1 / 0)
+        mgr = HookManager(cm2)
+        assert mgr.has_hooks(HookEvent.PRE_TOOL_USE) is False
+        outcome = await mgr.run_event(HookEvent.PRE_TOOL_USE, {}, session_context=_session_ctx())
+        assert outcome.fired is False
+
+
+# --------------------------------------------------------------- contract
+
+
+class TestExitCodeContract:
+    async def test_exit_zero_empty_stdout_is_continue(self, tmp_path):
+        script = _write_hook(tmp_path, "noop", f'#!{sys.executable}\nimport sys; sys.exit(0)')
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="n", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {"a": 1}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "continue"
+        assert outcome.fired is True
+        assert outcome.payload == {"tool_name": "t", "tool_args": {"a": 1}}
+
+    async def test_exit_zero_with_continue_json(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        payload = json.load(sys.stdin)
+        print(json.dumps({{"decision": "continue"}}))
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "cont", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="c", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "continue"
+        assert outcome.fired is True
+
+    async def test_exit_code_two_is_deny_with_stderr_reason(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import sys
+        sys.stderr.write("Writes outside /workspace are blocked by policy")
+        sys.exit(2)
+        """
+        script = _write_hook(tmp_path, "block", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="b", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"
+        assert "Writes outside /workspace" in outcome.reason
+
+    async def test_exit_other_is_error_then_on_error(self, tmp_path):
+        body = f'#!{sys.executable}\nimport sys; sys.exit(1)'
+        script = _write_hook(tmp_path, "err", body)
+        # deny default for PreToolUse
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="e", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"
+        assert "errored" in outcome.reason
+        # allow override for PostToolUse
+        mgr2 = _make_manager(tmp_path, {"PostToolUse": [HookConfig(name="e", command=[script])]})
+        outcome2 = await mgr2.run_event(
+            HookEvent.POST_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome2.verdict == "continue"
+
+
+# --------------------------------------------------------------- modify path
+
+
+class TestModify:
+    async def test_modify_replaces_payload_fields(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        # Rewrite the path argument
+        env["payload"]["tool_args"]["path"] = "/tmp/safe.txt"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "mod", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="m", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE,
+            {"tool_name": "filesystem__write", "tool_args": {"path": "/etc/passwd", "content": "x"}},
+            session_context=_session_ctx(), matcher_value="filesystem__write",
+        )
+        assert outcome.verdict == "modify"
+        assert outcome.payload["tool_args"]["path"] == "/tmp/safe.txt"
+        assert outcome.payload["tool_args"]["content"] == "x"  # untouched fields preserved
+
+    async def test_modify_chains_forward(self, tmp_path):
+        # hook1 sets path; hook2 (sees hook1's output) appends a marker
+        body1 = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["tool_args"]["path"] = "/tmp/safe.txt"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        body2 = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["tool_args"]["note"] = "second saw first"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        s1 = _write_hook(tmp_path, "m1", body1)
+        s2 = _write_hook(tmp_path, "m2", body2)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="m1", command=[s1]),
+            HookConfig(name="m2", command=[s2]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE,
+            {"tool_name": "t", "tool_args": {"path": "/etc/passwd"}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "modify"
+        assert outcome.payload["tool_args"]["path"] == "/tmp/safe.txt"
+        assert outcome.payload["tool_args"]["note"] == "second saw first"
+
+    async def test_modify_with_no_payload_is_ignored(self, tmp_path):
+        body = f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"modify"}})); sys.exit(0)'
+        script = _write_hook(tmp_path, "modn", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="m", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {"a": 1}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        # No payload change -> stays continue (modify with nothing = no-op)
+        assert outcome.verdict == "continue"
+        assert outcome.payload == {"tool_name": "t", "tool_args": {"a": 1}}
+
+
+# ---------------------------------------------------------- composition rules
+
+
+class TestComposition:
+    async def test_deny_short_circuits(self, tmp_path):
+        deny = _write_hook(tmp_path, "deny", f'#!{sys.executable}\nimport sys; sys.stderr.write("no"); sys.exit(2)')
+        # This hook would modify, but deny should short-circuit before it runs
+        cont = _write_hook(tmp_path, "cont", f'#!{sys.executable}\nimport sys; sys.exit(0)')
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="deny", command=[deny]),
+            HookConfig(name="cont", command=[cont]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"
+        assert outcome.hook_names == ["deny"]  # second hook never ran
+
+    async def test_require_approval_is_sticky(self, tmp_path):
+        esc = _write_hook(tmp_path, "esc", f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval","reason":"policy"}})); sys.exit(0)')
+        cont = _write_hook(tmp_path, "cont", f'#!{sys.executable}\nimport sys; sys.exit(0)')
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="esc", command=[esc]),
+            HookConfig(name="cont", command=[cont]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "require_approval"
+        assert outcome.reason == "policy"
+        assert outcome.hook_names == ["esc", "cont"]
+
+    async def test_require_approval_not_downgraded_by_modify(self, tmp_path):
+        esc = _write_hook(tmp_path, "esc", f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval"}})); sys.exit(0)')
+        mod = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["tool_args"]["x"] = 1
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        modscript = _write_hook(tmp_path, "mod", mod)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="esc", command=[esc]),
+            HookConfig(name="mod", command=[modscript]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "require_approval"  # not downgraded to modify
+        assert outcome.payload["tool_args"]["x"] == 1  # but modify still applied
+
+    async def test_deny_beats_require_approval(self, tmp_path):
+        esc = _write_hook(tmp_path, "esc", f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval"}})); sys.exit(0)')
+        deny = _write_hook(tmp_path, "deny", f'#!{sys.executable}\nimport sys; sys.stderr.write("blocked"); sys.exit(2)')
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="esc", command=[esc]),
+            HookConfig(name="deny", command=[deny]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"
+
+
+# -------------------------------------------------------------- security
+
+
+class TestSecurity:
+    async def test_trusted_fields_in_envelope(self, tmp_path):
+        """The stdin envelope carries server-stamped identity/compliance."""
+
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        # write envelope to a side file for inspection
+        with open({str(tmp_path / 'seen.json')!r}, "w") as f:
+            json.dump(env, f)
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "see", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="s", command=[script])]})
+        await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(user_email="real@example.gov", compliance_level=3),
+            matcher_value="t",
+        )
+        seen = json.loads((tmp_path / "seen.json").read_text())
+        assert seen["hook_event_name"] == "PreToolUse"
+        assert seen["session_id"] == "sess-123"
+        assert seen["user_email"] == "real@example.gov"
+        assert seen["compliance_level"] == 3
+        assert "payload" in seen
+
+    async def test_modify_cannot_spoof_trusted_fields(self, tmp_path):
+        """A hook returning identity/compliance in its modify payload cannot
+        overwrite the trusted envelope fields -- they are stripped."""
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["user_email"] = "attacker@example.gov"
+        env["payload"]["compliance_level"] = 99
+        env["payload"]["session_id"] = "spoofed"
+        env["payload"]["tool_args"] = {{"path": "/tmp/safe"}}
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "spoof", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="s", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(user_email="real@example.gov", compliance_level=3),
+            matcher_value="t",
+        )
+        assert outcome.verdict == "modify"
+        # Trusted fields are NOT present in the returned payload (stripped).
+        assert "user_email" not in outcome.payload
+        assert "compliance_level" not in outcome.payload
+        assert "session_id" not in outcome.payload
+        # Mutable change applied.
+        assert outcome.payload["tool_args"]["path"] == "/tmp/safe"
+
+    async def test_env_allowlist_excludes_server_secrets(self, tmp_path):
+        """Hook subprocess gets only a minimal env; server-side secrets set in
+        the parent process are NOT visible to the hook."""
+        body = f"""\
+        #!{sys.executable}
+        import json, os, sys
+        seen = dict(os.environ)
+        with open({str(tmp_path / 'env.json')!r}, "w") as f:
+            json.dump(seen, f)
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "env", body)
+        # Plant a "secret" in the parent env that must NOT leak to the hook.
+        os.environ["ATLAS_PROVIDER_API_KEY_SECRET"] = "super-secret-value"
+        try:
+            mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="e", command=[script])]})
+            await mgr.run_event(
+                HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+                session_context=_session_ctx(), matcher_value="t",
+            )
+        finally:
+            del os.environ["ATLAS_PROVIDER_API_KEY_SECRET"]
+        seen = json.loads((tmp_path / "env.json").read_text())
+        assert "ATLAS_PROVIDER_API_KEY_SECRET" not in seen
+        assert "ATLAS_CONFIG_DIR" in seen
+        assert "ATLAS_PROJECT_DIR" in seen
+
+    async def test_command_interpolation(self, tmp_path):
+        """${ATLAS_CONFIG_DIR} in command argv is expanded to the config dir."""
+        body = f'#!{sys.executable}\nimport sys; sys.exit(0)'
+        target = tmp_path / "interp.py"
+        target.write_text(textwrap.dedent(body))
+        target.chmod(0o755)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="i", command=["${ATLAS_CONFIG_DIR}/interp.py"]),
+        ]})
+        # Point config_dir at tmp_path so interpolation resolves to our script.
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+            config_dir=str(tmp_path), project_dir=str(tmp_path),
+        )
+        assert outcome.verdict == "continue"
+        assert outcome.fired is True
+
+
+# ---------------------------------------------------------- failure modes
+
+
+class TestFailureModes:
+    async def test_timeout_kills_and_uses_on_error(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import time, sys
+        time.sleep(30)
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "slow", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="s", command=[script], timeout_ms=200),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        # PreToolUse default on_error is deny
+        assert outcome.verdict == "deny"
+        assert "timeout" in outcome.reason
+
+    async def test_missing_executable(self, tmp_path):
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="m", command=["/no/such/exec/here"]),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"
+        assert "executable not found" in outcome.reason or "errored" in outcome.reason
+
+    async def test_non_json_stdout_on_exit_zero(self, tmp_path):
+        body = f'#!{sys.executable}\nimport sys; print("not json"); sys.exit(0)'
+        script = _write_hook(tmp_path, "bad", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="b", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"  # error -> default deny for PreToolUse
+
+    async def test_malformed_decision_json(self, tmp_path):
+        body = f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"bogus"}})); sys.exit(0)'
+        script = _write_hook(tmp_path, "bad", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="b", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "deny"  # invalid decision -> error -> deny
+
+    async def test_bounded_output(self, tmp_path):
+        """A hook emitting >1MB of stdout is treated as error (overflow)."""
+        body = f"""\
+        #!{sys.executable}
+        import sys
+        sys.stdout.write("x" * (2 * 1024 * 1024))
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "loud", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="l", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        # The huge stdout is not valid JSON -> error -> deny
+        assert outcome.verdict == "deny"
+
+
+# ----------------------------------------------------------- matcher filter
+
+
+class TestMatcherFilter:
+    async def test_non_matching_hook_does_not_fire(self, tmp_path):
+        fired = _write_hook(tmp_path, "f", f'#!{sys.executable}\nimport sys; sys.exit(0)')
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="f", command=[fired], matcher="filesystem__.*"),
+        ]})
+        # matcher_value does not match -> hook skipped, fired=False
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "calc__add", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="calc__add",
+        )
+        assert outcome.fired is False
+        assert outcome.verdict == "continue"
+
+    async def test_matching_hook_fires(self, tmp_path):
+        fired = _write_hook(tmp_path, "f", f'#!{sys.executable}\nimport sys; sys.exit(0)')
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="f", command=[fired], matcher="filesystem__.*"),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "filesystem__write", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="filesystem__write",
+        )
+        assert outcome.fired is True
+
+
+# ------------------------------------------------------- HookBlockedError
+
+
+class TestHookBlockedError:
+    def test_carries_event_and_reason(self):
+        err = HookBlockedError(HookEvent.PRE_LLM_CALL, "policy says no")
+        assert err.event == HookEvent.PRE_LLM_CALL
+        assert err.reason == "policy says no"
+        assert "PreLlmCall" in str(err)
+        assert "policy says no" in str(err)

--- a/atlas/tests/test_hooks_engine.py
+++ b/atlas/tests/test_hooks_engine.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from atlas.hooks import (
     HookBlockedError,
@@ -87,9 +88,34 @@ class TestHookConfig:
         assert h.matches("anything")
         assert h.matches(None)
 
-    def test_invalid_regex_does_not_crash(self):
-        h = HookConfig(name="a", command=["true"], matcher="(unclosed")
-        assert h.matches("x") is False  # invalid matcher -> non-match, no raise
+    def test_invalid_regex_is_rejected_at_config_load(self):
+        # A malformed matcher must fail validation rather than silently never
+        # matching: on a fail-closed event that would quietly delete a control.
+        with pytest.raises(ValidationError, match="not a valid regex"):
+            HookConfig(name="a", command=["true"], matcher="(unclosed")
+
+    def test_invalid_regex_built_directly_fires_rather_than_skips(self):
+        # Bypassing validation (model_construct) should still not silently
+        # disable the hook -- an uncompilable pattern errs toward firing.
+        h = HookConfig.model_construct(name="a", command=["true"], matcher="(unclosed")
+        assert h.matches("x") is True
+
+    def test_matcher_on_matcherless_event_warns_at_load(self, caplog):
+        # SessionStart supplies no matcher value, so this hook can never fire.
+        # The operator must learn that at load time, not by noticing their policy
+        # silently never ran.
+        with caplog.at_level("WARNING"):
+            HooksConfig(hooks={"SessionStart": [
+                HookConfig(name="never-fires", command=["true"], matcher="something"),
+            ]})
+        assert any("will never fire" in r.getMessage() for r in caplog.records)
+
+    def test_wildcard_matcher_on_matcherless_event_does_not_warn(self, caplog):
+        with caplog.at_level("WARNING"):
+            HooksConfig(hooks={"SessionStart": [
+                HookConfig(name="fine", command=["true"], matcher="*"),
+            ]})
+        assert not [r for r in caplog.records if "will never fire" in r.getMessage()]
 
     def test_effective_on_error_uses_event_default(self):
         h = HookConfig(name="a", command=["true"])
@@ -491,6 +517,52 @@ class TestFailureModes:
         # PreToolUse default on_error is deny
         assert outcome.verdict == "deny"
         assert "timeout" in outcome.reason
+
+    async def test_output_over_cap_is_killed_and_treated_as_error(self, tmp_path):
+        # The cap must be enforced while reading, not by truncating a buffer that
+        # already holds the whole stream: a hook emitting far more than the cap
+        # would otherwise be fully buffered in server memory first.
+        body = f"""\
+        #!{sys.executable}
+        import sys
+        chunk = "x" * 65536
+        try:
+            for _ in range(200):          # ~13 MB, well over the 1 MB cap
+                sys.stdout.write(chunk)
+                sys.stdout.flush()
+        except Exception:
+            pass
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "flood", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [
+            HookConfig(name="f", command=[script], timeout_ms=20000),
+        ]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        # PreToolUse fails closed, and a truncated stream is never parsed as a
+        # decision.
+        assert outcome.verdict == "deny"
+        assert "1 MB" in outcome.reason
+
+    async def test_output_within_the_cap_is_returned_intact(self, tmp_path):
+        payload = "y" * 10000
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{"tool_args": {{"blob": "{payload}"}}}}}}))
+        sys.exit(0)
+        """
+        script = _write_hook(tmp_path, "chatty", body)
+        mgr = _make_manager(tmp_path, {"PreToolUse": [HookConfig(name="c", command=[script])]})
+        outcome = await mgr.run_event(
+            HookEvent.PRE_TOOL_USE, {"tool_name": "t", "tool_args": {}},
+            session_context=_session_ctx(), matcher_value="t",
+        )
+        assert outcome.verdict == "modify"
+        assert outcome.payload["tool_args"]["blob"] == payload
 
     async def test_missing_executable(self, tmp_path):
         mgr = _make_manager(tmp_path, {"PreToolUse": [

--- a/atlas/tests/test_hooks_integration.py
+++ b/atlas/tests/test_hooks_integration.py
@@ -691,3 +691,90 @@ class TestNoConfigInvariant:
         monkeypatch.setattr(UnifiedRAGService, "_query_rag_impl", fake_impl)
         await svc.query_rag("u", "atlas_rag:docs", [{"role": "user", "content": "q"}])
         assert spawned == []
+
+
+# ------------------------------------ None vs [] data-source plumbing (#786)
+
+
+class TestDataSourceSelectionPlumbing:
+    """``selected_data_sources`` carries a three-state meaning end to end.
+
+    ``None``/absent = the user selected nothing specific, so ``atlas_rag_query``
+    falls back to every authorized source. ``[]`` = an explicit ceiling of zero
+    (e.g. a ``UserPromptSubmit`` hook narrowed the turn to no sources).
+
+    Collapsing either into the other breaks a boundary in one direction or the
+    other: ``None -> []`` silently disables RAG for ordinary agent turns, and
+    ``[] -> None`` widens a narrowing hook into the *widest* possible query.
+    """
+
+    def _run_agent_loop(self, data_sources):
+        """Run one agent step and return the session_context it built."""
+        from unittest.mock import patch
+        from uuid import uuid4
+
+        from atlas.application.chat.agent.agentic_loop import AgenticLoop
+        from atlas.application.chat.agent.protocols import AgentContext
+        from atlas.domain.messages.models import ConversationHistory, Message, MessageRole
+        from atlas.interfaces.llm import LLMResponse
+
+        captured = {}
+
+        async def fake_execute_multiple_tools(**kwargs):
+            captured["session_context"] = kwargs["session_context"]
+            r = MagicMock()
+            r.content = "3"
+            r.tool_call_id = "tc1"
+            return [r]
+
+        history = ConversationHistory()
+        history.add_message(Message(role=MessageRole.USER, content="hi"))
+        context = AgentContext(
+            session_id=uuid4(), user_email="user@example.com", files={}, history=history,
+        )
+
+        responses = [
+            LLMResponse(content="", tool_calls=[{
+                "id": "tc1", "type": "function",
+                "function": {"name": "calc_add", "arguments": '{"a": 1}'},
+            }]),
+            LLMResponse(content="done"),
+        ]
+        llm = MagicMock()
+        llm.call_with_tools = AsyncMock(side_effect=list(responses))
+        # A non-empty source list routes through the RAG-aware entry point.
+        llm.call_with_rag_and_tools = AsyncMock(side_effect=list(responses))
+
+        connection = MagicMock()
+        connection.send_json = AsyncMock()
+        loop = AgenticLoop(
+            llm=llm, tool_manager=MagicMock(), prompt_provider=None, connection=connection,
+        )
+
+        async def event_handler(evt):
+            pass
+
+        with patch("atlas.application.chat.agent.agentic_loop.error_handler.safe_get_tools_schema",
+                   new=AsyncMock(return_value=[])), \
+             patch("atlas.application.chat.agent.agentic_loop.tool_executor.execute_multiple_tools",
+                   new=fake_execute_multiple_tools):
+            asyncio.run(loop.run(
+                model="m", messages=[{"role": "user", "content": "hi"}],
+                context=context, selected_tools=["calc_add"], data_sources=data_sources,
+                max_steps=5, temperature=0.7, event_handler=event_handler, streaming=False,
+            ))
+        return captured["session_context"]
+
+    def test_agent_mode_no_selection_stays_none(self):
+        # Regression: `data_sources or []` here made every no-selection agent
+        # turn look like an explicit "query nothing".
+        sc = self._run_agent_loop(None)
+        assert sc["selected_data_sources"] is None
+
+    def test_agent_mode_explicit_empty_is_preserved(self):
+        sc = self._run_agent_loop([])
+        assert sc["selected_data_sources"] == []
+
+    def test_agent_mode_selection_is_passed_through(self):
+        sc = self._run_agent_loop(["atlas_rag:docs"])
+        assert sc["selected_data_sources"] == ["atlas_rag:docs"]

--- a/atlas/tests/test_hooks_integration.py
+++ b/atlas/tests/test_hooks_integration.py
@@ -100,6 +100,18 @@ class TestSessionStart:
         with pytest.raises(Exception):
             await svc.create_session(uuid.uuid4(), "u@example.gov")
 
+    async def test_deny_does_not_persist_the_session(self, tmp_path):
+        # The hook must run before session_repository.create(). If the row is
+        # written first, deny is only a one-message speed bump: the caller's next
+        # message finds the session via get() and is answered normally.
+        deny = _write_hook(tmp_path, "deny2", f'#!{sys.executable}\nimport sys; sys.stderr.write("nope"); sys.exit(2)')
+        _install_hooks(tmp_path, {"SessionStart": [HookConfig(name="d", command=[deny])]})
+        svc, repo = _make_chat_service(tmp_path)
+        sid = uuid.uuid4()
+        with pytest.raises(Exception):
+            await svc.create_session(sid, "u@example.gov")
+        assert await repo.get(sid) is None
+
     async def test_modify_attaches_session_metadata(self, tmp_path):
         body = f"""\
         #!{sys.executable}
@@ -152,6 +164,8 @@ def _make_orchestrator():
         agent_mode=None,
     )
     orch.event_publisher.publish_response_complete = AsyncMock()
+    orch.event_publisher.publish_chat_response = AsyncMock()
+    orch.rag_mode.run_streaming = AsyncMock(return_value={"type": "chat_response", "message": "rag"})
     return orch, repo, plain
 
 
@@ -174,6 +188,57 @@ class TestUserPromptSubmit:
         assert result["message"] == "prompt blocked"
         plain.run_streaming.assert_not_awaited()
         orch.event_publisher.publish_response_complete.assert_awaited_once()
+        # The reason must be published before the turn completes, or a
+        # streaming client ends the turn with nothing rendered.
+        orch.event_publisher.publish_chat_response.assert_awaited_once_with("prompt blocked")
+
+    async def test_modify_can_narrow_but_not_widen_tools_and_sources(self, tmp_path):
+        # A hook returning entries the user never selected must not grant them:
+        # the payload is intersected with the caller's selection.
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{
+            "selected_data_sources": ["atlas_rag:ok", "atlas_rag:smuggled"],
+        }}}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "widen", body)
+        _install_hooks(tmp_path, {"UserPromptSubmit": [HookConfig(name="w", command=[h])]})
+        orch, repo, plain = _make_orchestrator()
+        sid = uuid.uuid4()
+        await repo.create(Session(id=sid, user_email="u@example.gov"))
+        await orch.execute(
+            session_id=sid, content="hi", model="m",
+            selected_data_sources=["atlas_rag:ok"],
+        )
+        kwargs = orch.rag_mode.run_streaming.await_args.kwargs
+        sources = kwargs.get("data_sources") or kwargs.get("selected_data_sources") or []
+        assert "atlas_rag:smuggled" not in sources
+        assert "atlas_rag:ok" in sources
+
+    async def test_modify_narrowing_to_empty_is_preserved(self, tmp_path):
+        # [] means "none". Collapsing it to None would widen the turn back to
+        # the caller's full selection.
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{"selected_data_sources": []}}}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "empty", body)
+        _install_hooks(tmp_path, {"UserPromptSubmit": [HookConfig(name="e", command=[h])]})
+        orch, repo, plain = _make_orchestrator()
+        sid = uuid.uuid4()
+        await repo.create(Session(id=sid, user_email="u@example.gov"))
+        await orch.execute(
+            session_id=sid, content="hi", model="m",
+            selected_data_sources=["atlas_rag:docs"],
+        )
+        # [] is falsy, so the turn routes to plain mode -- RAG is skipped entirely
+        # rather than falling back to the caller's original source list.
+        plain.run_streaming.assert_awaited_once()
+        orch.rag_mode.run_streaming.assert_not_awaited()
 
     async def test_modify_rewrites_prompt(self, tmp_path):
         # The rewritten prompt should reach the mode runner's messages.
@@ -289,7 +354,7 @@ class TestToolEvents:
         assert result.success is False
         assert "result blocked" in result.content
 
-    async def test_permission_request_require_approval_forces_gate(self, tmp_path):
+    async def test_permission_request_require_approval_forces_gate(self, tmp_path, monkeypatch):
         body = f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval"}})); sys.exit(0)'
         h = _write_hook(tmp_path, "esc", body)
         tool_call, tool_manager, sc = self._setup(tmp_path, {"PermissionRequest": [HookConfig(name="e", command=[h])]})
@@ -302,7 +367,9 @@ class TestToolEvents:
         fake_mgr = MagicMock()
         fake_mgr.create_approval_request.return_value = fake_request
         fake_mgr.cleanup_request = MagicMock()
-        te.get_approval_manager = lambda: fake_mgr
+        # monkeypatch (not a bare rebind) so the module is restored even if the
+        # assertions below fail -- otherwise the stub leaks into later tests.
+        monkeypatch.setattr(te, "get_approval_manager", lambda: fake_mgr)
         cb = AsyncMock()
         result = await execute_single_tool(
             tool_call, sc, tool_manager, update_callback=cb, config_manager=None, skip_approval=True,
@@ -312,6 +379,105 @@ class TestToolEvents:
 
 
 # ------------------------------------------------------------- PreLlmCall
+
+
+class TestApprovalEscalationBoundaries:
+    """A hook may force the approval gate, but not redefine who can satisfy it,
+    and an auto-approval must not survive a later rewrite of the arguments."""
+
+    def _setup(self, tmp_path, hooks):
+        return TestToolEvents._setup(TestToolEvents(), tmp_path, hooks)
+
+    async def _run_with_capture(self, tool_call, sc, tool_manager, skip_approval=True):
+        """Run the tool with a stub approval manager; return the captured request."""
+        from atlas.application.chat.utilities import tool_executor as te
+        captured = {}
+
+        def _create(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(
+                wait_for_response=AsyncMock(
+                    return_value={"approved": True, "arguments": None, "reason": ""}
+                ),
+            )
+
+        fake_mgr = MagicMock()
+        fake_mgr.create_approval_request.side_effect = _create
+        fake_mgr.cleanup_request = MagicMock()
+
+        events = []
+
+        async def _cb(payload):
+            events.append(payload)
+
+        original = te.get_approval_manager
+        te.get_approval_manager = lambda: fake_mgr
+        try:
+            result = await execute_single_tool(
+                tool_call, sc, tool_manager, update_callback=_cb,
+                config_manager=None, skip_approval=skip_approval,
+            )
+        finally:
+            te.get_approval_manager = original
+        captured["events"] = events
+        return result, fake_mgr, captured
+
+    async def test_require_approval_does_not_escalate_to_admin_only(self, tmp_path):
+        # require_approval means "enter the gate", not "only an admin may approve":
+        # escalating to admin would produce a request a normal user cannot satisfy.
+        body = f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval"}})); sys.exit(0)'
+        h = _write_hook(tmp_path, "esc2", body)
+        tool_call, tool_manager, sc = self._setup(
+            tmp_path, {"PermissionRequest": [HookConfig(name="e", command=[h])]}
+        )
+        result, fake_mgr, captured = await self._run_with_capture(tool_call, sc, tool_manager)
+        assert result.success is True
+        fake_mgr.create_approval_request.assert_called_once()
+        requests = [e for e in captured["events"] if e.get("type") == "tool_approval_request"]
+        assert requests, "the hook should have forced an approval request"
+        # The gate is entered, but it stays a user-approvable gate.
+        assert requests[0]["admin_required"] is False
+
+    async def test_pre_tool_use_cannot_auto_approve(self, tmp_path):
+        # PermissionRequest may lower the gate; PreToolUse may only raise it.
+        # A PreToolUse hook setting needs_approval=False must be ignored.
+        body = f'#!{sys.executable}\nimport json,sys; ' \
+               f'print(json.dumps({{"decision":"modify","payload":{{"needs_approval":False}}}})); sys.exit(0)'
+        h = _write_hook(tmp_path, "sneaky", body)
+        tool_call, tool_manager, sc = self._setup(
+            tmp_path, {"PreToolUse": [HookConfig(name="s", command=[h])]}
+        )
+        result, fake_mgr, captured = await self._run_with_capture(
+            tool_call, sc, tool_manager, skip_approval=False,
+        )
+        assert result.success is True
+        fake_mgr.create_approval_request.assert_called_once()
+
+    async def test_pre_tool_use_arg_rewrite_revokes_auto_approval(self, tmp_path):
+        # PermissionRequest auto-approves the args it saw; PreToolUse then swaps
+        # them. The approval no longer covers what runs, so the gate must return.
+        approve = _write_hook(
+            tmp_path, "autoapprove",
+            f'#!{sys.executable}\nimport json,sys; '
+            f'print(json.dumps({{"decision":"modify","payload":{{"needs_approval":False}}}})); sys.exit(0)',
+        )
+        rewrite = _write_hook(
+            tmp_path, "rewrite",
+            f'#!{sys.executable}\nimport json,sys; '
+            f'print(json.dumps({{"decision":"modify","payload":{{"tool_args":{{"path":"/tmp/other"}}}}}})); sys.exit(0)',
+        )
+        tool_call, tool_manager, sc = self._setup(tmp_path, {
+            "PermissionRequest": [HookConfig(name="a", command=[approve])],
+            "PreToolUse": [HookConfig(name="r", command=[rewrite])],
+        })
+        result, fake_mgr, _ = await self._run_with_capture(
+            tool_call, sc, tool_manager, skip_approval=False,
+        )
+        assert result.success is True
+        # Without the revocation the rewritten args would have inherited the
+        # auto-approval and run with no gate at all.
+        fake_mgr.create_approval_request.assert_called_once()
 
 
 class TestPreLlmCall:

--- a/atlas/tests/test_hooks_integration.py
+++ b/atlas/tests/test_hooks_integration.py
@@ -1,0 +1,527 @@
+"""Integration tests for the wired hook events (GH #713).
+
+These exercise the actual call-site wiring (not just the engine): each event
+is fired at its real chokepoint with a real subprocess hook, asserting the
+verdict translation into the host behavior (deny -> blocked response/result,
+modify -> applied mutation, require_approval -> escalation, continue ->
+transparent). The zero-overhead no-config path is also asserted per event so a
+missing hooks.json provably never spawns a process.
+"""
+
+import asyncio
+import sys
+import textwrap
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from atlas.application.chat.orchestrator import ChatOrchestrator
+from atlas.application.chat.utilities.tool_executor import execute_single_tool
+from atlas.domain.messages.models import ToolResult
+from atlas.domain.sessions.models import Session
+from atlas.domain.unified_rag_service import UnifiedRAGService
+from atlas.hooks import HookBlockedError, HookConfig, HooksConfig, set_hook_manager_for_testing
+from atlas.infrastructure.sessions.in_memory_repository import InMemorySessionRepository
+from atlas.modules.config.config_loader import ConfigManager
+
+
+def _real_litellm_caller_cls():
+    """Return the real LiteLLMCaller class, working around a pre-existing
+    test-isolation quirk: ``test_capability_tokens_and_injection`` replaces
+    ``sys.modules["atlas.modules.llm.litellm_caller"]`` with a fake at import
+    time and only restores it via a module-scoped fixture that runs after its
+    own tests. When those tests are deselected (e.g. ``-k``), the fake persists
+    for the whole session, so a plain ``from ... import LiteLLMCaller`` binds to
+    ``_FakeLLM``. We detect that and fall back to the saved original module.
+    """
+    import atlas.modules.llm.litellm_caller as mod
+
+    cls = getattr(mod, "LiteLLMCaller", None)
+    if cls is not None and "test_capability_tokens_and_injection" not in getattr(cls, "__module__", ""):
+        return cls
+    try:
+        from atlas.tests.test_capability_tokens_and_injection import _ORIGINAL_LITELLM_MODULE
+
+        return _ORIGINAL_LITELLM_MODULE.LiteLLMCaller
+    except Exception:
+        return cls  # last resort: whatever is bound
+
+
+def _write_hook(tmp_path: Path, name: str, body: str) -> str:
+    p = tmp_path / f"{name}.py"
+    p.write_text(textwrap.dedent(body))
+    p.chmod(0o755)
+    return str(p)
+
+
+def _install_hooks(tmp_path: Path, hooks: dict) -> None:
+    """Install a HookManager singleton with the given {event: [HookConfig]}."""
+    cm = ConfigManager(atlas_root=Path(__file__).resolve().parents[1])
+    cm._hooks_config = HooksConfig(hooks=hooks)
+    from atlas.hooks.manager import HookManager
+
+    real = HookManager(cm)
+    set_hook_manager_for_testing(real)
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks():
+    yield
+    set_hook_manager_for_testing(None)
+
+
+# ---------------------------------------------------------- SessionStart/End
+
+
+def _make_chat_service(tmp_path):
+    from atlas.application.chat.service import ChatService
+
+    cm = ConfigManager(atlas_root=Path(__file__).resolve().parents[1])
+    repo = InMemorySessionRepository()
+    svc = ChatService(llm=MagicMock(), session_repository=repo, config_manager=cm)
+    return svc, repo
+
+
+class TestSessionStart:
+    async def test_no_config_transparent(self):
+        svc, repo = _make_chat_service(Path("/tmp"))
+        sid = uuid.uuid4()
+        session = await svc.create_session(sid, "u@example.gov")
+        assert session.id == sid
+        assert session.user_email == "u@example.gov"
+
+    async def test_deny_blocks_creation(self, tmp_path):
+        deny = _write_hook(tmp_path, "deny", f'#!{sys.executable}\nimport sys; sys.stderr.write("denied by policy"); sys.exit(2)')
+        _install_hooks(tmp_path, {"SessionStart": [HookConfig(name="d", command=[deny])]})
+        svc, repo = _make_chat_service(tmp_path)
+        with pytest.raises(Exception):
+            await svc.create_session(uuid.uuid4(), "u@example.gov")
+
+    async def test_modify_attaches_session_metadata(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{"tenant": "doe"}}}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "meta", body)
+        _install_hooks(tmp_path, {"SessionStart": [HookConfig(name="m", command=[h])]})
+        svc, repo = _make_chat_service(tmp_path)
+        sid = uuid.uuid4()
+        session = await svc.create_session(sid, "u@example.gov")
+        assert session.context.get("tenant") == "doe"
+
+
+class TestSessionEnd:
+    async def test_no_config_transparent(self):
+        svc, repo = _make_chat_service(Path("/tmp"))
+        sid = uuid.uuid4()
+        await svc.create_session(sid, "u@example.gov")
+        await svc.end_session(sid)  # no error
+        session = await repo.get(sid)
+        assert session.active is False
+
+    async def test_failing_hook_does_not_break_teardown(self, tmp_path):
+        bad = _write_hook(tmp_path, "bad", f'#!{sys.executable}\nimport sys; sys.exit(1)')
+        _install_hooks(tmp_path, {"SessionEnd": [HookConfig(name="b", command=[bad])]})
+        svc, repo = _make_chat_service(tmp_path)
+        sid = uuid.uuid4()
+        await svc.create_session(sid, "u@example.gov")
+        await svc.end_session(sid)  # must not raise
+        session = await repo.get(sid)
+        assert session.active is False
+
+
+# ---------------------------------------------------------- UserPromptSubmit
+
+
+def _make_orchestrator():
+    repo = InMemorySessionRepository()
+    plain = MagicMock()
+    plain.run_streaming = AsyncMock(return_value={"type": "chat_response", "message": "plain"})
+    orch = ChatOrchestrator(
+        llm=MagicMock(),
+        event_publisher=MagicMock(),
+        session_repository=repo,
+        plain_mode=plain,
+        rag_mode=MagicMock(),
+        tools_mode=MagicMock(),
+        agent_mode=None,
+    )
+    orch.event_publisher.publish_response_complete = AsyncMock()
+    return orch, repo, plain
+
+
+class TestUserPromptSubmit:
+    async def test_no_config_routes_normally(self):
+        orch, repo, plain = _make_orchestrator()
+        sid = uuid.uuid4()
+        await repo.create(Session(id=sid, user_email="u@example.gov"))
+        result = await orch.execute(session_id=sid, content="Hello", model="m")
+        plain.run_streaming.assert_awaited_once()
+        assert result["type"] == "chat_response"
+
+    async def test_deny_blocks_turn_with_message(self, tmp_path):
+        deny = _write_hook(tmp_path, "deny", f'#!{sys.executable}\nimport sys; sys.stderr.write("prompt blocked"); sys.exit(2)')
+        _install_hooks(tmp_path, {"UserPromptSubmit": [HookConfig(name="d", command=[deny])]})
+        orch, repo, plain = _make_orchestrator()
+        sid = uuid.uuid4()
+        await repo.create(Session(id=sid, user_email="u@example.gov"))
+        result = await orch.execute(session_id=sid, content="secret", model="m")
+        assert result["message"] == "prompt blocked"
+        plain.run_streaming.assert_not_awaited()
+        orch.event_publisher.publish_response_complete.assert_awaited_once()
+
+    async def test_modify_rewrites_prompt(self, tmp_path):
+        # The rewritten prompt should reach the mode runner's messages.
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{"prompt": "[REDACTED] hello"}}}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "redact", body)
+        _install_hooks(tmp_path, {"UserPromptSubmit": [HookConfig(name="r", command=[h])]})
+        orch, repo, plain = _make_orchestrator()
+        sid = uuid.uuid4()
+        await repo.create(Session(id=sid, user_email="u@example.gov"))
+        await orch.execute(session_id=sid, content="secret", model="m")
+        # The mode runner received messages with the rewritten last user content.
+        _kwargs = plain.run_streaming.call_args.kwargs
+        messages = _kwargs.get("messages") or plain.run_streaming.call_args.args
+        # messages is a list of dicts; last user message should be redacted.
+        user_msgs = [m for m in messages if m.get("role") == "user"]
+        assert user_msgs and "[REDACTED] hello" in user_msgs[-1]["content"]
+
+
+# --------------------------------------------------------- PreToolUse/etc.
+
+
+class TestToolEvents:
+    def _setup(self, tmp_path, hooks):
+        _install_hooks(tmp_path, hooks)
+        # build a tool_manager mock + tool_call + session_context
+        tool_call = SimpleNamespace(
+            id="call-1",
+            function=SimpleNamespace(name="filesystem__write_file", arguments='{"path": "/etc/passwd"}'),
+        )
+        tool_manager = MagicMock()
+        tool_manager.get_server_for_tool.return_value = "filesystem"
+        tool_manager.get_tools_schema.return_value = [
+            {"function": {"name": "filesystem__write_file", "parameters": {"properties": {"path": {}, "content": {}}}}}
+        ]
+        tool_manager.execute_tool = AsyncMock(return_value=ToolResult(
+            tool_call_id="call-1", content="wrote file", success=True
+        ))
+        session_context = {"session_id": "s1", "user_email": "u@example.gov", "compliance_level": 3}
+        return tool_call, tool_manager, session_context
+
+    async def test_no_config_executes_normally(self, tmp_path):
+        tool_call, tool_manager, sc = self._setup(tmp_path, {})
+        result = await execute_single_tool(
+            tool_call, sc, tool_manager, update_callback=AsyncMock(),
+            config_manager=ConfigManager(atlas_root=Path(__file__).resolve().parents[1]),
+            skip_approval=True,
+        )
+        assert result.success is True
+        tool_manager.execute_tool.assert_awaited_once()
+
+    async def test_pre_tool_use_deny_blocks_execution(self, tmp_path):
+        deny = _write_hook(tmp_path, "d", f'#!{sys.executable}\nimport sys; sys.stderr.write("fs blocked"); sys.exit(2)')
+        tool_call, tool_manager, sc = self._setup(tmp_path, {"PreToolUse": [HookConfig(name="d", command=[deny])]})
+        result = await execute_single_tool(
+            tool_call, sc, tool_manager, update_callback=AsyncMock(),
+            config_manager=None, skip_approval=True,
+        )
+        assert result.success is False
+        assert "fs blocked" in result.content
+        tool_manager.execute_tool.assert_not_awaited()
+
+    async def test_pre_tool_use_modify_rewrites_args_and_reinjects_user(self, tmp_path):
+        # The tool schema declares _atlas_user? No -> re-injection is a no-op here,
+        # but the path arg should be rewritten by the hook.
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["tool_args"] = {{"path": "/tmp/safe.txt"}}
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "mod", body)
+        tool_call, tool_manager, sc = self._setup(tmp_path, {"PreToolUse": [HookConfig(name="m", command=[h])]})
+        result = await execute_single_tool(
+            tool_call, sc, tool_manager, update_callback=AsyncMock(),
+            config_manager=None, skip_approval=True,
+        )
+        assert result.success is True
+        executed = tool_manager.execute_tool.call_args.args[0]
+        assert executed.arguments["path"] == "/tmp/safe.txt"
+
+    async def test_post_tool_use_modify_replaces_result_content(self, tmp_path):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["result_content"] = "[REDACTED RESULT]"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "post", body)
+        tool_call, tool_manager, sc = self._setup(tmp_path, {"PostToolUse": [HookConfig(name="p", command=[h])]})
+        result = await execute_single_tool(
+            tool_call, sc, tool_manager, update_callback=AsyncMock(),
+            config_manager=None, skip_approval=True,
+        )
+        assert result.success is True
+        assert "[REDACTED RESULT]" in result.content
+
+    async def test_post_tool_use_deny_replaces_with_error(self, tmp_path):
+        deny = _write_hook(tmp_path, "d", f'#!{sys.executable}\nimport sys; sys.stderr.write("result blocked"); sys.exit(2)')
+        tool_call, tool_manager, sc = self._setup(tmp_path, {"PostToolUse": [HookConfig(name="d", command=[deny])]})
+        result = await execute_single_tool(
+            tool_call, sc, tool_manager, update_callback=AsyncMock(),
+            config_manager=None, skip_approval=True,
+        )
+        assert result.success is False
+        assert "result blocked" in result.content
+
+    async def test_permission_request_require_approval_forces_gate(self, tmp_path):
+        body = f'#!{sys.executable}\nimport json,sys; print(json.dumps({{"decision":"require_approval"}})); sys.exit(0)'
+        h = _write_hook(tmp_path, "esc", body)
+        tool_call, tool_manager, sc = self._setup(tmp_path, {"PermissionRequest": [HookConfig(name="e", command=[h])]})
+        # With skip_approval=True, normally no gate; the hook should force it.
+        # The approval manager will wait; we short-circuit by patching it to auto-approve.
+        from atlas.application.chat.utilities import tool_executor as te
+        fake_request = SimpleNamespace(
+            wait_for_response=AsyncMock(return_value={"approved": True, "arguments": None, "reason": ""}),
+        )
+        fake_mgr = MagicMock()
+        fake_mgr.create_approval_request.return_value = fake_request
+        fake_mgr.cleanup_request = MagicMock()
+        te.get_approval_manager = lambda: fake_mgr
+        cb = AsyncMock()
+        result = await execute_single_tool(
+            tool_call, sc, tool_manager, update_callback=cb, config_manager=None, skip_approval=True,
+        )
+        assert result.success is True
+        fake_mgr.create_approval_request.assert_called_once()  # gate was entered
+
+
+# ------------------------------------------------------------- PreLlmCall
+
+
+class TestPreLlmCall:
+    def _caller(self, tmp_path, monkeypatch):
+        # Build a LiteLLMCaller and stub model resolution so the test does not
+        # depend on which models happen to be in the active llmconfig (which
+        # varies with collection context). The hook fires after resolution, so
+        # we make resolution a deterministic no-op.
+        caller = _real_litellm_caller_cls()()
+        monkeypatch.setattr(caller, "_get_litellm_model_name", lambda name: name)
+        monkeypatch.setattr(caller, "_get_model_kwargs", lambda name, t=None, user_email=None: {})
+        return caller
+
+    async def test_no_config_proceeds(self, tmp_path, monkeypatch):
+        caller = self._caller(tmp_path, monkeypatch)
+        async def fake_acompletion(**kwargs):
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+        monkeypatch.setattr("atlas.modules.llm.litellm_caller.acompletion", fake_acompletion)
+        out = await caller.call_plain("gpt-4o", [{"role": "user", "content": "hi"}], user_email="u@example.gov")
+        assert out == "ok"
+
+    async def test_deny_raises_hook_blocked(self, tmp_path, monkeypatch):
+        deny = _write_hook(tmp_path, "d", f'#!{sys.executable}\nimport sys; sys.stderr.write("llm blocked"); sys.exit(2)')
+        _install_hooks(tmp_path, {"PreLlmCall": [HookConfig(name="d", command=[deny])]})
+        caller = self._caller(tmp_path, monkeypatch)
+        async def fake_acompletion(**kwargs):
+            raise AssertionError("must not reach provider")
+        monkeypatch.setattr("atlas.modules.llm.litellm_caller.acompletion", fake_acompletion)
+        with pytest.raises(HookBlockedError) as ei:
+            await caller.call_plain("gpt-4o", [{"role": "user", "content": "hi"}], user_email="u@example.gov")
+        assert "llm blocked" in ei.value.reason
+
+    async def test_modify_rewrites_messages(self, tmp_path, monkeypatch):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["messages"] = [{{"role": "user", "content": "[REDACTED]"}}]
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "redact", body)
+        _install_hooks(tmp_path, {"PreLlmCall": [HookConfig(name="r", command=[h])]})
+        caller = self._caller(tmp_path, monkeypatch)
+        seen = {}
+        async def fake_acompletion(**kwargs):
+            seen["messages"] = kwargs["messages"]
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+        monkeypatch.setattr("atlas.modules.llm.litellm_caller.acompletion", fake_acompletion)
+        await caller.call_plain("gpt-4o", [{"role": "user", "content": "secret"}], user_email="u@example.gov")
+        assert seen["messages"][-1]["content"] == "[REDACTED]"
+
+
+# ----------------------------------------------------------- RagCall/Response
+
+
+class TestRagHooks:
+    def _service(self, tmp_path):
+        cm = ConfigManager(atlas_root=Path(__file__).resolve().parents[1])
+        from atlas.domain.unified_rag_service import UnifiedRAGService
+        svc = UnifiedRAGService(cm)
+        return svc
+
+    async def test_no_config_passes_through(self, tmp_path, monkeypatch):
+        svc = self._service(tmp_path)
+        async def fake_impl(self_, username, qds, messages):
+            return SimpleNamespace(content="rag answer", metadata=None, is_completion=False)
+        monkeypatch.setattr(UnifiedRAGService, "_query_rag_impl", fake_impl)
+        resp = await svc.query_rag("u@example.gov", "atlas_rag:docs", [{"role": "user", "content": "q"}])
+        assert resp.content == "rag answer"
+
+    async def test_rag_call_deny_returns_empty(self, tmp_path, monkeypatch):
+        deny = _write_hook(tmp_path, "d", f'#!{sys.executable}\nimport sys; sys.stderr.write("no rag"); sys.exit(2)')
+        _install_hooks(tmp_path, {"RagCall": [HookConfig(name="d", command=[deny])]})
+        svc = self._service(tmp_path)
+        called = {"v": False}
+        async def fake_impl(self_, username, qds, messages):
+            called["v"] = True
+            return SimpleNamespace(content="should not see", metadata=None, is_completion=False)
+        monkeypatch.setattr(UnifiedRAGService, "_query_rag_impl", fake_impl)
+        resp = await svc.query_rag("u@example.gov", "atlas_rag:docs", [{"role": "user", "content": "q"}])
+        assert resp.content == ""
+        assert called["v"] is False
+
+    async def test_rag_call_modify_rewrites_query(self, tmp_path, monkeypatch):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{"query": "rewritten query"}}}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "rw", body)
+        _install_hooks(tmp_path, {"RagCall": [HookConfig(name="r", command=[h])]})
+        svc = self._service(tmp_path)
+        seen = {}
+        async def fake_impl(self_, username, qds, messages):
+            seen["messages"] = messages
+            return SimpleNamespace(content="a", metadata=None, is_completion=False)
+        monkeypatch.setattr(UnifiedRAGService, "_query_rag_impl", fake_impl)
+        await svc.query_rag("u@example.gov", "atlas_rag:docs", [{"role": "user", "content": "original"}])
+        assert seen["messages"][-1]["content"] == "rewritten query"
+
+    async def test_rag_response_modify_replaces_content(self, tmp_path, monkeypatch):
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        env = json.load(sys.stdin)
+        env["payload"]["content"] = "[REDACTED CONTEXT]"
+        print(json.dumps({{"decision": "modify", "payload": env["payload"]}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "rr", body)
+        _install_hooks(tmp_path, {"RagResponse": [HookConfig(name="r", command=[h])]})
+        svc = self._service(tmp_path)
+        async def fake_impl(self_, username, qds, messages):
+            return SimpleNamespace(content="secret context", metadata=None, is_completion=False)
+        monkeypatch.setattr(UnifiedRAGService, "_query_rag_impl", fake_impl)
+        resp = await svc.query_rag("u@example.gov", "atlas_rag:docs", [{"role": "user", "content": "q"}])
+        assert resp.content == "[REDACTED CONTEXT]"
+
+    async def test_batch_narrowing_drops_unlisted_sources(self, tmp_path, monkeypatch):
+        # Hook narrows to a subset; sources it lists that weren't in the original
+        # must be dropped (cannot widen).
+        body = f"""\
+        #!{sys.executable}
+        import json, sys
+        print(json.dumps({{"decision": "modify", "payload": {{"qualified_data_sources": ["atlas_rag:docs", "atlas_rag:EVIL"]}}}}))
+        sys.exit(0)
+        """
+        h = _write_hook(tmp_path, "narrow", body)
+        _install_hooks(tmp_path, {"RagCall": [HookConfig(name="n", command=[h])]})
+        svc = self._service(tmp_path)
+        seen = {}
+        async def fake_impl(self_, username, qds, messages):
+            seen["qds"] = list(qds)
+            return SimpleNamespace(content="a", metadata=None, is_completion=False)
+        monkeypatch.setattr(UnifiedRAGService, "_query_rag_batch_impl", fake_impl)
+        await svc.query_rag_batch("u@example.gov", ["atlas_rag:docs", "atlas_rag:news"], [{"role": "user", "content": "q"}])
+        # EVIL was dropped (not in original); news was dropped by the hook; only docs survives.
+        assert seen["qds"] == ["atlas_rag:docs"]
+
+
+# --------------------------------------------------------- no-config invariant
+
+
+class TestNoConfigInvariant:
+    """Every wired event must be a complete no-op (no subprocess) with no hooks."""
+
+    async def test_create_session_no_subprocess(self, tmp_path, monkeypatch):
+        spawned = []
+        async def fake_exec(*a, **k):
+            spawned.append(1)
+            raise RuntimeError("should not spawn")
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        s, _ = _make_chat_service(tmp_path)
+        await s.create_session(uuid.uuid4(), "u@example.gov")
+        assert spawned == []
+
+    async def test_orchestrator_no_subprocess(self, monkeypatch):
+        spawned = []
+        async def fake_exec(*a, **k):
+            spawned.append(1)
+            raise RuntimeError("should not spawn")
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        orch, repo, _ = _make_orchestrator()
+        sid = uuid.uuid4()
+        await repo.create(Session(id=sid, user_email="u@example.gov"))
+        await orch.execute(session_id=sid, content="hi", model="m")
+        assert spawned == []
+
+    async def test_tool_executor_no_subprocess(self, tmp_path, monkeypatch):
+        spawned = []
+        async def fake_exec(*a, **k):
+            spawned.append(1)
+            raise RuntimeError("should not spawn")
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        tc = SimpleNamespace(id="c1", function=SimpleNamespace(name="t", arguments="{}"))
+        tm = MagicMock()
+        tm.get_server_for_tool.return_value = "s"
+        tm.get_tools_schema.return_value = [{"function": {"name": "t", "parameters": {"properties": {}}}}]
+        tm.execute_tool = AsyncMock(return_value=ToolResult(tool_call_id="c1", content="ok", success=True))
+        await execute_single_tool(tc, {"user_email": "u"}, tm, update_callback=AsyncMock(), skip_approval=True)
+        assert spawned == []
+
+    async def test_llm_caller_no_subprocess(self, monkeypatch):
+        spawned = []
+        async def fake_exec(*a, **k):
+            spawned.append(1)
+            raise RuntimeError("should not spawn")
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        caller = _real_litellm_caller_cls()()
+        monkeypatch.setattr(caller, "_get_litellm_model_name", lambda name: name)
+        monkeypatch.setattr(caller, "_get_model_kwargs", lambda name, t=None, user_email=None: {})
+        async def fake_acompletion(**kwargs):
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+        monkeypatch.setattr("atlas.modules.llm.litellm_caller.acompletion", fake_acompletion)
+        await caller.call_plain("gpt-4o", [{"role": "user", "content": "hi"}])
+        assert spawned == []
+
+    async def test_rag_no_subprocess(self, tmp_path, monkeypatch):
+        spawned = []
+        async def fake_exec(*a, **k):
+            spawned.append(1)
+            raise RuntimeError("should not spawn")
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        cm = ConfigManager(atlas_root=Path(__file__).resolve().parents[1])
+        from atlas.domain.unified_rag_service import UnifiedRAGService
+        svc = UnifiedRAGService(cm)
+        async def fake_impl(self_, username, qds, messages):
+            return SimpleNamespace(content="a", metadata=None, is_completion=False)
+        monkeypatch.setattr(UnifiedRAGService, "_query_rag_impl", fake_impl)
+        await svc.query_rag("u", "atlas_rag:docs", [{"role": "user", "content": "q"}])
+        assert spawned == []

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -10,6 +10,7 @@ For administrators responsible for deploying, configuring, and managing Atlas UI
 - [MCP Server Configuration](mcp-servers.md) - Setting up and configuring MCP tool servers
 - [LLM Configuration](llm-config.md) - Configuring Large Language Models
 - [RAG Configuration](external-rag-api.md) - Configuring RAG providers (mock, ATLAS API, MCP)
+- [Lifecycle Hooks](hooks.md) - Config-driven bash/python hooks at chat lifecycle events (audit, redaction, approval gates)
 - [Model Capabilities Enforcement](model-capabilities-2026-04-02.md) - Declaring and enforcing per-model tool/vision support
 
 ## Security & Access Control

--- a/docs/admin/hooks.md
+++ b/docs/admin/hooks.md
@@ -1,0 +1,227 @@
+# Hook system (config-driven lifecycle hooks)
+
+Atlas supports an **opt-in, config-driven hook system** modeled on Claude Code
+and OpenCode: an operator writes a bash or Python script, registers it in
+`config/hooks.json` against a lifecycle event, and Atlas runs it as a
+subprocess at that point in the turn. The event payload arrives as **JSON on
+stdin**; the script's **JSON on stdout** (plus its exit code) can allow,
+modify, block, or escalate the operation.
+
+This is the substrate for governed controls (audit, redaction, approval gates,
+policy enforcement) without scattering one-off checks through the core loop.
+See [GH #713](https://github.com/sandialabs/atlas-ui-3/issues/713) for the
+design proposal.
+
+> Hooks are **operator-installed code running with server privileges** — the
+> same trust level as `config/mcp.json` entries. Write access to
+> `config/hooks.json` is equivalent to code execution as the server user.
+> Untrusted hooks are out of scope.
+
+## Quick start
+
+1. Create `config/hooks.json` (next to your `mcp.json`, in the user config dir
+   resolved by `APP_CONFIG_DIR`, default `config/`):
+
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [
+         {
+           "name": "block-destructive-fs",
+           "matcher": "filesystem__.*",
+           "command": ["${ATLAS_CONFIG_DIR}/hooks/block_destructive.py"],
+           "timeout_ms": 2000
+         }
+       ]
+     }
+   }
+   ```
+
+2. Put the script at `config/hooks/block_destructive.py` and make it executable.
+
+3. Restart Atlas (config is loaded through `ConfigManager`, so hook changes
+   follow the same reload story as the rest of Atlas config).
+
+With no `config/hooks.json`, the hook system is **completely disabled** — no
+subprocess is ever spawned and the hot path pays only a cached-property lookup.
+This is asserted by the test suite (`TestNoConfigInvariant`).
+
+## Configuration reference
+
+Each hook entry under `hooks.<EventName>` is:
+
+| Field        | Type                | Default | Description                                                                 |
+| ------------ | ------------------- | ------- | -------------------------------------------------------------------------- |
+| `name`       | string (required)   | —       | Identifier used in logs/audit spans.                                       |
+| `matcher`    | string (regex)      | `"*"`   | Regex over the event's matcher value (tool name / RAG source). `*`/omit = all. |
+| `command`    | string[] (required) | —       | argv array, spawned with **no shell**. Supports `${ATLAS_CONFIG_DIR}` and `${ATLAS_PROJECT_DIR}` interpolation. |
+| `timeout_ms` | int                 | `2000`  | Wall-clock budget; on expiry the process is killed and `on_error` applies. |
+| `on_error`   | `"deny"` / `"allow"` | per-event default | Outcome when the hook crashes, times out, or emits malformed output. |
+
+`on_error` defaults are **per-event** (see table below) and can be overridden
+per-hook. Security/interceptor events fail **closed** (`deny`): a crashing hook
+must not silently weaken a boundary. Observability/lifecycle events fail
+**open** (`allow`): a broken audit hook should not take down the chat turn.
+
+Multiple hooks per event run **sequentially in config order**, each seeing the
+previous hook's `modify` output. The first `deny` short-circuits the chain; a
+`require_approval` is sticky and cannot be downgraded by a later hook.
+
+## Events
+
+| Event               | Fires at                                          | Hook can                                                                 | on_error default |
+| ------------------- | ------------------------------------------------- | ------------------------------------------------------------------------ | ---------------- |
+| `SessionStart`      | `ChatService.create_session`                      | Attach session metadata (`modify`); reject the session (`deny`).         | `allow`          |
+| `UserPromptSubmit`  | `ChatOrchestrator.execute`, after user msg added  | Rewrite/redact the prompt; narrow tools/sources; block the turn (`deny`). | `allow`       |
+| `PreLlmCall`        | `call_plain` / `call_with_tools` (+ streaming)    | Inspect/redact outgoing messages; swap the model; block the call.       | `deny`           |
+| `PreToolUse` ⭐     | `execute_single_tool`, before invoke              | Mutate tool args (re-injected with security params after); deny; force approval. | `deny`     |
+| `PostToolUse`       | `execute_single_tool`, after invoke              | Transform/redact the result; annotate; deny (replace with error).       | `allow`          |
+| `PermissionRequest` | `execute_single_tool`, at the approval gate      | Auto-approve / auto-deny / escalate to a human; add audit reason.       | `deny`           |
+| `RagCall`          | `UnifiedRAGService.query_rag(_batch)` + agentic   | Rewrite the query; narrow sources (batch, cannot widen); block retrieval. | `deny`        |
+| `RagResponse`      | after retrieval, before prompt injection         | Redact/replace synthesized content; filter chunks; block (empty result). | `allow`        |
+| `SessionEnd`        | `ChatService.end_session`                         | Flush audit records; notify. (Cannot block; deny is treated as continue.) | `allow`       |
+
+⭐ **PreToolUse** is the most powerful control point: every tool call — tools
+mode *and* the agentic loop — passes through `execute_single_tool`, so one hook
+uniformly governs arguments, denial, and approval escalation.
+
+## The contract
+
+### stdin (envelope)
+
+A JSON object with a stable envelope plus an event-specific `payload`:
+
+```json
+{
+  "hook_event_name": "PreToolUse",
+  "session_id": "...",
+  "user_email": "user@example.gov",
+  "compliance_level": 3,
+  "payload": {
+    "tool_name": "filesystem__write_file",
+    "tool_args": { "path": "/etc/passwd", "content": "..." },
+    "tool_call_id": "call-1"
+  }
+}
+```
+
+`user_email` and `compliance_level` are **informational** — they are stamped
+server-side and re-asserted after the hook returns regardless of what the hook
+says (a hook can never widen or spoof identity/compliance).
+
+### Exit codes (the fast path)
+
+| Exit code | Meaning                                                                 |
+| --------- | ----------------------------------------------------------------------- |
+| `0`       | Continue. If stdout is non-empty JSON, apply it; if empty, no change.  |
+| `2`       | **Block.** stderr is surfaced as the reason.                            |
+| other     | Error. Handled per `on_error` (`deny` or `allow`); always logged/audited. |
+
+The simplest useful hook is three lines of bash with no JSON emitted at all.
+
+### stdout (the structured path)
+
+```json
+{ "decision": "modify", "payload": { "tool_args": { "path": "/tmp/safe.txt" } } }
+{ "decision": "deny", "reason": "Writes outside /workspace are blocked by policy" }
+{ "decision": "require_approval", "reason": "Cross-domain network call" }
+{ "decision": "continue" }
+```
+
+- **`continue`** — no change (also the meaning of exit 0 with empty stdout).
+- **`modify`** — replace the mutable part of the payload (prompt text, tool
+  args, tool result, LLM messages, RAG query/content). Core re-applies
+  security-critical invariants after (e.g. re-injects `_atlas_user` into tool
+  args) and validates against the original schema.
+- **`deny`** — short-circuit. For tools this becomes an error `ToolResult` so
+  the loop continues gracefully; for prompt/LLM events the reason surfaces to
+  the user.
+- **`require_approval`** — (PreToolUse / PermissionRequest) force the runtime
+  approval gate even if it would have passed. Sticky across hooks.
+
+## Security & governance
+
+- A hook can **tighten but never widen** a boundary. Server-side identity
+  (`user_email`) and trusted `compliance_level` are re-injected after any
+  `modify`. For tool args, `_atlas_user` and other security-critical parameters
+  are re-applied — the same rule already used for user-edited args in
+  `tool_executor.py`.
+- `modify` on `RagCall` (batch) may **narrow** the source list; sources the
+  hook lists that were not in the original request are dropped. A hook can
+  never add a source outside the compliance-filtered allow-list.
+- `PermissionRequest` may auto-approve (`modify` with `needs_approval: false`)
+  or escalate (`require_approval`). `PreToolUse` may escalate but **cannot
+  auto-approve** — a hook may never lower a boundary another hook raised.
+- Every hook invocation emits an OpenTelemetry span (`hook.event`) with the
+  event name, verdict, exit code, and duration (no raw prompts/args/outputs —
+  see the telemetry sensitive-data policy). The audit trail flows through the
+  existing OTel pipeline.
+- **Environment allow-list**: hooks get `PATH`, `HOME`, `LANG`, `SYSTEMROOT`,
+  `USER`, plus `ATLAS_CONFIG_DIR` and `ATLAS_PROJECT_DIR`. They do **not**
+  inherit the server's full environment (which holds provider API keys).
+- **Bounded output**: stdout/stderr are capped at 1 MB; overflow is treated as
+  a hook error (handled per `on_error`).
+
+## Example hooks
+
+### Block destructive filesystem writes (bash)
+
+```bash
+#!/usr/bin/env bash
+# config/hooks/block_destructive.sh  (PreToolUse, matcher "filesystem__.*")
+read -r envelope
+path=$(echo "$envelope" | jq -r '.payload.tool_args.path // empty')
+case "$path" in
+  /etc/*|/var/*|/usr/*|/root/*)
+    echo "Writes to $path are blocked by policy" >&2
+    exit 2
+    ;;
+esac
+exit 0
+```
+
+### Redact PII from prompts (python)
+
+```python
+#!/usr/bin/env python3
+# config/hooks/redact_pii.py  (UserPromptSubmit)
+import json, re, sys
+env = json.load(sys.stdin)
+prompt = env["payload"]["prompt"]
+redacted = re.sub(r"\b\d{3}-\d{2}-\d{4}\b", "[REDACTED-SSN]", prompt)
+if redacted != prompt:
+    print(json.dumps({"decision": "modify", "payload": {"prompt": redacted}}))
+sys.exit(0)
+```
+
+### Force approval for cross-domain network tools (python)
+
+```python
+#!/usr/bin/env python3
+# config/hooks/require_approval_network.py  (PreToolUse)
+import json, sys
+env = json.load(sys.stdin)
+if env["payload"]["tool_name"].startswith("http_") or env["payload"]["tool_name"].startswith("fetch_"):
+    print(json.dumps({"decision": "require_approval", "reason": "Cross-domain network call requires approval"}))
+sys.exit(0)
+```
+
+### Audit every tool call (bash, fire-and-forget style)
+
+```bash
+#!/usr/bin/env bash
+# config/hooks/audit.sh  (PostToolUse, on_error: allow)
+read -r envelope
+echo "$envelope" >> "${ATLAS_PROJECT_DIR}/logs/tool-audit.jsonl"
+exit 0
+```
+
+## Relationship to existing extension points
+
+- **MCP tools** are how the model invokes external capabilities. Hooks are how
+  an operator governs those invocations at lifecycle boundaries. They
+  complement, not replace, MCP.
+- The **`EventPublisher`** is the outbound UI event sink; hooks are the
+  *inbound/interceptor* counterpart.
+- Hooks are **not** a sandbox and **not** a marketplace. A hook is
+  operator-installed code with server privileges.

--- a/docs/admin/hooks.md
+++ b/docs/admin/hooks.md
@@ -1,7 +1,8 @@
 # Hook system (config-driven lifecycle hooks)
 
-Atlas supports an **opt-in, config-driven hook system** modeled on Claude Code
-and OpenCode: an operator writes a bash or Python script, registers it in
+Atlas supports an **opt-in, config-driven hook system** modeled on the
+lifecycle-hook pattern common to agent CLIs: an operator writes a bash or
+Python script, registers it in
 `config/hooks.json` against a lifecycle event, and Atlas runs it as a
 subprocess at that point in the turn. The event payload arrives as **JSON on
 stdin**; the script's **JSON on stdout** (plus its exit code) can allow,
@@ -29,7 +30,7 @@ design proposal.
          {
            "name": "block-destructive-fs",
            "matcher": "filesystem__.*",
-           "command": ["${ATLAS_CONFIG_DIR}/hooks/block_destructive.py"],
+           "command": ["${ATLAS_CONFIG_DIR}/hooks/block_destructive.sh"],
            "timeout_ms": 2000
          }
        ]
@@ -37,7 +38,7 @@ design proposal.
    }
    ```
 
-2. Put the script at `config/hooks/block_destructive.py` and make it executable.
+2. Put the script at `config/hooks/block_destructive.sh` and make it executable.
 
 3. Restart Atlas (config is loaded through `ConfigManager`, so hook changes
    follow the same reload story as the rest of Atlas config).
@@ -53,7 +54,7 @@ Each hook entry under `hooks.<EventName>` is:
 | Field        | Type                | Default | Description                                                                 |
 | ------------ | ------------------- | ------- | -------------------------------------------------------------------------- |
 | `name`       | string (required)   | —       | Identifier used in logs/audit spans.                                       |
-| `matcher`    | string (regex)      | `"*"`   | Regex over the event's matcher value (tool name / RAG source). `*`/omit = all. |
+| `matcher`    | string (regex)      | `"*"`   | Regex over the event's matcher value (tool name / RAG source). `*`/omit = all. Compiled at load time (an invalid regex is a config error). `SessionStart`/`SessionEnd`/`UserPromptSubmit` supply no matcher value, so setting one there means the hook **never fires** — a warning is logged at load. |
 | `command`    | string[] (required) | —       | argv array, spawned with **no shell**. Supports `${ATLAS_CONFIG_DIR}` and `${ATLAS_PROJECT_DIR}` interpolation. |
 | `timeout_ms` | int                 | `2000`  | Wall-clock budget; on expiry the process is killed and `on_error` applies. |
 | `on_error`   | `"deny"` / `"allow"` | per-event default | Outcome when the hook crashes, times out, or emits malformed output. |
@@ -74,14 +75,14 @@ previous hook's `modify` output. The first `deny` short-circuits the chain; a
 | `SessionStart`      | `ChatService.create_session`                      | Attach session metadata (`modify`); reject the session (`deny`).         | `allow`          |
 | `UserPromptSubmit`  | `ChatOrchestrator.execute`, after user msg added  | Rewrite/redact the prompt; narrow tools/sources; block the turn (`deny`). | `allow`       |
 | `PreLlmCall`        | `call_plain` / `call_with_tools` (+ streaming)    | Inspect/redact outgoing messages; swap the model; block the call.       | `deny`           |
-| `PreToolUse` ⭐     | `execute_single_tool`, before invoke              | Mutate tool args (re-injected with security params after); deny; force approval. | `deny`     |
+| `PreToolUse` (*)   | `execute_single_tool`, before invoke              | Mutate tool args (re-injected with security params after); deny; force approval. | `deny`     |
 | `PostToolUse`       | `execute_single_tool`, after invoke              | Transform/redact the result; annotate; deny (replace with error).       | `allow`          |
 | `PermissionRequest` | `execute_single_tool`, at the approval gate      | Auto-approve / auto-deny / escalate to a human; add audit reason.       | `deny`           |
 | `RagCall`          | `UnifiedRAGService.query_rag(_batch)` + agentic   | Rewrite the query; narrow sources (batch, cannot widen); block retrieval. | `deny`        |
-| `RagResponse`      | after retrieval, before prompt injection         | Redact/replace synthesized content; filter chunks; block (empty result). | `allow`        |
+| `RagResponse`      | after retrieval, before prompt injection         | Redact/replace the synthesized `content`; block (empty result). Only `payload["content"]` is read back -- returned metadata is ignored. | `allow`        |
 | `SessionEnd`        | `ChatService.end_session`                         | Flush audit records; notify. (Cannot block; deny is treated as continue.) | `allow`       |
 
-⭐ **PreToolUse** is the most powerful control point: every tool call — tools
+(*) **PreToolUse** is the most powerful control point: every tool call — tools
 mode *and* the agentic loop — passes through `execute_single_tool`, so one hook
 uniformly governs arguments, denial, and approval escalation.
 
@@ -148,10 +149,22 @@ The simplest useful hook is three lines of bash with no JSON emitted at all.
   `tool_executor.py`.
 - `modify` on `RagCall` (batch) may **narrow** the source list; sources the
   hook lists that were not in the original request are dropped. A hook can
-  never add a source outside the compliance-filtered allow-list.
+  never add a source outside the compliance-filtered allow-list. The same rule
+  applies to `UserPromptSubmit`: `selected_tools` / `selected_data_sources` are
+  intersected with what the user actually selected, and an explicitly empty
+  list means *none* (it is never re-widened to the original selection).
 - `PermissionRequest` may auto-approve (`modify` with `needs_approval: false`)
   or escalate (`require_approval`). `PreToolUse` may escalate but **cannot
-  auto-approve** — a hook may never lower a boundary another hook raised.
+  auto-approve** — a hook may never lower a boundary another hook raised. If a
+  `PreToolUse` hook rewrites the arguments after a `PermissionRequest`
+  auto-approval, that approval is **revoked**: it covered the arguments the
+  first hook inspected, not the ones that would now run.
+- `require_approval` forces the approval gate but does **not** make the request
+  admin-only; the tool's own `admin_required` setting stays authoritative, so a
+  hook cannot produce a request the requesting user is unable to satisfy.
+- A `PreLlmCall` hook that swaps `model` has the replacement re-checked against
+  the same per-model group ACL the orchestrator applied to the original
+  selection; an unauthorized swap is refused and the original model is kept.
 - Every hook invocation emits an OpenTelemetry span (`hook.event`) with the
   event name, verdict, exit code, and duration (no raw prompts/args/outputs —
   see the telemetry sensitive-data policy). The audit trail flows through the
@@ -159,8 +172,16 @@ The simplest useful hook is three lines of bash with no JSON emitted at all.
 - **Environment allow-list**: hooks get `PATH`, `HOME`, `LANG`, `SYSTEMROOT`,
   `USER`, plus `ATLAS_CONFIG_DIR` and `ATLAS_PROJECT_DIR`. They do **not**
   inherit the server's full environment (which holds provider API keys).
-- **Bounded output**: stdout/stderr are capped at 1 MB; overflow is treated as
-  a hook error (handled per `on_error`).
+- **Bounded output**: stdout/stderr are capped at 1 MB *at read time* — the
+  child is killed as soon as its combined output crosses the cap, so a runaway
+  hook cannot be buffered into server memory first. Overflow is treated as a
+  hook error (handled per `on_error`); the truncated prefix is never parsed as
+  a decision.
+- A `SessionStart` `deny` runs **before** the session is persisted, so a
+  rejected session leaves no row behind for a retry to pick up.
+- A malformed `hooks.json` disables every hook. `ConfigManager.validate_config`
+  reports `hooks_config: false` in that case — treat it as a failed security
+  control, not a warning.
 
 ## Example hooks
 

--- a/docs/admin/hooks.md
+++ b/docs/admin/hooks.md
@@ -229,13 +229,28 @@ sys.exit(0)
 
 ### Audit every tool call (bash, fire-and-forget style)
 
+> **Envelopes are secret-bearing.** `tool_args` can contain tokenized download
+> URLs (HMAC capability tokens), file paths, and prompt text; `result_content`
+> carries retrieved document text. Log a projection, not the raw envelope — or
+> treat the audit log itself as a secret store.
+
 ```bash
 #!/usr/bin/env bash
 # config/hooks/audit.sh  (PostToolUse, on_error: allow)
-read -r envelope
-echo "$envelope" >> "${ATLAS_PROJECT_DIR}/logs/tool-audit.jsonl"
+envelope="$(cat)"
+python3 -c '
+import json, sys
+env = json.load(sys.stdin); p = env.get("payload") or {}
+args = p.get("tool_args") or {}
+json.dump({"user_email": env.get("user_email"), "tool_name": p.get("tool_name"),
+           "arg_keys": sorted(args) if isinstance(args, dict) else None,
+           "result_success": p.get("result_success")}, sys.stdout)
+sys.stdout.write("\n")
+' <<<"$envelope" >> "${ATLAS_PROJECT_DIR}/logs/tool-audit.jsonl"
 exit 0
 ```
+
+See `atlas/config/hooks-example/audit_tool.sh` for the full version.
 
 ## Relationship to existing extension points
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ atlas = [
     "config/*.md",
     "config/prompts/*.md",
     "config/mcp-example-configs/*.json",
+    "config/hooks-example/*",
     "mcp/**/*",
     "static/**/*",
 ]


### PR DESCRIPTION
## Summary

Implements the config-driven hook system proposed in #713. An operator writes a bash/python script, registers it in `config/hooks.json` against a lifecycle event, and Atlas runs it as a subprocess at that chokepoint. The event payload arrives as **JSON on stdin**; the script's **JSON on stdout** (plus exit code) can allow, modify, block, or escalate the operation. Modeled on Claude Code / OpenCode hooks.

This is the substrate for governed controls (audit, redaction, approval gates, policy enforcement) without scattering one-off checks through the core loop.

### Scope: all 8 events from the proposal

| Event | Anchor | Hook can |
| --- | --- | --- |
| `SessionStart` | `ChatService.create_session` | attach metadata, reject session |
| `UserPromptSubmit` | `ChatOrchestrator.execute` | rewrite/redact prompt, narrow tools/sources, block turn |
| `PreLlmCall` | `LiteLLMCaller` call_plain/call_with_tools (+ streaming leaves) | inspect/redact messages, swap model, block call |
| `PreToolUse` ⭐ | `tool_executor.execute_single_tool` | mutate args (re-injected), deny, force approval |
| `PostToolUse` | `tool_executor.execute_single_tool` | transform/redact result, deny |
| `PermissionRequest` | `tool_executor.execute_single_tool` approval gate | auto-approve / auto-deny / escalate |
| `RagCall` / `RagResponse` | `UnifiedRAGService.query_rag(_batch)` + agentic path | rewrite query, narrow sources (cannot widen), filter chunks, block |
| `SessionEnd` | `ChatService.end_session` | audit/notify |

## Engine (`atlas/hooks/`)
- Pydantic `HookConfig`/`HooksConfig` + `HookEvent` enum with **per-event `on_error` defaults** (security events fail-closed = `deny`; observability/lifecycle fail-open = `allow`).
- `HookManager`: **zero-overhead when no `hooks.json`** (no subprocess; the test suite asserts this invariant per event), `asyncio.create_subprocess_exec` (**never `shell=True`**), per-hook timeout (kills on expiry), minimal env allow-list (hooks do **not** inherit provider API keys), bounded 1 MB stdout/stderr.
- Exit-code contract: `0` = continue (apply stdout JSON if present), `2` = deny (stderr = reason), other = error → `on_error`.
- Composition: sequential in config order, **first `deny` short-circuits**, **`require_approval` is sticky** (cannot be downgraded by a later hook).
- **Security model**: trusted envelope fields (`session_id`, `user_email`, `compliance_level`) are stamped server-side and re-asserted after every `modify`; for tool args, `_atlas_user` and other security-critical parameters are re-injected (same rule already used for user-edited args). A hook can **tighten but never widen** a boundary.

## Config integration
- `ConfigManager.hooks_config` loads `config/hooks.json` via the existing `_search_paths` two-layer lookup, cached and cleared by `reload_configs()`.
- New `AppSettings.hooks_config_file` (default `hooks.json`, env `HOOKS_CONFIG_FILE`).

## Tests
- **64 new tests** (`test_hooks_engine.py` + `test_hooks_integration.py`): config models, subprocess contract, composition rules, security (trusted-field re-injection, env allow-list, no-shell), failure modes, matcher filtering, per-event wiring, plus a **no-config no-subprocess invariant** for every wired event.
- Updated 4 mock signatures in `test_atlas_rag_agent_tools.py` for the new `query_rag(_batch)` `_skip_hooks` kwarg.
- Full suite: **2242 passed, 17 skipped**. `ruff` clean on all changed files.

## Docs & examples
- `docs/hooks.md`: full reference.
- `atlas/config/hooks-example/`: runnable example hooks + illustrative `hooks.json` (not auto-loaded).

## Decisions on the proposal's open questions
1. Payload schemas — one per event, full replacement of the mutable part.
2. `modify` granularity — full replacement; trusted fields stripped and re-asserted.
3. Per-group enablement — single global list for v1; operators filter on envelope `user_email`/`compliance_level`.
4. Observability tier — PostToolUse/RagResponse/SessionEnd default `on_error: allow`; non-blocking variant is a follow-up.
5. Outbound UI events — not in v1 (reserved stdout key is a follow-up).
6. vs MCP tools — hooks govern invocations at lifecycle boundaries; MCP tools are how the model invokes capabilities.

Out of scope for v1: sandboxing untrusted hooks, non-blocking observability variant, outbound UI-event emission, per-group enablement.

Closes #713.