### PR TITLE
feat(rag): show backend reference label in the References section

### DIFF
--- a/atlas/modules/rag/atlas_rag_client.py
+++ b/atlas/modules/rag/atlas_rag_client.py
@@ -26,6 +26,7 @@ Response body (RagResponse):
         "references": [
           {
             "citation": "IEEE format" | null,
+            "reference": "human-readable source line" | null,
             "document_ref": 1,
             "filename": "doc.pdf",
             "sections": [
@@ -769,6 +770,10 @@ class AtlasRAGClient:
         ``sections`` carry the actual snippet text matched to the query.
         The reference's top section relevance becomes ``confidence_score``
         so existing UI/sorting code still works without changes.
+
+        The displayed label prefers the backend's ``reference`` string and
+        falls back to ``filename``, so backends that only send a filename
+        render exactly as before.
         """
         try:
             references_raw = metadata.get("references") or []
@@ -789,6 +794,13 @@ class AtlasRAGClient:
 
                 top_relevance = max((s.relevance for s in sections), default=0.0)
                 filename = ref.get("filename") or ""
+                # Newer backends send a human-readable ``reference`` string
+                # (e.g. an IEEE-style source line) in place of the older
+                # ``citation`` field. Prefer it as the displayed label and
+                # fall back to the filename when it is absent.
+                reference = ref.get("reference")
+                if not isinstance(reference, str) or not reference.strip():
+                    reference = None
 
                 try:
                     doc_metadata = DocumentMetadata(
@@ -797,7 +809,7 @@ class AtlasRAGClient:
                         confidence_score=top_relevance,
                         chunk_id=None,
                         last_modified=None,
-                        title=filename or None,
+                        title=reference or filename or None,
                         url=None,
                         citation=ref.get("citation"),
                         document_ref=ref.get("document_ref"),

--- a/atlas/tests/test_atlas_rag_client.py
+++ b/atlas/tests/test_atlas_rag_client.py
@@ -464,6 +464,83 @@ class TestParseResponseMetadata:
         assert doc.confidence_score == 0.9
         assert [s.text for s in doc.sections] == ["first snippet", "second snippet"]
 
+    def test_reference_field_becomes_display_label(self, client):
+        """Newer backends send ``reference``; it becomes the shown label."""
+        data = {
+            "metadata": {
+                "response_time": 1,
+                "references": [
+                    {
+                        "reference": "API Authentication Guide, tech-001.txt",
+                        "document_ref": 1,
+                        "filename": "tech-001.txt",
+                        "sections": [
+                            {"section_ref": 1, "text": "snippet", "relevance": 0.5},
+                        ],
+                    }
+                ],
+            },
+        }
+        result = client._parse_response_metadata(data, "technical-docs")
+        doc = result.documents_found[0]
+        assert doc.title == "API Authentication Guide, tech-001.txt"
+
+    def test_filename_used_when_reference_absent(self, client):
+        """Backends that only send ``filename`` render exactly as before."""
+        data = {
+            "metadata": {
+                "response_time": 1,
+                "references": [
+                    {"document_ref": 1, "filename": "tech-001.txt", "sections": []}
+                ],
+            },
+        }
+        result = client._parse_response_metadata(data, "technical-docs")
+        assert result.documents_found[0].title == "tech-001.txt"
+
+    def test_blank_reference_falls_back_to_filename(self, client):
+        data = {
+            "metadata": {
+                "response_time": 1,
+                "references": [
+                    {"reference": "   ", "document_ref": 1,
+                     "filename": "tech-001.txt", "sections": []}
+                ],
+            },
+        }
+        result = client._parse_response_metadata(data, "technical-docs")
+        assert result.documents_found[0].title == "tech-001.txt"
+
+    def test_non_string_reference_falls_back_to_filename(self, client):
+        """A malformed ``reference`` must not break parsing."""
+        data = {
+            "metadata": {
+                "response_time": 1,
+                "references": [
+                    {"reference": 42, "document_ref": 1,
+                     "filename": "tech-001.txt", "sections": []}
+                ],
+            },
+        }
+        result = client._parse_response_metadata(data, "technical-docs")
+        assert result.documents_found[0].title == "tech-001.txt"
+
+    def test_reference_is_sanitized_and_truncated(self, client):
+        """``reference`` goes through the same title validator as filenames."""
+        data = {
+            "metadata": {
+                "response_time": 1,
+                "references": [
+                    {"reference": "Bad\x00Label" + "A" * 300, "document_ref": 1,
+                     "filename": "tech-001.txt", "sections": []}
+                ],
+            },
+        }
+        result = client._parse_response_metadata(data, "technical-docs")
+        title = result.documents_found[0].title
+        assert "\x00" not in title
+        assert len(title) == 200
+
     def test_parses_metadata_no_references(self, client):
         data = {
             "message": {"role": "assistant", "content": "x"},

--- a/frontend/src/test/rag-citation-rendering.test.js
+++ b/frontend/src/test/rag-citation-rendering.test.js
@@ -283,3 +283,35 @@ describe('RAG references section', () => {
     expect(result).toBe(input)
   })
 })
+
+// --------------------------------------------------------------------------
+// Tests: backend `reference` label (rendered by the backend as the entry label)
+// --------------------------------------------------------------------------
+
+describe('backend reference labels', () => {
+  it('extracts a multi-word reference label containing a comma', () => {
+    const html =
+      '<p><strong>References</strong></p>\n' +
+      '<p>1. API Authentication Guide, tech-001.txt — technical-docs, 50% relevance</p>'
+    const labels = extractSourceLabels(html)
+    expect(labels.get('1').label).toBe('API Authentication Guide, tech-001.txt')
+  })
+
+  it('still extracts a bare filename label when no reference was sent', () => {
+    const html =
+      '<p><strong>References</strong></p>\n' +
+      '<p>1. tech-001.txt — technical-docs, 50% relevance</p>'
+    const labels = extractSourceLabels(html)
+    expect(labels.get('1').label).toBe('tech-001.txt')
+  })
+
+  it('shows the reference label in the collapsed summary', () => {
+    const html =
+      '<p><strong>References</strong></p>\n' +
+      '<p>1. API Authentication Guide, tech-001.txt — technical-docs, 50% relevance</p>'
+    const labels = extractSourceLabels(html)
+    const result = processReferencesSection(html, '', labels)
+    expect(result).toContain('API Authentication Guide, tech-001.txt')
+    expect(result).toContain('id="rag-ref-1"')
+  })
+})

--- a/mocks/atlas-rag-api-mock/README.md
+++ b/mocks/atlas-rag-api-mock/README.md
@@ -86,6 +86,7 @@ curl -X POST \
     "references": [
       {
         "citation": "[1] \"API Authentication Guide\", tech-001.txt available: https://docs.company.com/api/authentication",
+        "reference": "API Authentication Guide, tech-001.txt",
         "document_ref": 1,
         "filename": "tech-001.txt",
         "sections": [
@@ -107,6 +108,8 @@ curl -X POST \
 ```
 
 The frontend consumes `metadata.references[].sections[].text` to display the underlying evidence snippets in the expanded citation area beneath each reference.
+
+`metadata.references[].reference` is the human-readable source line shown as the reference's label. It is optional: when a backend omits it, the UI falls back to `filename`, which is what older backends effectively rendered.
 
 ### POST /admin/users
 

--- a/mocks/atlas-rag-api-mock/main.py
+++ b/mocks/atlas-rag-api-mock/main.py
@@ -191,6 +191,13 @@ class Section(BaseModel):
 
 class Reference(BaseModel):
     citation: Optional[str] = Field(None, description="Citation in IEEE format.")
+    reference: Optional[str] = Field(
+        None,
+        description=(
+            "Human-readable source line the UI shows as the reference label. "
+            "Falls back to filename when absent."
+        ),
+    )
     document_ref: int = Field(..., description="The document reference number for intext citations.")
     filename: str = Field(..., description="Filename of the source document.")
     sections: List[Section] = Field(..., description="Relevant sections from the source document.")
@@ -413,6 +420,20 @@ def _ieee_citation(document_ref: int, title: str, filename: str, url: Optional[s
     return " ".join(parts)
 
 
+def _reference_label(title: str, filename: str) -> str:
+    """Human-readable label a real backend would send as ``reference``.
+
+    Real deployments send a curated source line; the mock composes
+    ``"<title>, <filename>"`` so the UI has a value that is visibly
+    distinct from the bare filename.
+    """
+    if title and title != filename:
+        # Avoid characters _sanitize_label strips downstream (parens,
+        # brackets) so the mock's label survives rendering verbatim.
+        return f"{title}, {filename}"
+    return filename
+
+
 def search_corpus_for_references(
     query: str,
     corpus_id: str,
@@ -456,6 +477,7 @@ def search_corpus_for_references(
         references.append(
             Reference(
                 citation=_ieee_citation(document_ref, title, filename, doc.get("url")),
+                reference=_reference_label(title, filename),
                 document_ref=document_ref,
                 filename=filename,
                 sections=sections,


### PR DESCRIPTION
## Problem

The newest ATLAS-RAG response shape carries a human-readable `reference` string on each `metadata.references[]` entry:

```json
{
  "document_ref": 0,
  "filename": "string",
  "sections": [{"section_ref": 0, "text": "string", "relevance": 0}],
  "reference": "string"
}
```

`AtlasRAGClient._parse_metadata_newest` never read that key, so every entry in the UI's References section rendered as a bare filename (`tech-001.txt`) even when the backend supplied a proper source line. The loss was silent — `.get` returns `None` and the field is `Optional`, so the reference parsed "successfully" with a hole in it.

## Change

- `atlas/modules/rag/atlas_rag_client.py` — prefer `reference` as the displayed label, falling back to `filename` when it is absent, blank, or not a string. The value flows through the existing `DocumentMetadata.title` slot.
- `mocks/atlas-rag-api-mock/main.py` — emit `reference` alongside `citation` so the field is exercised locally.
- `mocks/atlas-rag-api-mock/README.md` — document the field and its fallback.
- Tests: 5 backend parser cases, 3 frontend label-extraction cases.

**No frontend code change.** The label reaches the UI through the markdown References block the backend already renders, so `ragCitations.js` picks it up unmodified. The frontend tests are there to pin the behavior, not because anything moved.

## Compatibility

Backends that send only `filename` render exactly as before — verified by test. The existing `citation` field is untouched and still renders as the italic line beneath each entry.

`DocumentMetadata.sanitize_title` (control-char strip, 200-char cap) and `_sanitize_label` (markdown/injection-char strip) both apply to the new value, so the attacker-influenced surface is unchanged.

## Verification

Full backend suite (`bash test/atlas_tests.sh`): **2448 passed, 17 skipped**.
Full frontend suite (`npx vitest run`): **579 passed, 53 files**.

End-to-end against the live mock (parser → markdown → `marked` → `ragCitations.js`):

```
--- extracted labels ---
 [1] API Authentication Guide, tech-001.txt
 [2] Deployment Pipeline, tech-003.txt
 [3] Microservices Architecture, tech-004.txt
--- collapsed summary (what the user sees closed) ---
[1] API Authentication Guide, tech-001.txt, [2] Deployment Pipeline, tech-003.txt, ...
--- anchors present ---
rag-ref-msg1-1, rag-ref-msg1-2, rag-ref-msg1-3
```

Previously those labels read `tech-001.txt`, `tech-003.txt`, `tech-004.txt`.

## Notes for reviewers

1. **Scoped to v1 `metadata.references`.** The v2 `hits`/`citations` shape already has a `title` field serving as the label, so it has no equivalent gap. If v2 also grows a `reference` key, `_parse_v2_documents` needs the same treatment.
2. **`_sanitize_label` strips parentheses and brackets** from labels before rendering (pre-existing). A backend `reference` of `PTO Policy (Rev. C)` renders as `PTO Policy Rev. C`. Not a regression, but more visible now that labels are richer than filenames. The mock deliberately uses a comma format to avoid it.
3. **Markdown round-trip fragility** (pre-existing): the frontend re-parses labels out of rendered HTML with a `N.\s` anchor. A `reference` containing a digit-dot-space sequence (`Doc 12. Overview`) could produce a spurious entry. Richer labels make this marginally more reachable. Fixing it properly means passing references as structured data rather than markdown — out of scope here.
4. `docs/admin/external-rag-api.md` still documents the older `rag_metadata` shape for v1 rather than `metadata.references`; that gap predates this change and I left it alone.