### PR TITLE
ci: publish to TestPyPI via trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -95,11 +95,17 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+      # Authenticates via OIDC trusted publishing — no token secret. The
+      # matching publisher on test.pypi.org is scoped to this workflow file
+      # and the `testpypi` environment above; changing either name breaks
+      # the exchange with `invalid-publisher`. `skip-existing` keeps a
+      # re-dispatch at an already-uploaded version from failing the job,
+      # since this path exists to be retried by hand.
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
 
   publish-pypi:
     name: Publish to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #806 - 2026-08-16
+- **TestPyPI publishes are authenticated again**: the `target: testpypi` escape hatch in `pypi-publish.yml` passed `password: ${{ secrets.TEST_PYPI_API_TOKEN }}`, but that secret was never created — an empty password makes `gh-action-pypi-publish` fall back to OIDC trusted publishing, which failed with `invalid-publisher` because test.pypi.org had no publisher (nor an `atlas-chat` project) configured. Every dispatch of that target has failed since it was added, leaving the `testpypi` deployment environment permanently red. The job now uses trusted publishing deliberately — the `password:` line is gone and a pending publisher is registered on test.pypi.org for this repo, workflow file, and the `testpypi` environment — so there is no token to store or rotate. `skip-existing: true` keeps a re-dispatch at an already-uploaded version from failing, since this path exists to be retried by hand. Production PyPI is untouched and still uses `PYPI_API_TOKEN`.
+
 ## [0.5.0] - 2026-08-16
 
 ### PR #802 - 2026-08-15

--- a/docs/developer/release-process.md
+++ b/docs/developer/release-process.md
@@ -49,6 +49,15 @@ to end users:
   as a last resort. Prefer cutting a patch release via the hotfix flow
   over reaching for this lever.
 
+  `target: testpypi` authenticates through **OIDC trusted publishing**,
+  not a token secret. The matching publisher on test.pypi.org is scoped
+  to project `atlas-chat`, owner `sandialabs`, repo `atlas-ui-3`,
+  workflow `pypi-publish.yml`, environment `testpypi` — renaming the
+  workflow file or the `testpypi` environment breaks the exchange with
+  `invalid-publisher`, which is a publisher-config error on PyPI's side
+  and not something a repo secret can fix. `target: pypi` still uses the
+  `PYPI_API_TOKEN` secret.
+
 ### Versioning
 
 The project uses **SemVer**: `MAJOR.MINOR.PATCH`.


### PR DESCRIPTION
The `target: testpypi` escape hatch in `pypi-publish.yml` has failed on every dispatch since it was added, leaving the `testpypi` deployment environment red (last run: [26148490888](https://github.com/sandialabs/atlas-ui-3/actions/runs/26148490888), 2026-05-20).

**Root cause.** The job passed `password: \${{ secrets.TEST_PYPI_API_TOKEN }}`, but that secret does not exist in this repo (only `PYPI_API_TOKEN`, `QUAY_USERNAME`, `QUAY_PASSWORD`, `RELEASE_PAT`). An empty password makes `gh-action-pypi-publish` fall back to OIDC trusted publishing, which then failed:

```
* `invalid-publisher`: valid token, but no corresponding publisher
  sub: repo:sandialabs/atlas-ui-3:environment:testpypi
```

test.pypi.org had neither a trusted publisher nor an `atlas-chat` project. Because the job only runs on `workflow_dispatch`, nothing forced the fix.

**Change.** Use trusted publishing deliberately instead of as a silent fallback: drop the `password:` line, and add `skip-existing: true` so a re-dispatch at an already-uploaded version does not fail a path that exists to be retried by hand. A pending publisher is registered on test.pypi.org scoped to project `atlas-chat`, owner `sandialabs`, repo `atlas-ui-3`, workflow `pypi-publish.yml`, environment `testpypi`.

Production PyPI is untouched and still uses `PYPI_API_TOKEN`.

**Verification.** After merge, dispatch `Publish Python Package to PyPI` with `target: testpypi` and confirm the run is green and `atlas-chat` appears on test.pypi.org.