### PR TITLE
fix(windows): stale POSIX-style APP_CONFIG_DIR no longer blanks the MCP config lookup; Build-Frontend matches intended body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #875 - 2026-08-31
+- **A stale POSIX-style `APP_CONFIG_DIR` no longer blanks the MCP config lookup on Windows**: a value like `/home/<user>/git/atlas-ui-3/config` (left in a Windows `.env` from a WSL/Linux setup) has no drive letter under Windows pathlib, so it is treated as relative and joined onto the current drive -- the backend searched a nonexistent `C:\home\...` location, logged "JSON config not found in any of these locations", and started with 0 MCP servers even though `config/mcp.json` existed next to the checkout. `ConfigManager._search_paths` now also searches the conventional repo-root `config/` directory (between the configured dir and the packaged `atlas/config/` defaults), the not-found warning names `APP_CONFIG_DIR` when it does not exist on the host, and `ps_agent_start.ps1` `Start-Backend` falls back to `<project_root>\config` with a loud warning. **Operators:** remove or fix any `APP_CONFIG_DIR=/home/...` line in your Windows `.env`; the app now tolerates it, but the clean setup is an unset value or a Windows path.
+- **`Build-Frontend` in `ps_agent_start.ps1` matches the intended body**: the `VITE_APP_NAME` fallback is the documented example default `"ATLAS"` (was `"Chat UI 13"`; `agent_start.sh` aligned so the parity pair stays consistent), and the `frontend/dist not found` error message uses `;` instead of an em dash to avoid mojibake on non-UTF8 Windows consoles.
+
 ### PR #873 - 2026-08-31
 - **S3 storage can now authenticate with IAM roles, EKS Pod Identity, IRSA or EC2 instance profiles**: `s3_access_key`/`s3_secret_key` defaulted to `minioadmin` and were passed straight to `boto3.client(...)`, which disables boto3's credential chain whenever explicit credentials (even empty strings) are given; they now default to `None` and falsy values are passed as `None`, while deployments setting `S3_ACCESS_KEY`/`S3_SECRET_KEY` are unchanged. An incomplete key pair is ignored (with a warning) rather than passed on to fail signing, and `docs/admin/file-storage.md` documents the credential-chain path.
 

