### PR TITLE
fix(chat-history): stop relying on DuckDB secondary indexes

### DIFF
--- a/atlas/core/duckdb_indexes.py
+++ b/atlas/core/duckdb_indexes.py
@@ -1,0 +1,66 @@
+"""Work around DuckDB's unreliable secondary (ART) indexes.
+
+DuckDB's ART indexes can silently stop matching rows that are plainly present:
+an equality lookup such as ``WHERE user_email = ?`` returns nothing while a full
+scan of the same table returns the row. Upstream has an open report of the same
+shape (duckdb/duckdb#19190). Once a file is affected the damage is durable --
+it survives reopening the database, and it is invisible to the application,
+which simply sees empty result sets and renders them as "no data".
+
+The blast radius is development only: DuckDB is the local/dev backend and
+PostgreSQL is the production one (see ``chat_history.database``). PostgreSQL's
+indexes are unaffected and remain necessary there, so this workaround is scoped
+to the DuckDB dialect and leaves every other backend untouched.
+
+Dropping the indexes rather than rebuilding them is deliberate. A rebuild
+repairs the rows that exist today but leaves the same failure mode armed for
+tomorrow; local datasets are small enough that a full scan is cheap, so the
+indexes buy nothing and are the only surface the bug needs. Dropping them on
+startup also repairs a database that is already affected.
+"""
+
+import logging
+
+from sqlalchemy import MetaData
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+def drop_duckdb_secondary_indexes(engine: Engine, metadata: MetaData) -> int:
+    """Drop the declared secondary indexes when ``engine`` is backed by DuckDB.
+
+    Only indexes declared on ``metadata`` are touched; the indexes DuckDB
+    maintains internally for primary-key and unique constraints are left alone,
+    since those enforce correctness rather than accelerate lookups.
+
+    Returns the number of indexes dropped (0 on every non-DuckDB backend).
+    """
+    if engine.dialect.name != "duckdb":
+        return 0
+
+    # ``Index.drop(checkfirst=True)`` cannot be used here: it probes the index
+    # via reflection, which duckdb-engine does not implement, so it silently
+    # skips every drop while reporting success. Emit the DDL directly instead.
+    dropped = 0
+    for table in metadata.sorted_tables:
+        for index in table.indexes:
+            try:
+                with engine.begin() as conn:
+                    conn.exec_driver_sql(f'DROP INDEX IF EXISTS "{index.name}"')
+                dropped += 1
+            except Exception:
+                # A missing index is the desired end state, so a failure to drop
+                # one is worth surfacing but never worth failing startup over.
+                logger.warning(
+                    "Could not drop DuckDB index %s on %s", index.name, table.name,
+                    exc_info=True,
+                )
+
+    if dropped:
+        logger.info(
+            "Dropped %d secondary index(es) on the DuckDB backend; lookups use "
+            "full scans instead. See atlas.core.duckdb_indexes for why.",
+            dropped,
+        )
+    return dropped

--- a/atlas/modules/agent_portal/database.py
+++ b/atlas/modules/agent_portal/database.py
@@ -17,6 +17,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
+from atlas.core.duckdb_indexes import drop_duckdb_secondary_indexes
+
 from .models import Base
 
 logger = logging.getLogger(__name__)
@@ -104,6 +106,7 @@ def init_database(db_url: Optional[str] = None) -> Engine:
     """
     engine = get_engine(db_url)
     Base.metadata.create_all(engine)
+    drop_duckdb_secondary_indexes(engine, Base.metadata)
     logger.info("Agent portal database tables created/verified")
     return engine
 

--- a/atlas/modules/chat_history/database.py
+++ b/atlas/modules/chat_history/database.py
@@ -12,6 +12,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 
+from atlas.core.duckdb_indexes import drop_duckdb_secondary_indexes
+
 from .models import Base
 
 logger = logging.getLogger(__name__)
@@ -89,6 +91,7 @@ def init_database(db_url: Optional[str] = None) -> Engine:
     """
     engine = get_engine(db_url)
     Base.metadata.create_all(engine)
