### PR TITLE
fix(sleep): emit heartbeat progress during long sleeps to prevent apparent hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fix - atlas_sleep heartbeat - 2026-08-27
+- **The `atlas_sleep` tool no longer appears to hang on long waits**: a 900-second sleep could show 79 minutes of elapsed time because the tool did a single `asyncio.sleep(seconds)` with zero `tool_progress` events — if the `tool_complete` frame was lost (WebSocket drop, backend error), the frontend row stayed in `calling` status forever with the clock ticking and the generic "taking longer than expected" warning. The wait is now broken into heartbeat intervals (capped at 30s) that emit `tool_progress` frames, so the frontend knows the sleep is alive, transitions to `in_progress`, and shows the actual (clamped) duration. The frontend `ToolElapsedTime` clock uses the heartbeat's `total` field (which reflects per-call/turn clamping) instead of the raw requested `seconds`, and escalates from "completing..." to "connection may be lost" (red) when the clock runs more than 60s past the wait without a `tool_complete` — so a genuinely stuck sleep is visually distinct from one that is wrapping up.
+
 ### Repo cleanup - 2026-08-27
 - **Removed 11 PR-evidence screenshots that no doc or code references** (~1.1 MB): `docs/developer/images/pr500-citations-screenshot.png`, `pr637-tiff-vision-proof.png`, `pr650-chat-export-active-prompt-ui.png`, `pr650-chat-export-prompt-e2e.png`, `pr664-agent-multi-tool-chain-2.png`, `rag-snippets-collapsed.png`, `rag-snippets-expanded.png`, `rag-snippets-live-pipeline.png`, `wormhole-e2e-console-2026-06-09.png`, `wormhole-e2e-dashboard-2026-06-09.png`, and `docs/readme_img/screenshot-10-24-2025.png`. These were review evidence attached to past PRs that landed in the tree rather than staying on the PR thread; every image still referenced by a doc or test is untouched. Same cleanup as #853.
 

--- a/atlas/modules/mcp_tools/sleep_tool.py
+++ b/atlas/modules/mcp_tools/sleep_tool.py
@@ -9,12 +9,19 @@ transport timeout to hit.
 Cancellation needs no extra plumbing: a stopped run cancels the asyncio task
 that drives the turn, and ``asyncio.sleep`` raises ``CancelledError``
 immediately, so an in-flight sleep aborts with the rest of the turn.
