### PR TITLE
Fix MCP prompt result text extraction

### DIFF
--- a/atlas/application/chat/preprocessors/prompt_override_service.py
+++ b/atlas/application/chat/preprocessors/prompt_override_service.py
@@ -122,6 +122,21 @@ class PromptOverrideService:
         if isinstance(prompt_obj, str):
             return prompt_obj
 
+        # MCP prompts/get returns a GetPromptResult whose text lives under
+        # messages[i].content, not on the result itself.
+        if hasattr(prompt_obj, "messages"):
+            messages = getattr(prompt_obj, "messages")
+            if isinstance(messages, list):
+                texts = []
+                for message in messages:
+                    content = getattr(message, "content", None)
+                    content_items = content if isinstance(content, list) else [content]
+                    for item in content_items:
+                        text = getattr(item, "text", None)
+                        if isinstance(text, str):
+                            texts.append(text)
+                return "\n".join(texts) if texts else None
+
         # FastMCP PromptMessage-like: may have 'content' list with text entries
         if hasattr(prompt_obj, "content"):
             content_field = getattr(prompt_obj, "content")

--- a/atlas/tests/test_multi_prompt.py
+++ b/atlas/tests/test_multi_prompt.py
@@ -147,6 +147,35 @@ class TestPromptTextExtraction:
     def test_extract_string(self, service):
         assert service._extract_prompt_text("hello") == "hello"
 
+    def test_extract_get_prompt_result_messages(self, service):
+        """Extracts text from the actual MCP prompts/get response shape."""
+        from mcp.types import GetPromptResult, PromptMessage, TextContent
+
+        prompt_obj = GetPromptResult(
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(type="text", text="Part 1."),
+                ),
+                PromptMessage(
+                    role="assistant",
+                    content=TextContent(type="text", text="Part 2."),
+                ),
+            ]
+        )
+
+        assert service._extract_prompt_text(prompt_obj) == "Part 1.\nPart 2."
+
+    def test_get_prompt_result_without_text_does_not_inject_repr(self, service):
+        """Structured MCP prompt results without text are skipped, not stringified."""
+        from types import SimpleNamespace
+
+        prompt_obj = SimpleNamespace(
+            messages=[SimpleNamespace(content=SimpleNamespace(data=b"image"))]
+        )
+
+        assert service._extract_prompt_text(prompt_obj) is None
+
     def test_extract_multi_content(self, service):
         """Concatenates all TextContent items, not just first."""
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary

- extract MCP prompt text from `GetPromptResult.messages[*].content`
- preserve message order when joining text content
- skip structured prompt results with no text instead of injecting their raw repr
- retain the existing legacy `.content` extraction path

## Tests

- adds a regression test using real MCP `GetPromptResult`, `PromptMessage`, and `TextContent` types
- adds coverage ensuring non-text structured prompt results return `None`

Fixes #783