--- a/agent_start.sh
+++ b/agent_start.sh
@@ -245,7 +245,7 @@ build_frontend() {
     # Use VITE_* values from the environment / .env instead of hardcoding.
     # If VITE_APP_NAME is not already set, fall back to the example default.
     if [ -z "$VITE_APP_NAME" ]; then
-        export VITE_APP_NAME="Chat UI 13"
+        export VITE_APP_NAME="ATLAS"
     fi
     # RAG citations UI is opt-in at build time; default to off if unset.
     if [ -z "$VITE_FEATURE_RAG_CITATIONS" ]; then

--- a/atlas/modules/config/config_loader.py
+++ b/atlas/modules/config/config_loader.py
@@ -50,6 +50,17 @@ class ConfigManager:
         Two-layer lookup:
         1. User config dir (APP_CONFIG_DIR, default "config/") - user customizations
         2. Package defaults (atlas/config/) - always available as fallback
+
+        The conventional repo-root ``config/`` directory is also searched in
+        between whenever APP_CONFIG_DIR does not already resolve to it. This
+        keeps a checkout working when APP_CONFIG_DIR names a directory that
+        does not exist on the current machine -- most commonly a POSIX-style
+        absolute path (e.g. ``/home/<user>/git/atlas-ui-3/config``) carried
+        over from WSL/Linux into a Windows ``.env``. On Windows such a value
+        has no drive letter, ``Path.is_absolute()`` is False, and the join
+        below produces a bogus drive-rooted path like ``C:\\home\\...``, so
+        without this fallback every config file would be reported missing and
+        MCP would start with 0 servers even though ``config/mcp.json`` exists.
         """
         project_root = self._atlas_root.parent
 
@@ -64,6 +75,7 @@ class ConfigManager:
         candidates: List[Path] = [
             config_dir / file_name,
             config_dir_project / file_name,
+            project_root / "config" / file_name,
             package_defaults,
         ]
 
@@ -114,6 +126,19 @@ class ConfigManager:
                 continue
 
         logger.warning(f"{file_type} config not found in any of these locations: {[str(p) for p in file_paths]}")
+        # Help operators self-diagnose the most common cause: APP_CONFIG_DIR
+        # pointing at a directory that does not exist on this machine (e.g. a
+        # POSIX-style path in a Windows .env). Never let the hint itself fail.
+        try:
+            configured_dir = self.app_settings.app_config_dir
+            if not Path(configured_dir).exists():
+                logger.warning(
+                    "APP_CONFIG_DIR '%s' does not exist on this machine; unset it or "
+                    "point it at an existing directory so the user config can be found",
+                    configured_dir,
+                )
+        except Exception:
+            pass
         return None
 
     @property

--- a/atlas/modules/config/config_loader.py
+++ b/atlas/modules/config/config_loader.py
@@ -10,6 +10,7 @@ Dependency direction: ``config_loader`` -> ``settings`` -> ``models``.
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -51,16 +52,20 @@ class ConfigManager:
         1. User config dir (APP_CONFIG_DIR, default "config/") - user customizations
         2. Package defaults (atlas/config/) - always available as fallback
 
-        The conventional repo-root ``config/`` directory is also searched in
-        between whenever APP_CONFIG_DIR does not already resolve to it. This
-        keeps a checkout working when APP_CONFIG_DIR names a directory that
-        does not exist on the current machine -- most commonly a POSIX-style
-        absolute path (e.g. ``/home/<user>/git/atlas-ui-3/config``) carried
-        over from WSL/Linux into a Windows ``.env``. On Windows such a value
-        has no drive letter, ``Path.is_absolute()`` is False, and the join
-        below produces a bogus drive-rooted path like ``C:\\home\\...``, so
-        without this fallback every config file would be reported missing and
-        MCP would start with 0 servers even though ``config/mcp.json`` exists.
+        When the configured user config dir (resolved against the project root
+        when relative) does not exist on the current machine, the conventional
+        repo-root ``config/`` directory is also searched in between. This keeps
+        a checkout working when APP_CONFIG_DIR names a directory that does not
+        exist here -- most commonly a POSIX-style absolute path (e.g.
+        ``/home/<user>/git/atlas-ui-3/config``) carried over from WSL/Linux
+        into a Windows ``.env``. On Windows such a value has no drive letter,
+        ``Path.is_absolute()`` is False, and the join below produces a bogus
+        drive-rooted path like ``C:\\home\\...``, so without this rescue every
+        config file would be reported missing and MCP would start with 0
+        servers even though ``config/mcp.json`` exists. When the configured
+        directory DOES exist, it stays authoritative (only it and the package
+        defaults are searched), so a deliberately partial custom dir is never
+        silently padded from the repo checkout.
         """
         project_root = self._atlas_root.parent
 
@@ -75,9 +80,16 @@ class ConfigManager:
         candidates: List[Path] = [
             config_dir / file_name,
             config_dir_project / file_name,
-            project_root / "config" / file_name,
-            package_defaults,
         ]
+
+        # Rescue for a stale/missing configured directory: without this the
+        # paths above simply do not exist anywhere on disk and every config
+        # file is reported missing. os.path.isdir takes the rendered path and
+        # never raises, keeping the lookup itself fail-safe.
+        if not os.path.isdir(str(config_dir_project)):
+            candidates.append(project_root / "config" / file_name)
+
+        candidates.append(package_defaults)
 
         seen = set()
         search_paths: List[Path] = []
@@ -126,19 +138,27 @@ class ConfigManager:
                 continue
 
         logger.warning(f"{file_type} config not found in any of these locations: {[str(p) for p in file_paths]}")
-        # Help operators self-diagnose the most common cause: APP_CONFIG_DIR
-        # pointing at a directory that does not exist on this machine (e.g. a
-        # POSIX-style path in a Windows .env). Never let the hint itself fail.
+        # Help operators self-diagnose the most common cause: an explicitly set
+        # APP_CONFIG_DIR pointing at a directory that does not exist on this
+        # machine (e.g. a POSIX-style path in a Windows .env). Skip when the
+        # setting is just the pydantic default, and resolve relative values
+        # against the project root (matching _search_paths), not the CWD.
+        # Never let the hint itself fail the load.
         try:
-            configured_dir = self.app_settings.app_config_dir
-            if not Path(configured_dir).exists():
-                logger.warning(
-                    "APP_CONFIG_DIR '%s' does not exist on this machine; unset it or "
-                    "point it at an existing directory so the user config can be found",
-                    configured_dir,
-                )
+            fields_set = getattr(self.app_settings, "model_fields_set", None)
+            if fields_set is None or "app_config_dir" in fields_set:
+                configured_dir = self.app_settings.app_config_dir
+                configured_path = Path(configured_dir)
+                if not configured_path.is_absolute():
+                    configured_path = self._atlas_root.parent / configured_path
+                if not os.path.isdir(str(configured_path)):
+                    logger.warning(
+                        "APP_CONFIG_DIR '%s' does not exist on this machine; unset it or "
+                        "point it at an existing directory so the user config can be found",
+                        configured_dir,
+                    )
         except Exception:
-            pass
+            pass  # diagnostic only; a failure here must never mask the real error
         return None
 
     @property

--- a/atlas/tests/test_config_manager_paths.py
+++ b/atlas/tests/test_config_manager_paths.py
@@ -1,9 +1,9 @@
 """Tests for ConfigManager config-file path resolution.
 
 Covers the two-layer lookup (user APP_CONFIG_DIR, then package defaults) and
-the repo-root ``config/`` fallback that rescues checkouts whose APP_CONFIG_DIR
-names a directory that does not exist on the current machine -- most commonly
-a POSIX-style absolute path (``/home/<user>/...``) carried from WSL/Linux into
+the repo-root ``config/`` rescue that applies only when the configured user
+config directory does not exist on the current machine -- most commonly a
+POSIX-style absolute path (``/home/<user>/...``) carried from WSL/Linux into
 a Windows ``.env``. On Windows pathlib such a value has no drive letter, is
 treated as relative, and joins onto the current drive as ``C:\\home\\...``
 (the exact "JSON config not found" symptom with 0 MCP servers loaded).
@@ -35,17 +35,22 @@ def test_prompt_provider_search_paths_prefer_project_config_dir():
     assert any("atlas/config/prompts" in s for s in str_paths)
 
 
-def _cm_with_settings(atlas_root, app_config_dir):
+def _cm_with_settings(atlas_root, app_config_dir, explicit=True):
     cm = ConfigManager(atlas_root=atlas_root)
-    # Only app_config_dir is consulted by _search_paths / the loader.
-    cm._app_settings = SimpleNamespace(app_config_dir=app_config_dir)
+    # model_fields_set mimics pydantic-settings: fields explicitly provided
+    # from any source. Only app_config_dir is consulted by the loader paths
+    # under test.
+    cm._app_settings = SimpleNamespace(
+        app_config_dir=app_config_dir,
+        model_fields_set={"app_config_dir"} if explicit else set(),
+    )
     return cm
 
 
-def test_missing_app_config_dir_falls_back_to_project_config(tmp_path, caplog):
+def test_missing_app_config_dir_falls_back_to_project_config(tmp_path):
     """A nonexistent APP_CONFIG_DIR must not blind the lookup: the conventional
-    repo-root config/ is still searched (before package defaults) and the file
-    is actually loaded from there."""
+    repo-root config/ is searched (before package defaults) and the file is
+    actually loaded from there."""
     atlas_root = tmp_path / "atlas"
     repo_config = tmp_path / "config"
     repo_config.mkdir()
@@ -55,33 +60,36 @@ def test_missing_app_config_dir_falls_back_to_project_config(tmp_path, caplog):
 
     paths = cm._search_paths("mcp.json")
     assert repo_config / "mcp.json" in paths
-    # Repo-root fallback comes before package defaults.
+    # Repo-root rescue comes before package defaults.
     assert paths.index(repo_config / "mcp.json") < paths.index(
         atlas_root / "config" / "mcp.json"
     )
 
-    with caplog.at_level(logging.INFO, logger="atlas.modules.config.config_loader"):
-        data = cm._load_file_with_error_handling(paths, "JSON")
+    data = cm._load_file_with_error_handling(paths, "JSON")
     assert data == {"calc": {"command": "x"}}
 
 
-def test_missing_app_config_dir_hint_fires_when_nothing_found(tmp_path, caplog):
-    """When no candidate exists, the warning names APP_CONFIG_DIR as the likely
-    cause so the operator sees the stale-path problem immediately."""
+def test_existing_custom_app_config_dir_is_not_padded_from_repo(tmp_path):
+    """When APP_CONFIG_DIR points at an existing custom dir, only that dir and
+    the package defaults are searched: a deliberately partial custom dir must
+    not silently pull in files from the repo-root config/ layer."""
     atlas_root = tmp_path / "atlas"
+    custom = tmp_path / "custom"
+    custom.mkdir()  # exists, but has no mcp.json
     repo_config = tmp_path / "config"
-    repo_config.mkdir()  # exists, but has no rag-sources.json
+    repo_config.mkdir()
+    (repo_config / "mcp.json").write_text('{"from_repo": {}}', encoding="utf-8")
 
-    cm = _cm_with_settings(atlas_root, "/nonexistent/posix/config")
-    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.config_loader"):
-        data = cm._load_file_with_error_handling(cm._search_paths("rag-sources.json"), "JSON")
-    assert data is None
-    assert any("APP_CONFIG_DIR" in r.message and "does not exist" in r.message for r in caplog.records)
+    cm = _cm_with_settings(atlas_root, str(custom))
+    paths = cm._search_paths("mcp.json")
+    assert (repo_config / "mcp.json") not in paths
+    # Without the file anywhere, the loader degrades to an empty config.
+    assert cm._load_file_with_error_handling(paths, "JSON") is None
 
 
-def test_existing_app_config_dir_wins_over_project_fallback(tmp_path):
-    """When APP_CONFIG_DIR is valid, its file wins; the fallback stays in the
-    list but is only reached if the configured dir lacks the file."""
+def test_existing_app_config_dir_wins_over_project_rescue(tmp_path):
+    """When APP_CONFIG_DIR is valid, its file wins; the rescue is only reached
+    if the configured dir does not exist at all."""
     atlas_root = tmp_path / "atlas"
     custom = tmp_path / "custom"
     custom.mkdir()
@@ -95,9 +103,9 @@ def test_existing_app_config_dir_wins_over_project_fallback(tmp_path):
     assert data == {"from_custom": {}}
 
 
-def test_default_app_config_dir_deduplicates_project_fallback(tmp_path):
-    """With the default relative "config", the new repo-root candidate is the
-    same path as config_dir_project, so it must be deduplicated away."""
+def test_default_app_config_dir_deduplicates_project_rescue(tmp_path):
+    """With the default relative "config", the rescue candidate is the same
+    path as config_dir_project, so it must be deduplicated away."""
     atlas_root = tmp_path / "atlas"
     cm = _cm_with_settings(atlas_root, "config")
     paths = cm._search_paths("mcp.json")
@@ -110,7 +118,7 @@ def test_windows_posix_app_config_dir_reproduces_bogus_path_and_recovers(monkeyp
     independent): APP_CONFIG_DIR=/home/agarlan/git/atlas-ui-3/config has no
     drive under Windows semantics, so the old join produced the logged
     'C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json'. The repo-root
-    fallback must now be present after the bogus candidates so the real
+    rescue must now be present after the bogus candidates so the real
     config/mcp.json is found."""
     atlas_root = PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/atlas")
     repo_config = PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/config")
@@ -132,6 +140,34 @@ def test_windows_posix_app_config_dir_reproduces_bogus_path_and_recovers(monkeyp
     assert repo_candidate in str_paths
     assert package_defaults in str_paths
     assert str_paths.index(repo_candidate) < str_paths.index(package_defaults)
+
+
+def test_missing_app_config_dir_hint_fires_when_nothing_found(tmp_path, caplog):
+    """When no candidate exists, the warning names APP_CONFIG_DIR as the likely
+    cause so the operator sees the stale-path problem immediately."""
+    atlas_root = tmp_path / "atlas"
+    repo_config = tmp_path / "config"
+    repo_config.mkdir()  # exists, but has no rag-sources.json
+
+    cm = _cm_with_settings(atlas_root, "/nonexistent/posix/config")
+    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.config_loader"):
+        data = cm._load_file_with_error_handling(cm._search_paths("rag-sources.json"), "JSON")
+    assert data is None
+    assert any("APP_CONFIG_DIR" in r.message and "does not exist" in r.message for r in caplog.records)
+
+
+def test_missing_app_config_dir_hint_skipped_for_pydantic_default(tmp_path, caplog):
+    """The hint must not fire when APP_CONFIG_DIR was never explicitly set
+    (AppSettings default "config"), e.g. an installed package run from a
+    non-repo CWD."""
+    atlas_root = tmp_path / "atlas"
+    cm = _cm_with_settings(atlas_root, "config", explicit=False)
+    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.config_loader"):
+        data = cm._load_file_with_error_handling(cm._search_paths("no-such-config.json"), "JSON")
+    assert data is None
+    assert not any("APP_CONFIG_DIR" in r.message and "does not exist" in r.message for r in caplog.records)
+    # The base "not found in any of these locations" warning still fires.
+    assert any("not found in any of these locations" in r.message for r in caplog.records)
 
 
 def test_missing_app_config_dir_hint_not_logged_when_dir_exists(tmp_path, caplog):

--- a/atlas/tests/test_config_manager_paths.py
+++ b/atlas/tests/test_config_manager_paths.py
@@ -1,4 +1,19 @@
+"""Tests for ConfigManager config-file path resolution.
 
+Covers the two-layer lookup (user APP_CONFIG_DIR, then package defaults) and
+the repo-root ``config/`` fallback that rescues checkouts whose APP_CONFIG_DIR
+names a directory that does not exist on the current machine -- most commonly
+a POSIX-style absolute path (``/home/<user>/...``) carried from WSL/Linux into
+a Windows ``.env``. On Windows pathlib such a value has no drive letter, is
+treated as relative, and joins onto the current drive as ``C:\\home\\...``
+(the exact "JSON config not found" symptom with 0 MCP servers loaded).
+"""
+
+import logging
+from pathlib import PureWindowsPath
+from types import SimpleNamespace
+
+import atlas.modules.config.config_loader as config_loader_module
 from atlas.modules.config.config_manager import ConfigManager
 from atlas.modules.prompts.prompt_provider import PromptProvider
 
@@ -18,3 +33,117 @@ def test_prompt_provider_search_paths_prefer_project_config_dir():
     str_paths = [str(p) for p in provider._base_paths]
     assert any("config/prompts" in s for s in str_paths)
     assert any("atlas/config/prompts" in s for s in str_paths)
+
+
+def _cm_with_settings(atlas_root, app_config_dir):
+    cm = ConfigManager(atlas_root=atlas_root)
+    # Only app_config_dir is consulted by _search_paths / the loader.
+    cm._app_settings = SimpleNamespace(app_config_dir=app_config_dir)
+    return cm
+
+
+def test_missing_app_config_dir_falls_back_to_project_config(tmp_path, caplog):
+    """A nonexistent APP_CONFIG_DIR must not blind the lookup: the conventional
+    repo-root config/ is still searched (before package defaults) and the file
+    is actually loaded from there."""
+    atlas_root = tmp_path / "atlas"
+    repo_config = tmp_path / "config"
+    repo_config.mkdir()
+    (repo_config / "mcp.json").write_text('{"calc": {"command": "x"}}', encoding="utf-8")
+
+    cm = _cm_with_settings(atlas_root, "/nonexistent/posix/config")
+
+    paths = cm._search_paths("mcp.json")
+    assert repo_config / "mcp.json" in paths
+    # Repo-root fallback comes before package defaults.
+    assert paths.index(repo_config / "mcp.json") < paths.index(
+        atlas_root / "config" / "mcp.json"
+    )
+
+    with caplog.at_level(logging.INFO, logger="atlas.modules.config.config_loader"):
+        data = cm._load_file_with_error_handling(paths, "JSON")
+    assert data == {"calc": {"command": "x"}}
+
+
+def test_missing_app_config_dir_hint_fires_when_nothing_found(tmp_path, caplog):
+    """When no candidate exists, the warning names APP_CONFIG_DIR as the likely
+    cause so the operator sees the stale-path problem immediately."""
+    atlas_root = tmp_path / "atlas"
+    repo_config = tmp_path / "config"
+    repo_config.mkdir()  # exists, but has no rag-sources.json
+
+    cm = _cm_with_settings(atlas_root, "/nonexistent/posix/config")
+    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.config_loader"):
+        data = cm._load_file_with_error_handling(cm._search_paths("rag-sources.json"), "JSON")
+    assert data is None
+    assert any("APP_CONFIG_DIR" in r.message and "does not exist" in r.message for r in caplog.records)
+
+
+def test_existing_app_config_dir_wins_over_project_fallback(tmp_path):
+    """When APP_CONFIG_DIR is valid, its file wins; the fallback stays in the
+    list but is only reached if the configured dir lacks the file."""
+    atlas_root = tmp_path / "atlas"
+    custom = tmp_path / "custom"
+    custom.mkdir()
+    (custom / "mcp.json").write_text('{"from_custom": {}}', encoding="utf-8")
+    repo_config = tmp_path / "config"
+    repo_config.mkdir()
+    (repo_config / "mcp.json").write_text('{"from_repo": {}}', encoding="utf-8")
+
+    cm = _cm_with_settings(atlas_root, str(custom))
+    data = cm._load_file_with_error_handling(cm._search_paths("mcp.json"), "JSON")
+    assert data == {"from_custom": {}}
+
+
+def test_default_app_config_dir_deduplicates_project_fallback(tmp_path):
+    """With the default relative "config", the new repo-root candidate is the
+    same path as config_dir_project, so it must be deduplicated away."""
+    atlas_root = tmp_path / "atlas"
+    cm = _cm_with_settings(atlas_root, "config")
+    paths = cm._search_paths("mcp.json")
+    str_paths = [str(p) for p in paths]
+    assert len(str_paths) == len(set(str_paths))
+
+
+def test_windows_posix_app_config_dir_reproduces_bogus_path_and_recovers(monkeypatch, tmp_path):
+    """Reproduce the exact Windows failure with PureWindowsPath (platform-
+    independent): APP_CONFIG_DIR=/home/agarlan/git/atlas-ui-3/config has no
+    drive under Windows semantics, so the old join produced the logged
+    'C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json'. The repo-root
+    fallback must now be present after the bogus candidates so the real
+    config/mcp.json is found."""
+    atlas_root = PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/atlas")
+    repo_config = PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/config")
+
+    monkeypatch.setattr(config_loader_module, "Path", PureWindowsPath)
+    cm = _cm_with_settings(atlas_root, "/home/agarlan/git/atlas-ui-3/config")
+
+    paths = cm._search_paths("mcp.json")
+    str_paths = [str(p) for p in paths]
+
+    # The exact bogus path from the Windows log is still generated (drive-rooted
+    # join of the drive-less POSIX value) -- documented, and harmless because it
+    # simply does not exist.
+    assert "C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json" in str_paths
+
+    # The fix: the real repo-root config dir is searched before package defaults.
+    repo_candidate = str(repo_config / "mcp.json")
+    package_defaults = str(atlas_root / "config" / "mcp.json")
+    assert repo_candidate in str_paths
+    assert package_defaults in str_paths
+    assert str_paths.index(repo_candidate) < str_paths.index(package_defaults)
+
+
+def test_missing_app_config_dir_hint_not_logged_when_dir_exists(tmp_path, caplog):
+    """No extra noise when APP_CONFIG_DIR exists but merely lacks the file."""
+    atlas_root = tmp_path / "atlas"
+    custom = tmp_path / "custom"
+    custom.mkdir()
+
+    cm = _cm_with_settings(atlas_root, str(custom))
+    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.config_loader"):
+        data = cm._load_file_with_error_handling(cm._search_paths("mcp.json"), "JSON")
+    assert data is None
+    assert not any("does not exist on this machine" in r.message for r in caplog.records)
+    # The base "not found in any of these locations" warning still fires.
+    assert any("not found in any of these locations" in r.message for r in caplog.records)

--- a/docs/getting-started/python-package.md
+++ b/docs/getting-started/python-package.md
@@ -455,6 +455,8 @@ atlas-server --env /path/to/.env --config-folder /path/to/config
 
 > **Auto-detection**: If a `config/` directory exists next to the loaded `.env` file, `atlas-server` automatically uses it as the config directory. You do not need to pass `--config-folder` or set `APP_CONFIG_DIR` unless you want to override this default.
 
+> **Stale `APP_CONFIG_DIR` values**: `APP_CONFIG_DIR` must point at a directory that exists on the machine running Atlas. A POSIX-style absolute path (for example `/home/<user>/.../config`) left in a Windows `.env` from a WSL or Linux setup does not resolve on Windows -- Windows pathlib sees it as drive-less and joins it onto the current drive (producing a nonexistent `C:\home\...` location), which makes every config file look missing and starts MCP with 0 servers. If the configured directory does not exist, Atlas logs a warning naming `APP_CONFIG_DIR` and still searches the conventional `config/` directory next to the project as a fallback, then the packaged defaults in `atlas/config/`.
+
 ## Development Installation (Editable Mode)
 
 For development, install the package in **editable mode** (`pip install -e .`). This creates a symlink from your Python environment to your local source code directory, allowing you to modify the code and see changes immediately without reinstalling.

--- a/docs/getting-started/python-package.md
+++ b/docs/getting-started/python-package.md
@@ -1,6 +1,6 @@
 # Using Atlas as a Python Package
 
-Last updated: 2026-02-04
+Last updated: 2026-08-31
 
 Atlas can be installed as a Python package, allowing you to use it programmatically in your scripts or integrate it into your applications.
 

--- a/ps_agent_start.ps1
+++ b/ps_agent_start.ps1
@@ -526,7 +526,7 @@ function Build-Frontend {
     # Use VITE_* values from the environment / .env instead of hardcoding.
     # If VITE_APP_NAME is not already set, fall back to the example default.
     if (-not $env:VITE_APP_NAME) {
-        $env:VITE_APP_NAME = "Chat UI 13"
+        $env:VITE_APP_NAME = "ATLAS"
     }
 
     # RAG citations UI is opt-in at build time; default to off if unset.
@@ -547,7 +547,7 @@ function Build-Frontend {
     # Copy build output to atlas/static/ so the backend always serves from one
     # location, matching the PyPI package layout.
     if (-not (Test-Path "$PROJECT_ROOT/frontend/dist")) {
-        Write-Host "ERROR: frontend/dist not found after build — keeping existing atlas/static/ assets."
+        Write-Host "ERROR: frontend/dist not found after build; keeping existing atlas/static/ assets."
         throw "frontend/dist not found after build."
     }
     if (Test-Path "$PROJECT_ROOT/atlas/static") {
@@ -572,6 +572,15 @@ function Start-Backend {
     # Set APP_CONFIG_DIR so user overrides in <project_root>/config/ take
     # precedence over package defaults in atlas/config/ (CWD is atlas/).
     if (-not $env:APP_CONFIG_DIR) {
+        $env:APP_CONFIG_DIR = "$PROJECT_ROOT/config"
+    } elseif (-not (Test-Path -LiteralPath $env:APP_CONFIG_DIR -PathType Container)) {
+        # A stale APP_CONFIG_DIR (commonly a POSIX-style path such as
+        # /home/<user>/... left in .env from a WSL/Linux setup) is drive-less
+        # under Windows path semantics, so the backend would search a bogus
+        # "C:\home\..." location, find no mcp.json, and start with 0 MCP
+        # servers even though <project_root>\config\mcp.json exists. Fall
+        # back to the project config dir and say why.
+        Write-Warning "APP_CONFIG_DIR points at '$($env:APP_CONFIG_DIR)', which does not exist on this machine. Falling back to '$PROJECT_ROOT/config' (a stale POSIX-style path from WSL/Linux in .env is a common cause)."
         $env:APP_CONFIG_DIR = "$PROJECT_ROOT/config"
     }
     $uvicornExe = "$PROJECT_ROOT/.venv/Scripts/uvicorn.exe"

--- a/ps_agent_start.ps1
+++ b/ps_agent_start.ps1
@@ -573,15 +573,24 @@ function Start-Backend {
     # precedence over package defaults in atlas/config/ (CWD is atlas/).
     if (-not $env:APP_CONFIG_DIR) {
         $env:APP_CONFIG_DIR = "$PROJECT_ROOT/config"
-    } elseif (-not (Test-Path -LiteralPath $env:APP_CONFIG_DIR -PathType Container)) {
-        # A stale APP_CONFIG_DIR (commonly a POSIX-style path such as
-        # /home/<user>/... left in .env from a WSL/Linux setup) is drive-less
-        # under Windows path semantics, so the backend would search a bogus
-        # "C:\home\..." location, find no mcp.json, and start with 0 MCP
-        # servers even though <project_root>\config\mcp.json exists. Fall
-        # back to the project config dir and say why.
-        Write-Warning "APP_CONFIG_DIR points at '$($env:APP_CONFIG_DIR)', which does not exist on this machine. Falling back to '$PROJECT_ROOT/config' (a stale POSIX-style path from WSL/Linux in .env is a common cause)."
-        $env:APP_CONFIG_DIR = "$PROJECT_ROOT/config"
+    } else {
+        # Resolve a relative value against the project root, NOT the current
+        # location (which is atlas/ here), matching how the backend resolves
+        # relative APP_CONFIG_DIR values in _search_paths.
+        $configuredDir = $env:APP_CONFIG_DIR
+        if (-not [System.IO.Path]::IsPathRooted($configuredDir)) {
+            $configuredDir = Join-Path $PROJECT_ROOT $configuredDir
+        }
+        if (-not (Test-Path -LiteralPath $configuredDir -PathType Container)) {
+            # A stale APP_CONFIG_DIR (commonly a POSIX-style path such as
+            # /home/<user>/... left in .env from a WSL/Linux setup) is drive-less
+            # under Windows path semantics, so the backend would search a bogus
+            # "C:\home\..." location, find no mcp.json, and start with 0 MCP
+            # servers even though <project_root>\config\mcp.json exists. Fall
+            # back to the project config dir and say why.
+            Write-Warning "APP_CONFIG_DIR points at '$($env:APP_CONFIG_DIR)' (resolved: '$configuredDir'), which does not exist on this machine. Falling back to '$PROJECT_ROOT/config' (a stale POSIX-style path from WSL/Linux in .env is a common cause)."
+            $env:APP_CONFIG_DIR = "$PROJECT_ROOT/config"
+        }
     }
     $uvicornExe = "$PROJECT_ROOT/.venv/Scripts/uvicorn.exe"
     $arguments = "main:app --host $HostName --port $Port"

--- a/test/pr-validation/test_pr875_windows_posix_config_path.sh
+++ b/test/pr-validation/test_pr875_windows_posix_config_path.sh
@@ -125,6 +125,17 @@ cm = make_cm(str(custom))
 data = cm._load_file_with_error_handling(cm._search_paths("mcp.json"), "JSON")
 check("valid APP_CONFIG_DIR keeps priority", data == {"from_custom": {}}, f"data={data}")
 
+# --- 4b. Existing custom dir is never padded from the repo checkout ---
+partial = workdir / "partial"
+partial.mkdir()  # exists but has no mcp.json
+cm = make_cm(str(partial))
+paths = [str(p) for p in cm._search_paths("mcp.json")]
+check(
+    "existing custom APP_CONFIG_DIR excludes repo-root config from candidates",
+    str(workdir / "config" / "mcp.json") not in paths,
+    f"paths={paths}",
+)
+
 # --- 5. Self-diagnosing warning fires when nothing is found ---
 records = []
 handler = logging.Handler()

--- a/test/pr-validation/test_pr875_windows_posix_config_path.sh
+++ b/test/pr-validation/test_pr875_windows_posix_config_path.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Test script for PR #875: recover config lookup from stale POSIX-style APP_CONFIG_DIR
+# Covers the PR test plan end to end:
+#   1. Reproduce the exact Windows symptom path (C:\home\agarlan\...\config\mcp.json)
+#      via PureWindowsPath and assert the repo-root fallback is searched first.
+#   2. Run the REAL ConfigManager.mcp_config against a fixture checkout whose
+#      APP_CONFIG_DIR points at a nonexistent POSIX path and assert the MCP
+#      config is found in the conventional config/ directory (1 server loads,
+#      instead of 0).
+#   3. Assert the default (relative "config") search list is unchanged.
+#   4. Assert a valid APP_CONFIG_DIR still wins over the fallback.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PASSED=0
+FAILED=0
+
+print_result() {
+    if [ $1 -eq 0 ]; then
+        echo -e "\033[0;32mPASSED\033[0m: $2"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "\033[0;31mFAILED\033[0m: $2"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+cd "$PROJECT_ROOT"
+if [ -f .venv/bin/activate ]; then
+    source .venv/bin/activate
+else
+    echo "FATAL: .venv not found; run uv venv && uv pip install -e '.[dev]'"
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d /tmp/pr875.XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+python - "$WORKDIR" << 'PYEOF'
+import logging
+import sys
+from pathlib import Path, PureWindowsPath
+
+import atlas.modules.config.config_loader as config_loader_module
+from atlas.modules.config.config_manager import ConfigManager
+
+workdir = Path(sys.argv[1])
+failures = []
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"PASSED: {name}")
+    else:
+        print(f"FAILED: {name} {detail}")
+        failures.append(name)
+
+# ---- Fixture checkout: atlas/ package dir + conventional config/mcp.json ----
+atlas_root = workdir / "atlas"
+atlas_root.mkdir()
+repo_config = workdir / "config"
+repo_config.mkdir()
+(repo_config / "mcp.json").write_text(
+    '{"calc": {"command": ["python", "srv.py"], "groups": ["users"]}}'
+)
+
+def make_cm(app_config_dir):
+    cm = ConfigManager(atlas_root=atlas_root)
+    cm._app_settings = type(
+        "S", (), {"app_config_dir": app_config_dir, "mcp_config_file": "mcp.json"}
+    )()
+    return cm
+
+# --- 1. Real end-to-end: stale POSIX APP_CONFIG_DIR, config still found ---
+cm = make_cm("/home/agarlan/git/atlas-ui-3/config")
+cfg = cm.mcp_config
+check(
+    "stale POSIX APP_CONFIG_DIR still loads config/mcp.json (1 server, was 0)",
+    list(cfg.servers) == ["calc"],
+    f"got servers={list(cfg.servers)}",
+)
+
+# --- 2. Windows-flavour reproduction of the exact logged path + recovery ---
+repo_cfg_win = PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/config")
+saved = config_loader_module.Path
+config_loader_module.Path = PureWindowsPath
+try:
+    cm = make_cm("/home/agarlan/git/atlas-ui-3/config")
+    cm._atlas_root = PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/atlas")
+    paths = cm._search_paths("mcp.json")
+    strs = [str(p) for p in paths]
+finally:
+    config_loader_module.Path = Path
+
+check(
+    "reproduces logged bogus path C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json",
+    "C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json" in strs,
+    f"paths={strs}",
+)
+repo_candidate = str(repo_cfg_win / "mcp.json")
+pkg_defaults = "C:\\Users\\agarlan\\git\\atlas-ui-3\\atlas\\config\\mcp.json"
+check("repo-root fallback present on Windows-flavour lookup", repo_candidate in strs, f"paths={strs}")
+check(
+    "repo-root fallback precedes package defaults",
+    strs.index(repo_candidate) < strs.index(pkg_defaults),
+)
+check(
+    "bogus candidates come first (documented), real candidates follow",
+    strs.index("C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json") < strs.index(repo_candidate),
+)
+
+# --- 3. Default relative config: list must be deduplicated and unchanged in order ---
+cm = make_cm("config")
+paths = [str(p) for p in cm._search_paths("mcp.json")]
+check("default relative config has no duplicate candidates", len(paths) == len(set(paths)))
+check(
+    "default lookup still puts user config before package defaults",
+    paths.index(str(workdir / "config" / "mcp.json")) < paths.index(str(atlas_root / "config" / "mcp.json")),
+)
+
+# --- 4. Valid absolute APP_CONFIG_DIR wins over the fallback ---
+custom = workdir / "custom"
+custom.mkdir()
+(custom / "mcp.json").write_text('{"from_custom": {}}')
+cm = make_cm(str(custom))
+data = cm._load_file_with_error_handling(cm._search_paths("mcp.json"), "JSON")
+check("valid APP_CONFIG_DIR keeps priority", data == {"from_custom": {}}, f"data={data}")
+
+# --- 5. Self-diagnosing warning fires when nothing is found ---
+records = []
+handler = logging.Handler()
+handler.emit = lambda r: records.append(r)
+logger = logging.getLogger("atlas.modules.config.config_loader")
+logger.addHandler(handler)
+logger.setLevel(logging.WARNING)
+cm = make_cm("/nonexistent/posix/config")
+data = cm._load_file_with_error_handling(cm._search_paths("rag-sources.json"), "JSON")
+check(
+    "warning names stale APP_CONFIG_DIR",
+    data is None and any("APP_CONFIG_DIR" in r.getMessage() and "does not exist" in r.getMessage() for r in records),
+    f"records={[r.getMessage() for r in records]}",
+)
+
+print()
+if failures:
+    print(f"PR875 validation: {len(failures)} FAILED")
+    raise SystemExit(1)
+print("PR875 validation: all checks passed")
+PYEOF
+print_result $? "ConfigManager stale-POSIX-path recovery (end-to-end)"
+
+# --- 6. Backend unit tests as final gate ---
+bash ./test/run_tests.sh backend > /tmp/pr875_backend.log 2>&1
+print_result $? "backend test suite"
+
+echo ""
+echo "===================="
+echo "PASSED: $PASSED  FAILED: $FAILED"
+[ $FAILED -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Problem

Two Windows startup issues, owned end to end here:

1. **0 MCP servers load on Windows even though `config/mcp.json` exists.** The logs show:

   ```
   JSON config not found in any of these locations: ['C:\\home\\agarlan\\git\\atlas-ui-3\\config\\mcp.json']
   ```

   followed by `Created empty MCP config (no configuration file found)`.

2. **`Build-Frontend` in `ps_agent_start.ps1` drifted from the intended function body.**

## Root cause (1): POSIX-style `APP_CONFIG_DIR` is drive-less on Windows

`AppSettings.app_config_dir` picks up `APP_CONFIG_DIR` from the process env / `.env`. A value like `/home/agarlan/git/atlas-ui-3/config` (a leftover from a WSL/Linux setup of the same checkout) is:

- **absolute on POSIX**, so nothing breaks on Linux;
- **not absolute on Windows** — pathlib sees no drive letter (`is_absolute() == False`, `root='\', drive=''`), so `ConfigManager._search_paths` takes the `project_root / config_dir` branch, and joining a rooted drive-less path onto `C:\...\<repo>\atlas` *replaces everything after the drive letter*:

  ```python
  PureWindowsPath("C:/Users/agarlan/git/atlas-ui-3/atlas") / PureWindowsPath("/home/agarlan/git/atlas-ui-3/config")
  # -> C:\home\agarlan\git\atlas-ui-3\config
  ```

  which reproduces the logged `C:\home\agarlan\git\atlas-ui-3\config\mcp.json` byte for byte. The real `config\mcp.json` next to the checkout is never searched, so Atlas logs "not found", builds an empty `MCPConfig`, and starts with **0 MCP servers**.

### Fix

- `ConfigManager._search_paths` now also searches the conventional repo-root `config/` directory **between** the configured dir and the packaged `atlas/config/` defaults. A stale `APP_CONFIG_DIR` (POSIX path on Windows, deleted dir, typo) can no longer blind the lookup. With the default relative `config`, the new candidate deduplicates to the existing list, so default behavior is unchanged; with a valid absolute dir, that dir still wins (first match).
- The "config not found in any of these locations" warning now appends a hint naming `APP_CONFIG_DIR` when that directory does not exist on the host, so this failure is self-diagnosing next time.
- `ps_agent_start.ps1`'s `Start-Backend` (the Windows startup path from the report) now falls back to `<project_root>\config` with a loud `Write-Warning` when the inherited `APP_CONFIG_DIR` does not exist on the machine — this covers the operator's flow even before the backend fix is deployed.

## Build-Frontend matches the intended body

- `$env:VITE_APP_NAME` fallback is now the documented example default **`"ATLAS"`** (`.env.example` ships `VITE_APP_NAME=ATLAS`; the comment already said "fall back to the example default"). `agent_start.sh` is aligned so the parity pair stays consistent — flagging that this also changes the Linux fallback from `"Chat UI 13"`; easy to drop if unintended.
- The `frontend/dist not found` message uses `;` instead of an em dash (matches the intended body; also avoids mojibake on non-UTF8 Windows consoles).

## Verification (Linux — explicit limits below)

- **PowerShell 7.4.7** (Core, runs on Linux): full `ps_agent_start.ps1` parses with 0 syntax errors; existing `test/pr-validation/test_pr863_ps_env_parser.ps1` regression suite passes.
- **`Build-Frontend` equivalence**: token-for-token equality with the intended body (98 meaningful tokens via the PowerShell tokenizer — only blank-line placement differs). Behavior exercised with a stubbed `npm`: happy path (`npm install` → `npm run build` → `dist` copied to `atlas/static`, `VITE_APP_NAME` defaults to `ATLAS`, `VITE_FEATURE_RAG_CITATIONS` to `false`), install failure throws the exact message, build failure **preserves existing `atlas/static`**, missing `dist` throws and preserves assets.
- **Config resolution**: new unit tests in `atlas/tests/test_config_manager_paths.py`, including a `PureWindowsPath` simulation (platform-independent, runs on Linux) that reproduces the exact logged `C:\home\agarlan\...\mcp.json` path and asserts the repo-root fallback precedes package defaults; native-POSIX fallback + loader tests; default-dedup regression test.
- End-to-end on Linux: `ConfigManager.mcp_config` with a stale POSIX `APP_CONFIG_DIR` and `config/mcp.json` in a fixture checkout loads 1 server (previously: 0).
- `./test/run_tests.sh backend` green (includes live E2E); `ruff check` clean on changed files (48 pre-existing warnings on `main` untouched); `npm run lint` matches the `main` baseline (4 pre-existing warnings, 0 errors — no frontend files changed).

## What could NOT be verified (no Windows host)

- Actual `windows-pathlib` behavior was validated via `PureWindowsPath` (the platform-independent Windows flavour) rather than a real `WindowsPath`; concrete `WindowsPath.exists()` resolution against the current drive was not executed on a Windows kernel.
- The `ps1` changes were parsed and the extracted functions executed under PowerShell 7.4.7 on Linux, but not under Windows PowerShell 5.1 (`Start-Backend`'s `Test-Path -LiteralPath` and `Start-Process` semantics are equivalent for these calls, but this was not observed on Windows).
- The operator-side `.env` still contains the stale value; after merge the app tolerates it (repo-root fallback), but removing/commenting `APP_CONFIG_DIR=/home/...` in the Windows `.env` is the clean fix and is now warned about at startup.

Docs updated: `docs/getting-started/python-package.md` (stale `APP_CONFIG_DIR` behavior + fallback). Follow-up candidate (not in this PR): `PromptProvider._resolve_base_paths` has the same theoretical weakness if `PROMPT_BASE_PATH` is set to a POSIX-absolute path on Windows.