+
+Progress heartbeats: the wait is broken into heartbeat intervals (capped at
+``HEARTBEAT_MAX_INTERVAL`` seconds) so the frontend receives regular
+``tool_progress`` frames. Without them a long sleep (up to 2h by default)
+sits in ``calling`` status with no signal that it is alive; if the WebSocket
+drops the ``tool_complete`` frame is lost and the row spins forever (the
+"79-minute 900-second sleep" hang).
 """
 
 import asyncio
 import logging
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 from atlas.domain.messages.models import ToolCall, ToolResult
 
@@ -27,6 +34,22 @@ SLEEP_TOOL_NAME = "atlas_agent_sleep"
 # is created once per turn and mutated here, which is what makes the cumulative
 # budget below a *turn* budget rather than a per-call one.
 TURN_BUDGET_KEY = "turn_sleep_budget"
+
+# Heartbeat interval for progress events during a long sleep. The wait is
+# broken into chunks of this size (or smaller for short sleeps) so the
+# frontend receives regular ``tool_progress`` frames and knows the sleep is
+# alive. Capped at 30s to match the default WebSocket ping interval; shorter
+# sleeps get proportionally shorter intervals so even a 30s wait gets a few
+# beats. Waits at or below the minimum threshold sleep in a single shot --
+# they are too short for a heartbeat to matter.
+HEARTBEAT_MAX_INTERVAL = 30.0
+HEARTBEAT_MIN_SLEEP = 10.0
+
+# Key for the update callback inside the tool execution context dict. The
+# sleep tool receives the same ``context`` dict that MCP tools do, and the
+# tool executor puts the WebSocket update callback there so MCP tools can
+# emit progress. The sleep tool reads it the same way.
+UPDATE_CALLBACK_KEY = "update_callback"
 
 SLEEP_TOOL_SCHEMA = {
     "type": "function",
@@ -110,6 +133,64 @@ def _turn_budget_remaining(
     return budget, max(max_turn_seconds - spent, 0.0)
 
 
+def _heartbeat_interval(total_seconds: float) -> float:
+    """Seconds between progress heartbeats for a wait of ``total_seconds``.
+
+    Short waits get proportionally short intervals (a 30s sleep beats every
+    3s); long waits are capped at ``HEARTBEAT_MAX_INTERVAL`` so a 2h sleep
+    does not flood the WebSocket. Waits at or below the minimum threshold
+    return the full duration -- the caller sleeps in a single shot.
+    """
+    if total_seconds <= HEARTBEAT_MIN_SLEEP:
+        return total_seconds
+    return min(max(total_seconds / 10.0, HEARTBEAT_MIN_SLEEP / 2.0), HEARTBEAT_MAX_INTERVAL)
+
+
+async def _sleep_with_heartbeats(
+    total_seconds: float,
+    tool_call_id: str,
+    context: Optional[Dict[str, Any]],
+) -> None:
+    """Sleep for ``total_seconds``, emitting ``tool_progress`` heartbeats.
+
+    The wait is broken into chunks so the frontend receives regular progress
+    frames. Without them a long sleep sits in ``calling`` status with no
+    signal that it is alive; if the WebSocket drops the ``tool_complete``
+    frame is lost and the row spins forever.
+
+    Cancellation is preserved: ``asyncio.sleep(chunk)`` raises
+    ``CancelledError`` immediately on cancel, same as a single long sleep.
+    """
+    update_callback: Optional[Callable[[Dict[str, Any]], Awaitable[None]]] = None
+    if isinstance(context, dict):
+        cb = context.get(UPDATE_CALLBACK_KEY)
+        if callable(cb):
+            update_callback = cb
+
+    if update_callback is None or total_seconds <= HEARTBEAT_MIN_SLEEP:
+        await asyncio.sleep(total_seconds)
+        return
+
+    interval = _heartbeat_interval(total_seconds)
+    elapsed = 0.0
+    while elapsed < total_seconds:
+        chunk = min(interval, total_seconds - elapsed)
+        await asyncio.sleep(chunk)
+        elapsed += chunk
+        try:
+            from atlas.application.chat.utilities.event_notifier import notify_tool_progress
+            await notify_tool_progress(
+                tool_call_id,
+                SLEEP_TOOL_NAME,
+                elapsed,
+                total_seconds,
+                f"waiting {elapsed:g}/{total_seconds:g}s",
+                update_callback,
+            )
+        except Exception:
+            logger.debug("Sleep heartbeat failed (non-fatal)", exc_info=True)
+
+
 async def execute_sleep_tool(
     tool_call: ToolCall,
     max_seconds: float,
@@ -168,7 +249,7 @@ async def execute_sleep_tool(
         "turn budget remaining %.3fs)",
         seconds, requested, max_seconds, remaining,
     )
-    await asyncio.sleep(seconds)
+    await _sleep_with_heartbeats(seconds, tool_call.id, context)
     if budget is not None:
         budget["slept_seconds"] = max_turn_seconds - remaining + seconds
 

--- a/atlas/tests/test_agent_sleep_tool.py
+++ b/atlas/tests/test_agent_sleep_tool.py
@@ -10,8 +10,11 @@ from atlas.domain.messages.models import ToolCall
 from atlas.modules.mcp_tools import client as mcp_client
 from atlas.modules.mcp_tools.client import MCPToolManager
 from atlas.modules.mcp_tools.sleep_tool import (
+    HEARTBEAT_MAX_INTERVAL,
+    HEARTBEAT_MIN_SLEEP,
     SLEEP_TOOL_NAME,
     TURN_BUDGET_KEY,
+    _heartbeat_interval,
     execute_sleep_tool,
 )
 
@@ -259,3 +262,161 @@ def test_step_clamp_falls_back_when_no_config_manager():
 
     assert orchestrator._bounded_agent_steps(10_000) == 10
     assert orchestrator._bounded_agent_steps(3) == 3
+
+
+# --- Heartbeat progress tests ------------------------------------------------
+
+def test_heartbeat_interval_short_sleep_returns_full_duration():
+    """Waits at or below the threshold sleep in a single shot."""
+    assert _heartbeat_interval(5) == 5
+    assert _heartbeat_interval(HEARTBEAT_MIN_SLEEP) == HEARTBEAT_MIN_SLEEP
+
+
+def test_heartbeat_interval_long_sleep_is_capped():
+    """Long waits are capped so a 2h sleep does not flood the WebSocket."""
+    assert _heartbeat_interval(7200) == HEARTBEAT_MAX_INTERVAL
+    assert _heartbeat_interval(900) == HEARTBEAT_MAX_INTERVAL
+
+
+def test_heartbeat_interval_medium_sleep_scales_proportionally():
+    """A 60s wait gets ~6s intervals; a 120s wait gets ~12s."""
+    assert _heartbeat_interval(60) == 6.0
+    assert _heartbeat_interval(120) == 12.0
+
+
+@pytest.mark.asyncio
+async def test_sleep_emits_progress_heartbeats(monkeypatch):
+    """A long sleep with an update callback emits tool_progress frames."""
+    progress_calls = []
+
+    async def fake_callback(payload):
+        progress_calls.append(payload)
+
+    chunks = []
+
+    async def fake_sleep(seconds):
+        chunks.append(seconds)
+
+    monkeypatch.setattr("atlas.modules.mcp_tools.sleep_tool.asyncio.sleep", fake_sleep)
+
+    result = await execute_sleep_tool(
+        _call(seconds=60),
+        max_seconds=7200,
+        context={"update_callback": fake_callback},
+    )
+
+    assert result.success is True
+    # Multiple heartbeat chunks were slept.
+    assert len(chunks) > 1
+    # The total sleep time equals the requested duration.
+    assert abs(sum(chunks) - 60.0) < 0.01
+    # Progress events were emitted.
+    assert len(progress_calls) >= 2
+    # Each progress event carries the tool_call_id, elapsed, and total.
+    for p in progress_calls:
+        assert p["type"] == "tool_progress"
+        assert p["tool_call_id"] == "sleep-1"
+        assert p["total"] == 60.0
+    # The last progress event reports full elapsed.
+    assert abs(progress_calls[-1]["progress"] - 60.0) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_short_sleep_does_not_emit_heartbeats(monkeypatch):
+    """A short sleep (<= HEARTBEAT_MIN_SLEEP) sleeps in one shot, no beats."""
+    progress_calls = []
+
+    async def fake_callback(payload):
+        progress_calls.append(payload)
+
+    slept = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr("atlas.modules.mcp_tools.sleep_tool.asyncio.sleep", fake_sleep)
+
+    result = await execute_sleep_tool(
+        _call(seconds=5),
+        max_seconds=7200,
+        context={"update_callback": fake_callback},
+    )
+
+    assert result.success is True
+    assert slept == [5.0]
+    assert progress_calls == []
+
+
+@pytest.mark.asyncio
+async def test_sleep_without_callback_does_not_emit_heartbeats(monkeypatch):
+    """No update callback in context means a single sleep, no progress frames."""
+    slept = []
+
+    async def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr("atlas.modules.mcp_tools.sleep_tool.asyncio.sleep", fake_sleep)
+
+    result = await execute_sleep_tool(
+        _call(seconds=900),
+        max_seconds=7200,
+    )
+
+    assert result.success is True
+    assert slept == [900.0]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_is_cancellable(monkeypatch):
+    """A cancelled heartbeat loop raises CancelledError, same as a single sleep."""
+    progress_calls = []
+
+    async def fake_callback(payload):
+        progress_calls.append(payload)
+
+    call_count = 0
+
+    async def fake_sleep(seconds):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError()
+        # First chunk: let it pass
+        return
+
+    monkeypatch.setattr("atlas.modules.mcp_tools.sleep_tool.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await execute_sleep_tool(
+            _call(seconds=900),
+            max_seconds=7200,
+            context={"update_callback": fake_callback},
+        )
+
+    # At least one heartbeat was emitted before cancellation.
+    assert len(progress_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_total_reflects_clamped_duration(monkeypatch):
+    """The progress total is the *clamped* duration, not the requested one."""
+    progress_calls = []
+
+    async def fake_callback(payload):
+        progress_calls.append(payload)
+
+    async def fake_sleep(seconds):
+        pass
+
+    monkeypatch.setattr("atlas.modules.mcp_tools.sleep_tool.asyncio.sleep", fake_sleep)
+
+    result = await execute_sleep_tool(
+        _call(seconds=10000),
+        max_seconds=300,
+        context={"update_callback": fake_callback},
+    )
+
+    assert result.success is True
+    # All heartbeats should report the clamped total (300), not 10000.
+    for p in progress_calls:
+        assert p["total"] == 300.0

--- a/frontend/src/components/Message.jsx
+++ b/frontend/src/components/Message.jsx
@@ -299,7 +299,7 @@ const Message = ({ message, userIndex = null, onRewind = null, onCorrect = null 
                 </span>
               )}
               <span className="font-medium text-sm min-w-0 break-words">{message.tool_name}</span>
-              {isToolActive && <ToolElapsedTime timestamp={message.timestamp} toolName={message.tool_name} arguments={message.arguments} />}
+              {isToolActive && <ToolElapsedTime timestamp={message.timestamp} toolName={message.tool_name} arguments={message.arguments} progressRaw={message.progressRaw} />}
             </button>
           ) : (
             <button
@@ -332,7 +332,7 @@ const Message = ({ message, userIndex = null, onRewind = null, onCorrect = null 
               </span>
               <span className="font-medium min-w-0 break-words">{message.tool_name}</span>
               <span className="text-gray-400 text-sm min-w-0 break-words">({message.server_name})</span>
-              {isToolActive && <ToolElapsedTime timestamp={message.timestamp} toolName={message.tool_name} arguments={message.arguments} />}
+              {isToolActive && <ToolElapsedTime timestamp={message.timestamp} toolName={message.tool_name} arguments={message.arguments} progressRaw={message.progressRaw} />}
             </button>
           )}
 

--- a/frontend/src/components/ToolElapsedTime.jsx
+++ b/frontend/src/components/ToolElapsedTime.jsx
@@ -4,16 +4,21 @@ import { SLEEP_TOOL, migrateToolName } from '../constants/atlasTools'
 // Live "Xs" / "Xm Ys" ticker shown next to an active tool call. Once the tool
 // has been running past TOOL_SLOW_THRESHOLD_SEC we append a warning message.
 //
-// For the built-in sleep tool we instead show a progress clock against the requested
-// duration (`MM:SS of MM:SS`), because the generic slow-tool warning is
-// meaningless for a tool whose job is to wait minutes or hours (#838). Once the
-// requested wait has elapsed we switch to a "completing..." hint — the backend
-// is wrapping up and the tool_complete frame has not arrived yet.
+// For the built-in sleep tool we instead show a progress clock against the
+// *actual* wait duration (`MM:SS of MM:SS`). The actual duration comes from
+// the backend's heartbeat `tool_progress` frames (which carry the clamped
+// total), falling back to the requested `seconds` argument before the first
+// heartbeat arrives (#838, extended for the heartbeat fix). Once the
+// requested wait has elapsed we switch to a "completing..." hint; if the
+// clock runs well past the wait without a `tool_complete` frame the hint
+// escalates to "connection may be lost" so the user can distinguish a
+// finishing sleep from a genuinely stuck one.
 //
 // Extracted from Message.jsx. The 1-second setInterval is intentional — this
 // is a UI ticker, not a polling loop. See AGENTS.md on Message.jsx polling
 // rules.
 const TOOL_SLOW_THRESHOLD_SEC = 30
+const STALE_OVERDUE_SEC = 60
 
 // Clock style `MM:SS` (or `HH:MM:SS` for waits of an hour or more) — matches
 // the format the issue asked for and stays compact for the long waits the
@@ -30,7 +35,7 @@ const formatClock = (totalSec, useHours = false) => {
   return (useHours || hours > 0) ? `${String(hours).padStart(2, '0')}:${mm}:${ss}` : `${mm}:${ss}`
 }
 
-const ToolElapsedTime = ({ timestamp, toolName, arguments: args }) => {
+const ToolElapsedTime = ({ timestamp, toolName, arguments: args, progressRaw }) => {
   const [elapsed, setElapsed] = useState(0)
   const startRef = useRef(timestamp ? new Date(timestamp).getTime() : Date.now())
 
@@ -48,21 +53,27 @@ const ToolElapsedTime = ({ timestamp, toolName, arguments: args }) => {
     return () => clearInterval(id)
   }, [])
 
-  // Sleep tool: show progress against the requested duration instead of the
-  // generic "taking longer than expected" warning, which is misleading for a
-  // tool whose purpose is to wait minutes or hours (#838). A non-numeric or
-  // non-positive `seconds` falls back to the generic timer so we never show a
-  // nonsense "of NaN:NaN".
+  // Sleep tool: show progress against the *actual* wait duration instead of
+  // the generic "taking longer than expected" warning, which is misleading
+  // for a tool whose purpose is to wait minutes or hours (#838). The actual
+  // duration comes from the backend heartbeat's `total` field (which reflects
+  // clamping to the per-call/turn caps); before the first heartbeat arrives
+  // we fall back to the requested `seconds` argument. A non-numeric or
+  // non-positive value falls back to the generic timer.
   const rawSeconds = (args && args.seconds != null) ? args.seconds : null
+  const heartbeatTotal = (
+    progressRaw &&
+    Number.isFinite(Number(progressRaw.total)) &&
+    Number(progressRaw.total) > 0
+  ) ? Number(progressRaw.total) : null
   const sleepSeconds = (
     migrateToolName(toolName) === SLEEP_TOOL &&
-    rawSeconds != null &&
-    Number.isFinite(Number(rawSeconds)) &&
-    Number(rawSeconds) > 0
-  ) ? Number(rawSeconds) : null
+    (heartbeatTotal != null || (rawSeconds != null && Number.isFinite(Number(rawSeconds)) && Number(rawSeconds) > 0))
+  ) ? (heartbeatTotal != null ? heartbeatTotal : Number(rawSeconds)) : null
 
   if (sleepSeconds != null) {
     const overdue = elapsed >= sleepSeconds
+    const stale = elapsed >= sleepSeconds + STALE_OVERDUE_SEC
     // Keep both numbers on the same clock style: once either side crosses the
     // hour boundary, render both as HH:MM:SS so the elapsed / requested pair
     // never reads like `01:00 of 2:00:00`.
@@ -70,9 +81,11 @@ const ToolElapsedTime = ({ timestamp, toolName, arguments: args }) => {
     return (
       <span className="flex items-center gap-1 text-xs text-gray-400 ml-1">
         <span>{formatClock(elapsed, useHours)} of {formatClock(sleepSeconds, useHours)}</span>
-        {overdue && (
+        {stale ? (
+          <span className="text-red-400">- connection may be lost</span>
+        ) : overdue ? (
           <span className="text-yellow-400">- completing...</span>
-        )}
+        ) : null}
       </span>
     )
   }

--- a/frontend/src/test/ToolElapsedTime.test.jsx
+++ b/frontend/src/test/ToolElapsedTime.test.jsx
@@ -193,3 +193,91 @@ describe('ToolElapsedTime -- atlas_agent_sleep (#838)', () => {
     expect(container.textContent).not.toContain('of 20:00')
   })
 })
+
+describe('ToolElapsedTime -- heartbeat total from progressRaw', () => {
+  it('uses progressRaw.total as the clock denominator when available', () => {
+    // The backend clamps a 10000s request to 300s; the heartbeat reports
+    // total=300, so the clock should show the clamped duration, not 10000.
+    const { container } = render(
+      <ToolElapsedTime
+        timestamp={isoNow()}
+        toolName="atlas_agent_sleep"
+        arguments={{ seconds: 10000 }}
+        progressRaw={{ progress: 60, total: 300 }}
+      />
+    )
+    tick(60)
+    // 60s elapsed of 300s clamped -> 01:00 of 05:00
+    expect(container.textContent).toBe('01:00 of 05:00')
+    expect(container.textContent).not.toContain('20:00')
+  })
+
+  it('falls back to args.seconds before the first heartbeat arrives', () => {
+    const { container } = render(
+      <ToolElapsedTime
+        timestamp={isoNow()}
+        toolName="atlas_agent_sleep"
+        arguments={{ seconds: 1200 }}
+        progressRaw={undefined}
+      />
+    )
+    tick(60)
+    expect(container.textContent).toBe('01:00 of 20:00')
+  })
+
+  it('uses the consolidated tool name (atlas_sleep) too', () => {
+    const { container } = render(
+      <ToolElapsedTime
+        timestamp={isoNow()}
+        toolName="atlas_sleep"
+        arguments={{ seconds: 1200 }}
+        progressRaw={{ progress: 60, total: 1200 }}
+      />
+    )
+    tick(60)
+    expect(container.textContent).toBe('01:00 of 20:00')
+  })
+})
+
+describe('ToolElapsedTime -- stale hint for stuck sleep', () => {
+  it('shows "connection may be lost" past the overdue threshold', () => {
+    // 900s sleep, 900 + 61 = 961s elapsed -> stale
+    const { container } = render(
+      <ToolElapsedTime
+        timestamp={isoNow()}
+        toolName="atlas_agent_sleep"
+        arguments={{ seconds: 900 }}
+      />
+    )
+    tick(961)
+    expect(container.textContent).toContain('connection may be lost')
+    expect(container.textContent).not.toContain('completing...')
+  })
+
+  it('shows "completing..." before the stale threshold', () => {
+    // 900s sleep, 910s elapsed -> overdue but not yet stale (< 900 + 60)
+    const { container } = render(
+      <ToolElapsedTime
+        timestamp={isoNow()}
+        toolName="atlas_agent_sleep"
+        arguments={{ seconds: 900 }}
+      />
+    )
+    tick(910)
+    expect(container.textContent).toContain('completing...')
+    expect(container.textContent).not.toContain('connection may be lost')
+  })
+
+  it('does not show stale hint for a sleep still in progress', () => {
+    const { container } = render(
+      <ToolElapsedTime
+        timestamp={isoNow()}
+        toolName="atlas_agent_sleep"
+        arguments={{ seconds: 1200 }}
+      />
+    )
+    tick(60)
+    expect(container.textContent).not.toContain('connection may be lost')
+    expect(container.textContent).not.toContain('completing...')
+  })
+})


### PR DESCRIPTION
## Problem

The `atlas_sleep` tool did a single `asyncio.sleep(seconds)` for up to 7200 seconds (2 hours by default) with **zero `tool_progress` events**. If the `tool_complete` frame was lost (WebSocket disconnect, backend error, task cancellation without `tool_interrupted`), the frontend row stayed in `calling` status forever with the clock ticking.

**Evidence from the screenshot:** a 900-second sleep showed 79 minutes elapsed with the generic "taking longer than expected" warning instead of the sleep progress clock -- the `tool_complete` never arrived, so the row spun indefinitely.

## Root Cause

`execute_sleep_tool` in `atlas/modules/mcp_tools/sleep_tool.py` called `await asyncio.sleep(seconds)` as a single blocking call. Between `tool_start` and `tool_complete`, nothing was emitted on the WebSocket. The frontend has no staleness watchdog (documented gap in `websocketHandlers.test.js:353-355`), so a row that never receives `tool_complete` stays in `calling` with the clock counting up forever.

The sleep tool also bypassed the progress-handler wiring in `mcp_execution.py` (it returns before the generic MCP path that constructs `_progress_handler`), so no heartbeat was emitted.

## Fix

### Backend (`sleep_tool.py`)

- Break the wait into **heartbeat intervals** (capped at 30s, proportional for shorter waits) that emit `tool_progress` frames via the `update_callback` already present in the tool execution context dict.
- The heartbeat `total` field reflects the **clamped** duration (per-call cap and turn budget), not the raw request -- so the frontend clock is accurate even when the model asks for more than the cap allows.
- Short sleeps (<=10s) and calls without an `update_callback` still sleep in a single shot (no overhead).
- Cancellation is preserved: `asyncio.sleep(chunk)` raises `CancelledError` immediately on cancel, same as the single long sleep.

### Frontend (`ToolElapsedTime.jsx`, `Message.jsx`)

- `ToolElapsedTime` now accepts `progressRaw` (set on the message by the `tool_progress` handler) and uses `progressRaw.total` as the clock denominator when available, falling back to `args.seconds` before the first heartbeat arrives.
- Added a **"connection may be lost" (red)** hint when elapsed exceeds the wait by more than 60 seconds, distinguishing a finishing sleep (yellow "completing...") from a genuinely stuck one (red "connection may be lost").

## Tests

**Backend (8 new tests in `test_agent_sleep_tool.py`):**
- `_heartbeat_interval` returns correct values for short/medium/long waits
- Long sleep with callback emits multiple `tool_progress` frames with correct elapsed/total
- Short sleep (<=10s) does not emit heartbeats
- Sleep without callback does not emit heartbeats
- Heartbeat loop is cancellable (raises `CancelledError`)
- Heartbeat total reflects clamped duration (10000s request clamped to 300s -> total=300)

**Frontend (6 new tests in `ToolElapsedTime.test.jsx`):**
- Uses `progressRaw.total` as the clock denominator when available
- Falls back to `args.seconds` before the first heartbeat
- Works with the consolidated tool name (`atlas_sleep`)
- Shows "connection may be lost" past the overdue threshold (sleepSeconds + 60)
- Shows "completing..." before the stale threshold
- Does not show stale hint for a sleep still in progress

All 67 backend and 35 frontend related tests pass. Lint passes with 0 errors.

## Files Changed

| File | Change |
|------|--------|
| `atlas/modules/mcp_tools/sleep_tool.py` | Heartbeat loop, `_sleep_with_heartbeats`, `_heartbeat_interval` |
| `atlas/tests/test_agent_sleep_tool.py` | 8 new heartbeat tests |
| `frontend/src/components/ToolElapsedTime.jsx` | `progressRaw` support, stale hint |
| `frontend/src/components/Message.jsx` | Pass `progressRaw` to `ToolElapsedTime` |
| `frontend/src/test/ToolElapsedTime.test.jsx` | 6 new frontend tests |
| `CHANGELOG.md` | Changelog entry