### PR TITLE
feat: canvas width and orientation controls (#754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #TBD - 2026-09-02
+- **The canvas can now take the full window or stack above the chat** (#754): the canvas header gains an expand/shrink control (half <-> full width, with the chat hidden at full) and a move control (beside the chat <-> above the chat), alongside the existing close button. Below 768px the layout is forced to stacked -- a side-by-side split is unreadable on a phone -- and the move control is hidden without overwriting the stored preference, so widening the window restores it. Both choices persist per browser in local storage.
+
 ### PR #876 - 2026-09-01
 - **The Active Tools strip's "+N more" / "Show less" toggle expands visibly again**: making the strip a single row (#870) turned the pill row into `flex-nowrap` + `overflow-x-auto`, so expanding it only lengthened a row that already scrolled horizontally -- the extra pills rendered off-screen and clicking "+25 more" looked like it did nothing. Expanded, the row now wraps into a height-capped (`max-h-24`), vertically scrolling block; collapsed, it stays the single horizontally scrolling row from #870. The toggle also exposes `aria-expanded`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### PR #TBD - 2026-09-02
+### PR #883 - 2026-09-02
 - **The canvas can now take the full window or stack above the chat** (#754): the canvas header gains an expand/shrink control (half <-> full width, with the chat hidden at full) and a move control (beside the chat <-> above the chat), alongside the existing close button. Below 768px the layout is forced to stacked -- a side-by-side split is unreadable on a phone -- and the move control is hidden without overwriting the stored preference, so widening the window restores it. Both choices persist per browser in local storage.
 
 ### PR #876 - 2026-09-01

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -7,6 +7,7 @@ first-run setup, see [getting-started/](../getting-started/README.md).
 
 ## Features
 
+- [Canvas Layout Controls](canvas-layout/README.md) - Expand the canvas to full width, stack it above the chat, and keep the choice per device
 - [Custom Prompt Library](custom-prompts/README.md) - Save, edit, and reuse your own prompts
 - [Rewind / Edit a Previous Prompt](rewind-edit/README.md) - Edit one of your earlier messages and re-run from there
 - [Workspaces](workspaces/README.md) - Save prompt, data source, and tool selections as named contexts and switch between them

--- a/docs/user-guide/canvas-layout/README.md
+++ b/docs/user-guide/canvas-layout/README.md
@@ -1,0 +1,41 @@
+# Canvas Layout Controls
+
+Last updated: 2026-09-02
+
+The canvas is the panel that shows tool output -- documents, images, charts,
+rendered HTML. By default it opens beside the chat and takes about half the
+window. On a narrow window, and especially on a phone, a side-by-side split
+leaves both the chat and the document too narrow to read. The canvas header
+carries two controls for reshaping that split, plus the existing close button.
+
+## The controls
+
+All three live in the top-right corner of the canvas header.
+
+| Control | What it does |
+| --- | --- |
+| Expand / Shrink (`Maximize` / `Minimize` icon) | Toggles between **half** (the canvas shares the window with the chat) and **full** (the canvas takes the whole content area and the chat is hidden). |
+| Move (`PanelTop` / `PanelRight` icon) | Toggles between **beside the chat** (canvas on the right) and **above the chat** (canvas stacked on top, chat below). |
+| Close (`X`) | Hides the canvas entirely. |
+
+Hiding the canvas is not permanent: reopen it from the canvas button in the app
+header, and new canvas content arriving from a tool reopens it automatically.
+
+## Narrow windows and phones
+
+Below 768px wide the layout is always stacked -- canvas above, chat below --
+because a horizontal split at that width is unusable. The Move control is
+hidden while that applies, since there is nothing to choose. Your stored
+"beside the chat" preference is not overwritten: widen the window (or rotate a
+tablet back to landscape) and the side-by-side layout returns.
+
+The Expand control still works on a narrow window, and is the fastest way to
+read a document on a phone: expand to full, read, then shrink back to get the
+chat input in view again.
+
+## Persistence
+
+Both choices are remembered in the browser's local storage
+(`chatui-canvas-size` and `chatui-canvas-orientation`), so the same device keeps
+your layout across sessions. The setting is per-browser, not per-account -- your
+phone and your desktop each keep their own preference.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import ElicitationDialog from './components/ElicitationDialog'
 import AgentPortal from './components/AgentPortal'
 import { ToastProvider, DialogProvider } from './components/ui/ToastProvider'
 import { watchAppViewportHeight } from './utils/visualViewportHeight'
+import { useCanvasLayout } from './hooks/useCanvasLayout'
 
 // Log build info to browser console on startup
 console.info(
@@ -41,6 +42,16 @@ function ChatInterface() {
   const [filesPanelOpen, setFilesPanelOpen] = useState(false)
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
   const { canvasContent, customUIContent, canvasFiles, features, pendingElicitation } = useChat()
+  const {
+    size: canvasSize,
+    effectiveOrientation: canvasOrientation,
+    isNarrow: canvasIsNarrow,
+    toggleSize: toggleCanvasSize,
+    toggleOrientation: toggleCanvasOrientation,
+  } = useCanvasLayout()
+
+  // The canvas hides the chat only while it is actually open and set to full size
+  const canvasIsFullscreen = canvasPanelOpen && canvasSize === 'full'
 
   useEffect(() => watchAppViewportHeight(), [])
 
@@ -140,16 +151,27 @@ function ChatInterface() {
             onCloseCanvas={() => setCanvasPanelOpen(false)}
           />
 
-          {/* Content Area - Chat and Canvas side by side */}
-          <div className="flex flex-1 overflow-hidden min-h-0">
-            {/* Chat Area */}
-            <ChatArea />
+          {/* Content Area - chat and canvas, side by side or stacked */}
+          <div
+            className={`flex flex-1 overflow-hidden min-h-0 ${canvasOrientation === 'top' ? 'flex-col-reverse' : ''}`}
+          >
+            {/* Chat Area - kept mounted (never unmounted) so drafts survive a full-size canvas */}
+            <div
+              className={`flex flex-1 min-h-0 min-w-0 overflow-hidden ${canvasIsFullscreen ? 'hidden' : ''}`}
+            >
+              <ChatArea />
+            </div>
 
             {/* Canvas Panel */}
             <CanvasPanel
               isOpen={canvasPanelOpen}
               onClose={() => setCanvasPanelOpen(false)}
               onWidthChange={setCanvasPanelWidth}
+              size={canvasSize}
+              orientation={canvasOrientation}
+              orientationLocked={canvasIsNarrow}
+              onToggleSize={toggleCanvasSize}
+              onToggleOrientation={toggleCanvasOrientation}
             />
           </div>
         </div>

--- a/frontend/src/components/CanvasPanel.jsx
+++ b/frontend/src/components/CanvasPanel.jsx
@@ -1,4 +1,4 @@
-import { X, ChevronLeft, ChevronRight, Download, FileText, Image, File, Code } from 'lucide-react'
+import { X, ChevronLeft, ChevronRight, Download, FileText, Image, File, Code, Maximize2, Minimize2, PanelRight, PanelTop } from 'lucide-react'
 import { useChat } from '../contexts/ChatContext'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
@@ -50,7 +50,16 @@ const processCanvasContent = (content) => {
 const MIN_WIDTH = 300;
 const MAX_WIDTH = window.innerWidth * 0.9;
 
-const CanvasPanel = ({ isOpen, onClose, onWidthChange }) => {
+const CanvasPanel = ({
+  isOpen,
+  onClose,
+  onWidthChange,
+  size = 'half',
+  orientation = 'right',
+  orientationLocked = false,
+  onToggleSize,
+  onToggleOrientation,
+}) => {
   const { 
     canvasContent, 
     customUIContent, 
@@ -408,18 +417,37 @@ const CanvasPanel = ({ isOpen, onClose, onWidthChange }) => {
     )
   }
 
+  const isStacked = orientation === 'top';
+  const isFullSize = size === 'full';
+  // The drag handle only makes sense for a side-by-side canvas that isn't already full screen
+  const showResizeHandle = !isMobile && !isStacked && !isFullSize;
+
+  const panelStyle = isStacked
+    ? {
+        width: '100%',
+        minWidth: 0,
+        maxWidth: '100%',
+        height: isFullSize ? '100%' : '50%',
+        flexShrink: 0,
+        boxSizing: 'border-box',
+      }
+    : {
+        width: isFullSize ? '100%' : `${width}px`,
+        minWidth: isFullSize ? '100%' : `${MIN_WIDTH}px`,
+        maxWidth: isFullSize ? '100%' : `${window.innerWidth * 0.9}px`,
+        boxSizing: 'border-box',
+      };
+
   return (
     <aside
-      className={`bg-gray-800 border-l border-gray-700 transform transition-all duration-300 ease-in-out ${isOpen ? 'flex flex-col' : 'hidden'}`}
-      style={{
-        width: isMobile ? '100vw' : `${width}px`,
-        minWidth: isMobile ? '100vw' : `${MIN_WIDTH}px`,
-        maxWidth: isMobile ? '100vw' : `${window.innerWidth * 0.9}px`,
-        boxSizing: 'border-box',
-      }}
+      className={`bg-gray-800 ${isStacked ? 'border-b' : 'border-l'} border-gray-700 transform transition-all duration-300 ease-in-out ${isOpen ? 'flex flex-col' : 'hidden'}`}
+      style={panelStyle}
+      data-testid="canvas-panel"
+      data-canvas-size={size}
+      data-canvas-orientation={orientation}
     >
       {/* Draggable Divider */}
-      {!isMobile && (
+      {showResizeHandle && (
         <div
           style={{
             position: 'absolute',
@@ -449,12 +477,36 @@ const CanvasPanel = ({ isOpen, onClose, onWidthChange }) => {
       <div className="border-b border-gray-700 bg-gray-900">
         <div className="flex items-center justify-between p-4">
           <h2 className="text-lg font-semibold text-gray-100">Canvas</h2>
-          <button
-            onClick={onClose}
-            className="p-2 rounded-lg bg-gray-700 hover:bg-gray-600 transition-colors"
-          >
-            <X className="w-5 h-5" />
-          </button>
+          <div className="flex items-center gap-2">
+            {!orientationLocked && (
+            <button
+              onClick={onToggleOrientation}
+              className="p-2 rounded-lg bg-gray-700 hover:bg-gray-600 transition-colors"
+              title={isStacked ? 'Move canvas beside the chat' : 'Move canvas above the chat'}
+              aria-label={isStacked ? 'Move canvas beside the chat' : 'Move canvas above the chat'}
+              data-testid="canvas-orientation-toggle"
+            >
+              {isStacked ? <PanelRight className="w-5 h-5" /> : <PanelTop className="w-5 h-5" />}
+            </button>
+            )}
+            <button
+              onClick={onToggleSize}
+              className="p-2 rounded-lg bg-gray-700 hover:bg-gray-600 transition-colors"
+              title={isFullSize ? 'Shrink canvas to half the screen' : 'Expand canvas to the full screen'}
+              aria-label={isFullSize ? 'Shrink canvas to half the screen' : 'Expand canvas to the full screen'}
+              data-testid="canvas-size-toggle"
+            >
+              {isFullSize ? <Minimize2 className="w-5 h-5" /> : <Maximize2 className="w-5 h-5" />}
+            </button>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-lg bg-gray-700 hover:bg-gray-600 transition-colors"
+              title="Hide canvas"
+              aria-label="Hide canvas"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
         </div>
         
         {/* File navigation */}

--- a/frontend/src/components/CanvasPanel.jsx
+++ b/frontend/src/components/CanvasPanel.jsx
@@ -48,7 +48,6 @@ const processCanvasContent = (content) => {
 
 
 const MIN_WIDTH = 300;
-const MAX_WIDTH = window.innerWidth * 0.9;
 
 const CanvasPanel = ({
   isOpen,

--- a/frontend/src/hooks/useCanvasLayout.js
+++ b/frontend/src/hooks/useCanvasLayout.js
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react'
+import { usePersistentState } from './chat/usePersistentState'
+
+export const CANVAS_SIZES = ['half', 'full']
+export const CANVAS_ORIENTATIONS = ['right', 'top']
+
+const SIZE_KEY = 'chatui-canvas-size'
+const ORIENTATION_KEY = 'chatui-canvas-orientation'
+
+// Below this width a side-by-side split leaves both panes too narrow to read,
+// so the canvas stacks above the chat no matter what the stored preference says.
+export const NARROW_VIEWPORT_PX = 768
+
+function readIsNarrow() {
+  if (typeof window === 'undefined') return false
+  return window.innerWidth < NARROW_VIEWPORT_PX
+}
+
+/**
+ * Canvas layout preference: how much room the canvas takes ("half" or "full")
+ * and where it sits relative to the chat ("right" or "top"). Persisted per
+ * browser so the same device keeps the user's choice across sessions.
+ */
+export function useCanvasLayout() {
+  const [storedSize, setSize] = usePersistentState(SIZE_KEY, 'half')
+  const [storedOrientation, setOrientation] = usePersistentState(ORIENTATION_KEY, 'right')
+  const [isNarrow, setIsNarrow] = useState(readIsNarrow)
+
+  useEffect(() => {
+    const onResize = () => setIsNarrow(readIsNarrow())
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  const size = CANVAS_SIZES.includes(storedSize) ? storedSize : 'half'
+  const orientation = CANVAS_ORIENTATIONS.includes(storedOrientation) ? storedOrientation : 'right'
+
+  // What the layout actually renders as. The stored preference is left alone so
+  // rotating back to a wide viewport restores the user's side-by-side choice.
+  const effectiveOrientation = isNarrow ? 'top' : orientation
+
+  const toggleSize = useCallback(() => {
+    setSize((prev) => (prev === 'full' ? 'half' : 'full'))
+  }, [setSize])
+
+  const toggleOrientation = useCallback(() => {
+    setOrientation((prev) => (prev === 'top' ? 'right' : 'top'))
+  }, [setOrientation])
+
+  return { size, orientation, effectiveOrientation, isNarrow, toggleSize, toggleOrientation }
+}
+
+export default useCanvasLayout

--- a/frontend/src/test/canvas-layout.test.jsx
+++ b/frontend/src/test/canvas-layout.test.jsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for the canvas width/orientation controls (issue #754).
+ * Covers: cycling half <-> full, switching between side-by-side and stacked,
+ * and persistence of both choices in localStorage.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CanvasPanel from '../components/CanvasPanel'
+import { useCanvasLayout } from '../hooks/useCanvasLayout'
+
+vi.mock('../contexts/ChatContext', () => ({
+  useChat: () => ({
+    canvasContent: 'hello canvas',
+    customUIContent: null,
+    canvasFiles: [],
+    currentCanvasFileIndex: 0,
+    setCurrentCanvasFileIndex: vi.fn(),
+    downloadFile: vi.fn(),
+  }),
+}))
+
+const createLocalStorageMock = () => {
+  let store = {}
+  return {
+    getItem: vi.fn(key => (key in store ? store[key] : null)),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value)
+    }),
+    removeItem: vi.fn(key => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+  }
+}
+
+describe('canvas layout controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    Object.defineProperty(window, 'localStorage', {
+      value: createLocalStorageMock(),
+      writable: true,
+    })
+  })
+
+  it('defaults to a half-width canvas beside the chat', () => {
+    render(<CanvasPanel isOpen={true} onClose={vi.fn()} />)
+    const panel = screen.getByTestId('canvas-panel')
+    expect(panel.dataset.canvasSize).toBe('half')
+    expect(panel.dataset.canvasOrientation).toBe('right')
+  })
+
+  it('renders full size without a drag handle and stacked without a left border', () => {
+    const { rerender } = render(
+      <CanvasPanel isOpen={true} onClose={vi.fn()} size="full" orientation="right" />
+    )
+    let panel = screen.getByTestId('canvas-panel')
+    expect(panel.style.width).toBe('100%')
+    expect(panel.querySelector('[style*="ew-resize"]')).toBeNull()
+
+    rerender(<CanvasPanel isOpen={true} onClose={vi.fn()} size="half" orientation="top" />)
+    panel = screen.getByTestId('canvas-panel')
+    expect(panel.style.height).toBe('50%')
+    expect(panel.className).toContain('border-b')
+    expect(panel.className).not.toContain('border-l')
+  })
+
+  it('invokes the size and orientation callbacks from the header buttons', async () => {
+    const user = userEvent.setup()
+    const onToggleSize = vi.fn()
+    const onToggleOrientation = vi.fn()
+    render(
+      <CanvasPanel
+        isOpen={true}
+        onClose={vi.fn()}
+        onToggleSize={onToggleSize}
+        onToggleOrientation={onToggleOrientation}
+      />
+    )
+
+    await user.click(screen.getByTestId('canvas-size-toggle'))
+    await user.click(screen.getByTestId('canvas-orientation-toggle'))
+
+    expect(onToggleSize).toHaveBeenCalledTimes(1)
+    expect(onToggleOrientation).toHaveBeenCalledTimes(1)
+  })
+
+  it('persists the layout choice for the device', () => {
+    const { result } = renderHook(() => useCanvasLayout())
+    expect(result.current.size).toBe('half')
+    expect(result.current.orientation).toBe('right')
+
+    act(() => {
+      result.current.toggleSize()
+      result.current.toggleOrientation()
+    })
+
+    expect(result.current.size).toBe('full')
+    expect(result.current.orientation).toBe('top')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('chatui-canvas-size', '"full"')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('chatui-canvas-orientation', '"top"')
+
+    // A fresh mount reads the stored preference back
+    const remounted = renderHook(() => useCanvasLayout())
+    expect(remounted.result.current.size).toBe('full')
+    expect(remounted.result.current.orientation).toBe('top')
+  })
+
+  it('stacks the canvas on a narrow viewport without losing the stored preference', () => {
+    const original = window.innerWidth
+    window.innerWidth = 500
+    try {
+      const { result } = renderHook(() => useCanvasLayout())
+      expect(result.current.isNarrow).toBe(true)
+      expect(result.current.orientation).toBe('right')
+      expect(result.current.effectiveOrientation).toBe('top')
+
+      act(() => {
+        window.innerWidth = 1200
+        window.dispatchEvent(new Event('resize'))
+      })
+      expect(result.current.isNarrow).toBe(false)
+      expect(result.current.effectiveOrientation).toBe('right')
+    } finally {
+      window.innerWidth = original
+    }
+  })
+
+  it('hides the orientation toggle when the viewport locks the layout', () => {
+    render(<CanvasPanel isOpen={true} onClose={vi.fn()} orientation="top" orientationLocked={true} />)
+    expect(screen.queryByTestId('canvas-orientation-toggle')).toBeNull()
+    expect(screen.getByTestId('canvas-size-toggle')).toBeTruthy()
+  })
+
+  it('falls back to the default layout when stored values are unusable', () => {
+    window.localStorage.getItem.mockImplementation(key =>
+      key === 'chatui-canvas-size' ? '"gigantic"' : '"sideways"'
+    )
+    const { result } = renderHook(() => useCanvasLayout())
+    expect(result.current.size).toBe('half')
+    expect(result.current.orientation).toBe('right')
+  })
+})

--- a/frontend/src/test/canvas-layout.test.jsx
+++ b/frontend/src/test/canvas-layout.test.jsx
@@ -5,8 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
-import { renderHook } from '@testing-library/react'
+import { render, screen, act, renderHook } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import CanvasPanel from '../components/CanvasPanel'
 import { useCanvasLayout } from '../hooks/useCanvasLayout'


### PR DESCRIPTION
Closes #754.

## Problem

The canvas opened beside the chat at a fixed ~half width with no way to change it. On a phone that split leaves both the chat and the document too narrow to read, which is exactly what the issue reports. The follow-up comments ask for a vertical (canvas-above-chat) option on desktop too, and for the choice to persist in browser storage per device.

## What changed

Two controls in the canvas header, next to the existing close button:

| Control | Behavior |
| --- | --- |
| Expand / Shrink | half <-> full. At full the canvas takes the whole content area and the chat is hidden. |
| Move | beside the chat <-> above the chat (stacked). |
| Close (existing) | the "none" state. |

Details worth calling out:

- **The chat is hidden, not unmounted**, at full size (`hidden` class rather than a conditional render), so an in-progress draft survives expanding and shrinking.
- **Below 768px the layout is forced to stacked** and the Move control is hidden, since a horizontal split at that width is the complaint in the issue. The *stored* preference is deliberately not overwritten, so widening the window (or rotating a tablet back to landscape) restores the user's side-by-side choice. `useCanvasLayout` returns both `orientation` (stored) and `effectiveOrientation` (what renders).
- **Persistence** is per browser via the existing `usePersistentState` helper (`chatui-canvas-size`, `chatui-canvas-orientation`), with unrecognized stored values falling back to the defaults. Phone and desktop therefore keep separate preferences, as requested in the issue thread.
- **Reopening from "none"** is unchanged: the canvas button in the app header, or new canvas content arriving from a tool.
- The drag-to-resize handle is suppressed when it cannot do anything (full size, stacked, or mobile).

## Verification

- `npx vitest run` - 64 files, 710 tests pass, including 7 new ones in `frontend/src/test/canvas-layout.test.jsx` covering defaults, full-size and stacked rendering, the header callbacks, localStorage persistence and round-trip, bad stored values, the narrow-viewport override plus its restore on resize, and the hidden Move control.
- `npm run lint` - 0 errors (4 pre-existing warnings, untouched files).
- `npm run build` - clean.
- `bash scripts/check-docs.sh` - OK, new doc indexed.

## Docs

New user-guide page `docs/user-guide/canvas-layout/README.md`, indexed in `docs/user-guide/README.md`, plus a CHANGELOG entry.