### PR TITLE
release: 0.6.0 (2026.08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-22
+
 ### PR #832 - 2026-08-21
 - **Transfer MCP `read_file_from_disk` no longer injects the entire file into the model context** (closes #831): the tool-result text is now a head+tail preview — the first and last `MCP_TRANSFER_PREVIEW_LINES` lines (default 50 each) of a UTF-8 file, joined by an omission marker when the file exceeds twice the line budget. A byte ceiling (`MCP_TRANSFER_PREVIEW_BYTES`, default 16 KiB) also applies, so a file with few but very long lines (minified bundles, single-line JSON) cannot bypass the line budget. Short files (under both budgets) are returned in full. When the preview is trimmed the text is emitted under `content_preview` and the `content` key is omitted, so a blind forward into `write_file_to_disk(content=...)` fails loudly instead of silently writing the omission marker. The complete file still travels as a base64 artifact so the agent can forward it to a downstream tool without re-reading. Binary files no longer inject a redundant `content_base64` into the tool result — the bytes travel only as the artifact. Structured truncation metadata (`truncated`, `total_lines`, `omitted_lines`, `preview_lines`) is emitted as integers for programmatic consumers. New env vars `MCP_TRANSFER_PREVIEW_LINES` and `MCP_TRANSFER_PREVIEW_BYTES` control the head/tail line budget and byte ceiling.
 

--- a/atlas/version.py
+++ b/atlas/version.py
@@ -3,4 +3,4 @@
 Single source of truth for the application version number.
 """
 
-VERSION = "0.5.0"
+VERSION = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "atlas-chat"
-version = "0.5.0"
+version = "0.6.0"
 description = "Trusted AI agent platform with MCP, RAG, access control, and auditable tool use"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
<!--
This file is used as the body of the draft release PR opened by
.github/workflows/release-cut.yml. Keep it actionable and
review-friendly. Full process docs live at
docs/developer/release-process.md.
-->

# Release 0.6.0 (2026.08)

This PR was opened by the `release-cut` automation. It cuts
`release/2026.08` from `main` and bumps the version. Nothing
publishes until a maintainer manually tags `v0.6.0` on this
branch — see the runbook at
[docs/developer/release-process.md](../docs/developer/release-process.md).

## What this PR contains

- New branch `release/2026.08` cut from `main` at
  `6e01abf4c56108d5ec216002dcce26d11d5d365b`.
- `atlas/version.py` and `pyproject.toml` bumped from
  `0.5.0` → `0.6.0`.
- `CHANGELOG.md`: `## [Unreleased]` section finalized as
  `## [0.6.0] - 2026-08-22`; new empty `[Unreleased]`
  prepended.

## Release captain

Assign yourself to this PR. You own the checklist below, the smoke
test, the tag push, and the GitHub Release.

## Stabilization window

This PR stays open for the rest of the month. During that window:

- Only bug fixes merge to `release/2026.08`. Features and
  refactors continue to land on `main` as normal.
- Fix on `main` first, then cherry-pick to the release branch:
  `git cherry-pick -x <sha>`.
- Each cherry-pick gets a CHANGELOG note under the
  `## [0.6.0]` section on the release branch.

## Pre-tag checklist

Complete every item before pushing the tag. Do not merge this PR
until the tag is pushed and publish workflows are green.

### Code & CI

- [ ] `CI/CD Pipeline` is green on the latest commit of
      `release/2026.08`.
- [ ] `Security Checks` is green.
- [ ] No known P0 or P1 bugs filed against the release branch.
- [ ] `atlas/version.py` and `pyproject.toml` both show `0.6.0`.
- [ ] `CHANGELOG.md` has a populated `## [0.6.0]` section with
      at least one entry per user-visible change since the previous
      release.

### Smoke test (manual)

See [docs/developer/release-process.md#smoke-test](../docs/developer/release-process.md#smoke-test).

- [ ] `uv build --wheel` succeeds on `release/2026.08`.
- [ ] Fresh `atlas-init` + `atlas-chat` one-shot call works against
      a real LLM.
- [ ] Tool-call path works (`atlas-chat --tools calculator_evaluate`).
- [ ] `atlas-server` boots and `/api/health` returns `0.6.0`.

### Publish

- [ ] Tag pushed: `git tag -a v0.6.0 -m "Atlas UI 3 v0.6.0" && git push origin v0.6.0`.
- [ ] GitHub Release created from the tag, targeting
      `release/2026.08`, with CHANGELOG section as the body.
- [ ] `pypi-publish.yml` completed, `atlas-chat==0.6.0`
      visible on PyPI.
- [ ] `quay-publish.yml` completed, `quay.io/<ns>/atlas-ui-3:0.6.0`
      image pushed.

### Post-publish

- [ ] This PR merged into `main` (fast-forward if possible) so the
      version bump and any hotfixes carry forward.
- [ ] Follow-up issue filed for any deferred items surfaced during
      stabilization.

## Rollback

If the release is broken in the wild, **do not rewrite history**.
Yank the bad version on PyPI and cut a patch release via the hotfix
flow in the runbook. Rolling forward beats rolling back.