+    drop_duckdb_secondary_indexes(engine, Base.metadata)
     logger.info("Chat history database tables created/verified")
     return engine
 

--- a/atlas/tests/test_duckdb_index_dropping.py
+++ b/atlas/tests/test_duckdb_index_dropping.py
@@ -1,0 +1,102 @@
+"""Tests for the DuckDB secondary-index workaround.
+
+DuckDB's ART indexes can silently stop matching rows that are present in the
+file, which surfaces as empty conversations and missing custom prompts. The
+workaround drops those indexes on the DuckDB backend only -- PostgreSQL keeps
+them. See ``atlas.core.duckdb_indexes``.
+"""
+
+import pytest
+from sqlalchemy import (
+    Column,
+    Index,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    inspect,
+)
+
+from atlas.core.duckdb_indexes import drop_duckdb_secondary_indexes
+
+
+@pytest.fixture
+def metadata():
+    md = MetaData()
+    Table(
+        "widgets",
+        md,
+        Column("id", String(36), primary_key=True),
+        Column("owner", String(255), nullable=False, index=True),
+        Column("updated_at", String(64), nullable=False),
+        Index("ix_widgets_owner_updated", "owner", "updated_at"),
+    )
+    return md
+
+
+def _duckdb_index_names(engine):
+    """Read the index list from DuckDB directly.
+
+    duckdb-engine cannot reflect indexes -- ``inspect().get_indexes()`` always
+    returns an empty list -- so asserting through it would pass vacuously.
+    """
+    with engine.connect() as conn:
+        return sorted(
+            row[0]
+            for row in conn.exec_driver_sql(
+                "select index_name from duckdb_indexes()"
+            ).fetchall()
+        )
+
+
+def test_drops_declared_indexes_on_duckdb(tmp_path, metadata):
+    engine = create_engine(f"duckdb:///{tmp_path / 'widgets.db'}")
+    metadata.create_all(engine)
+    assert _duckdb_index_names(engine) == [
+        "ix_widgets_owner",
+        "ix_widgets_owner_updated",
+    ]
+
+    dropped = drop_duckdb_secondary_indexes(engine, metadata)
+
+    assert dropped == 2
+    assert _duckdb_index_names(engine) == []
+
+
+def test_rows_remain_queryable_after_dropping(tmp_path, metadata):
+    engine = create_engine(f"duckdb:///{tmp_path / 'widgets.db'}")
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            "insert into widgets values ('w1', 'someone', '2026-01-01')"
+        )
+
+    drop_duckdb_secondary_indexes(engine, metadata)
+
+    with engine.connect() as conn:
+        found = conn.exec_driver_sql(
+            "select count(*) from widgets where owner = 'someone'"
+        ).scalar()
+    assert found == 1
+
+
+def test_is_a_no_op_on_other_backends(tmp_path, metadata):
+    """Only DuckDB is affected; every other dialect keeps its indexes."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'widgets.db'}")
+    metadata.create_all(engine)
+
+    dropped = drop_duckdb_secondary_indexes(engine, metadata)
+
+    assert dropped == 0
+    assert inspect(engine).get_indexes("widgets"), "non-DuckDB indexes must survive"
+
+
+def test_init_database_leaves_no_indexes(tmp_path, monkeypatch):
+    """The chat-history startup path drops the indexes it just created."""
+    from atlas.modules.chat_history import database as chat_db
+
+    monkeypatch.setattr(chat_db, "_engine", None)
+    monkeypatch.setattr(chat_db, "_session_factory", None)
+    engine = chat_db.init_database(f"duckdb:///{tmp_path / 'chat.db'}")
+
+    assert _duckdb_index_names(engine) == []

--- a/docs/admin/chat-history.md
+++ b/docs/admin/chat-history.md
@@ -60,6 +60,38 @@ When using `agent_start.sh`, the script automatically:
 - If DuckDB URL is configured, ensures the `data/` directory exists
 - Tables are created automatically on first startup (via `Base.metadata.create_all`)
 
+### Secondary Indexes on DuckDB
+
+The DuckDB backend runs without the secondary indexes declared in `models.py`;
+they are dropped during startup. DuckDB's ART indexes can silently stop
+matching rows that are present in the file, so an equality lookup such as
+`WHERE user_email = ?` returns nothing while a full scan of the same table
+returns the row. The failure is durable — it survives reopening the database —
+and it is invisible to the application, which renders the empty result as
+"no data". Symptoms are conversations that open with no messages and custom
+prompts missing from the prompt list, while the conversation list still looks
+complete.
+
+Dropping the indexes rather than rebuilding them is deliberate: a rebuild
+repairs the rows that exist today but leaves the same failure mode armed for
+tomorrow. Local datasets are small enough that a full scan is cheap.
+
+This applies to DuckDB only. PostgreSQL keeps its indexes, which are correct
+there and matter at production scale.
+
+A database that predates this behavior repairs itself on the next startup. To
+repair a file out of band, stop the application (DuckDB holds an exclusive
+lock) and run:
+
+```bash
+python scripts/repair_duckdb_indexes.py data/chat_history.db
+```
+
+Pass `--check` to inspect without modifying, or `--rebuild` to recreate the
+indexes instead of leaving them off. The script copies the database before
+making changes. No row data is lost in either case — only the indexes are
+wrong.
+
 ## Database Schema
 
 Four tables are created:

--- a/scripts/repair_duckdb_indexes.py
+++ b/scripts/repair_duckdb_indexes.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Repair a DuckDB database whose secondary indexes have stopped matching rows.
+
+Symptom: rows are present in the file but invisible to the application. In the
+chat history database this shows up as conversations that open with no messages
+and custom prompts missing from the prompt list, while the conversation list
+itself still looks complete. An equality lookup returns nothing where a full
+scan of the same table returns the row -- see ``atlas.core.duckdb_indexes``.
+
+Only the indexes are wrong; no row data is lost. Dropping the indexes restores
+correct results immediately.
+
+The application drops these indexes automatically on startup, so an existing
+database usually repairs itself. Use this script to repair a file out of band,
+to confirm a database is affected, or to rebuild rather than drop.
+
+Usage:
+    python scripts/repair_duckdb_indexes.py data/chat_history.db
+    python scripts/repair_duckdb_indexes.py data/chat_history.db --rebuild
+    python scripts/repair_duckdb_indexes.py data/chat_history.db --check
+
+Stop the application first: DuckDB takes an exclusive lock on the file.
+"""
+
+import argparse
+import shutil
+import sys
+import time
+from pathlib import Path
+
+try:
+    import duckdb
+except ImportError:
+    sys.exit("duckdb is not installed in this environment")
+
+
+def _check(con) -> int:
+    """List the secondary indexes present, with the row count of each table."""
+    indexes = con.execute(
+        "select index_name, table_name from duckdb_indexes()"
+    ).fetchall()
+    if not indexes:
+        print("no secondary indexes present -- nothing to repair")
+        return 0
+
+    for index_name, table_name in indexes:
+        total = con.execute(f'select count(*) from "{table_name}"').fetchone()[0]
+        print(f"  {index_name} on {table_name} ({total} rows)")
+    print(f"{len(indexes)} index(es) present; run without --check to drop them")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("database", type=Path, help="path to the DuckDB file")
+    parser.add_argument(
+        "--rebuild", action="store_true",
+        help="recreate the indexes after dropping them instead of leaving them off",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="report the indexes present and exit without modifying the file",
+    )
+    parser.add_argument(
+        "--no-backup", action="store_true", help="skip the pre-repair copy",
+    )
+    args = parser.parse_args()
+
+    if not args.database.exists():
+        print(f"no database at {args.database}", file=sys.stderr)
+        return 1
+
+    if not args.check and not args.no_backup:
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        backup = args.database.with_name(f"{args.database.name}.prerepair-{stamp}")
+        shutil.copy2(args.database, backup)
+        wal = args.database.with_name(args.database.name + ".wal")
+        if wal.exists():
+            shutil.copy2(wal, backup.with_name(backup.name + ".wal"))
+        print(f"backed up to {backup}")
+
+    try:
+        con = duckdb.connect(str(args.database), read_only=args.check)
+    except duckdb.IOException as exc:
+        print(
+            f"cannot open the database -- stop the application first:\n  {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    with con:
+        if args.check:
+            return _check(con)
+
+        indexes = con.execute("select index_name, sql from duckdb_indexes()").fetchall()
+        if not indexes:
+            print("no secondary indexes present -- nothing to repair")
+            return 0
+
+        for name, _sql in indexes:
+            con.execute(f'DROP INDEX "{name}"')
+            print(f"  dropped {name}")
+
+        if args.rebuild:
+            for name, sql in indexes:
+                con.execute(sql)
+                print(f"  rebuilt {name}")
+
+        con.execute("CHECKPOINT")
+
+    print(
+        f"{len(indexes)} index(es) "
+        f"{'rebuilt' if args.rebuild else 'dropped'}; rows are now visible to lookups"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

DuckDB's ART indexes can silently stop matching rows that are present in the file. An equality lookup such as `WHERE user_email = ?` returns nothing, while a full scan of the same table returns the row.

Two properties make this worse than a normal bug:

- **It is durable.** The index does not recover on reopen. Once a file is affected it stays affected, and every subsequent write lands in a table whose index no longer resolves it.
- **It is silent.** No error, no warning. The application receives an empty result set and renders it as "no data".

The user-visible symptom reads as data loss: conversations open with **no messages**, and custom prompts **disappear** from the prompt list. The conversation list still looks complete, which makes it look like a rendering bug rather than a lookup one — the index backing that list is separate from the ones that broke.

No data is actually lost. The rows are intact and a full scan finds all of them; only the indexes are wrong.

Upstream has an open report of the same shape: [duckdb/duckdb#19190](https://github.com/duckdb/duckdb/issues/19190) ("Missing results for index lookup"). That report describes a non-deterministic variant resolved by `SET threads=1`; the durable variant here is not affected by the thread count, so it appears to be the same family with a persistent outcome.

## Scope

**Development only.** DuckDB is the local/dev backend; PostgreSQL is the production one. PostgreSQL's indexes are unaffected and remain necessary there, so production behavior is unchanged.

## Change

Drop the declared secondary indexes on the DuckDB backend during `init_database()`, for both the chat-history and agent-portal stores. Dropping them also repairs a database that is already affected, so existing local databases heal on the next startup.

**Why drop rather than rebuild.** A rebuild repairs the rows that exist today but leaves the same failure mode armed for tomorrow. Local datasets are small enough that a full scan is cheap, so these indexes buy little and are the only surface the bug needs.

One implementation note worth flagging for review: `Index.drop(checkfirst=True)` **cannot** be used here. It probes for the index via reflection, which duckdb-engine does not implement, so it skips every drop while reporting success. The DDL is emitted directly instead. This was caught by a test that asserted through `inspect().get_indexes()` — which always returns `[]` on duckdb-engine and therefore passed vacuously. The tests now read `duckdb_indexes()` directly.

## Repair script

`scripts/repair_duckdb_indexes.py` repairs a file out of band, for inspecting or fixing a database without starting the application:

```bash
python scripts/repair_duckdb_indexes.py data/chat_history.db          # drop
python scripts/repair_duckdb_indexes.py data/chat_history.db --check  # inspect only
python scripts/repair_duckdb_indexes.py data/chat_history.db --rebuild
```

It copies the database before making changes. The application must be stopped first — DuckDB holds an exclusive lock on the file.

## Testing

- New `atlas/tests/test_duckdb_index_dropping.py`: indexes are dropped on DuckDB, rows stay queryable afterwards, the helper is a no-op on other backends, and the chat-history startup path leaves no indexes behind.
- Full suite: **2334 passed, 17 skipped**.
- Verified against a database exhibiting the fault: affected conversations returned 0 messages and one of two stored prompts before the change, and all conversations plus both prompts after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)