### PR TITLE
fix(ui): make the Data Sources tab keyboard-operable and scroll the opened tab into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #890 - 2026-09-04
+- **Follow-ups to the Data Sources tab** (#889): the source rows are real toggle buttons (`aria-pressed`) instead of click-only `<div>`s, so the picker is operable from the keyboard -- promoting it into a focus-trapped modal tab had left every source unreachable by Tab, with "Enable All"/"Clear All" the only way in. Out-of-boundary rows stay focusable via `aria-disabled` so their explanation is still discoverable. The tab strip also scrolls the selected tab into view when the panel opens straight onto one; adding a sixth tab in second position had pushed General, User Info and Admin past the right edge on a narrow window, so those opened with the strip parked at the far left and no tab visibly selected.
+
 ### PR #888 - 2026-09-04
 - Move data source selection into its own second tab in Tools and Settings instead of combining it with MCP tool selection.
 

--- a/frontend/src/components/DataSourcesSelector.jsx
+++ b/frontend/src/components/DataSourcesSelector.jsx
@@ -190,15 +190,26 @@ const DataSourcesSelector = () => {
               const clickable = !outOfBoundary || isSelected
 
               return (
-                <div
+                // A real <button> with aria-pressed, not a click-only <div>:
+                // the picker is now a tab of the Tools and Settings modal,
+                // whose every other tab is fully keyboard-operable, and a
+                // plain div left the source rows unreachable by keyboard
+                // altogether -- Enable All / Clear All were the only way in.
+                // Out-of-boundary rows stay focusable via aria-disabled rather
+                // than the `disabled` attribute, so their explanatory title is
+                // still discoverable.
+                <button
+                  type="button"
                   key={selectionKey}
+                  aria-pressed={isSelected}
+                  aria-disabled={clickable ? undefined : true}
                   onClick={clickable ? () => toggleDataSource(selectionKey) : undefined}
                   title={outOfBoundary
                     ? (isSelected
                       ? 'Outside the selected model\'s compliance boundary; the server will not query it. Click to deselect.'
                       : 'Outside the selected model\'s compliance boundary; the server will not query it')
                     : undefined}
-                  className={`px-3 py-2 rounded-lg border transition-colors ${
+                  className={`w-full text-left px-3 py-2 rounded-lg border transition-colors ${
                     outOfBoundary
                       ? `bg-gray-800 border-gray-700 text-gray-500 opacity-60 ${isSelected ? 'cursor-pointer' : 'cursor-not-allowed'}`
                       : isSelected
@@ -234,7 +245,7 @@ const DataSourcesSelector = () => {
                       {isSelected && ' — selected but will not be searched; click to deselect'}
                     </div>
                   )}
-                </div>
+                </button>
               )
             })}
           </div>

--- a/frontend/src/components/SettingsPanel.jsx
+++ b/frontend/src/components/SettingsPanel.jsx
@@ -184,6 +184,21 @@ const SettingsPanel = ({ isOpen, onClose, initialTab = null, promptIntent = null
     }
   }, [activeTab, visibleTabs])
 
+  // The strip scrolls horizontally once the tabs outgrow the panel, and
+  // opening straight onto a tab only moves `activeTab` -- nothing scrolls. A
+  // request for a later tab (Admin, and since the Data Sources tab was added,
+  // General and User Info too on a narrow window) therefore rendered its panel
+  // under a strip still parked at the far left, with no tab visibly selected.
+  // Arrow-key navigation is unaffected: focus() scrolls on its own.
+  useEffect(() => {
+    if (!isOpen) return
+    const el = document.getElementById(`settings-tab-${activeTab}`)
+    // jsdom (and some older browsers) do not implement scrollIntoView.
+    if (typeof el?.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    }
+  }, [isOpen, activeTab])
+
   // A tab the user picks themselves supersedes any pending request.
   const selectTab = useCallback((tabId) => {
     pendingTabRef.current = null

--- a/frontend/src/test/data-sources-tab-keyboard.test.jsx
+++ b/frontend/src/test/data-sources-tab-keyboard.test.jsx
@@ -1,0 +1,184 @@
+/**
+ * Follow-ups to PR #889, which promoted the data source picker out of the
+ * Tools & Integrations tab into a Data Sources tab of the Tools and Settings
+ * modal.
+ *
+ * That move puts the picker inside a focus-trapped ARIA tabs pattern whose
+ * every other tab is fully keyboard-operable, and it inserts a sixth tab in
+ * second position, pushing the later tabs past the right edge of the strip on
+ * a narrow window. Both are covered here.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import DataSourcesSelector from '../components/DataSourcesSelector'
+import SettingsPanel from '../components/SettingsPanel'
+import { ThemeProvider } from '../contexts/ThemeContext'
+import { useChat } from '../contexts/ChatContext'
+import { useMarketplace } from '../contexts/MarketplaceContext'
+
+vi.mock('../contexts/ChatContext', () => ({ useChat: vi.fn() }))
+vi.mock('../contexts/MarketplaceContext', () => ({ useMarketplace: vi.fn() }))
+
+vi.mock('../hooks/useGlobusAuth', () => ({
+  useGlobusAuth: () => ({
+    authStatus: null, loading: false, error: null,
+    fetchAuthStatus: vi.fn(), login: vi.fn(), logout: vi.fn(), isAuthenticated: false,
+  })
+}))
+vi.mock('../components/ToolsPanel', () => ({ default: () => <div>tools tab body</div> }))
+vi.mock('../components/admin/AdminQuickPanel', () => ({ default: () => <div>admin quick controls</div> }))
+vi.mock('../components/PromptManager', () => ({ default: () => <div>prompt manager</div> }))
+
+const SOURCES = [
+  { id: 'public-docs', label: 'public-docs', serverName: 'atlas_rag', serverComplianceLevel: 'Public', complianceLevel: 'Public' },
+  { id: 'internal-docs', label: 'internal-docs', serverName: 'atlas_rag', serverComplianceLevel: 'Internal', complianceLevel: 'Internal' },
+]
+
+const COMPLIANCE_LEVELS = [
+  { name: 'Public', allowed_with: ['Public'] },
+  { name: 'Internal', allowed_with: ['Internal', 'Public'] },
+]
+
+function mockChat(overrides = {}) {
+  useChat.mockReturnValue({
+    ragSources: SOURCES,
+    selectedDataSources: new Set(),
+    toggleDataSource: vi.fn(),
+    addDataSources: vi.fn(),
+    clearDataSources: vi.fn(),
+    features: { compliance_levels: false, rag: true, tools: true },
+    complianceLevelFilter: null,
+    models: [
+      { name: 'public-model', compliance_level: 'Public' },
+      { name: 'internal-model', compliance_level: 'Internal' },
+    ],
+    currentModel: 'internal-model',
+    settings: { autoApproveTools: false },
+    updateSettings: vi.fn(),
+    agentModeAvailable: false,
+    isInAdminGroup: true,
+    ...overrides,
+  })
+  useMarketplace.mockReturnValue({
+    complianceLevels: COMPLIANCE_LEVELS,
+    isComplianceAccessible: (userLevel, resourceLevel) => {
+      if (!userLevel) return true
+      if (!resourceLevel) return false
+      const level = COMPLIANCE_LEVELS.find(l => l.name === userLevel)
+      return !!level && level.allowed_with.includes(resourceLevel)
+    },
+  })
+}
+
+describe('DataSourcesSelector - keyboard operability', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders each source as a focusable toggle button rather than a bare div', () => {
+    mockChat()
+    render(<DataSourcesSelector />)
+
+    const row = screen.getByRole('button', { name: /public-docs/ })
+    expect(row).toHaveAttribute('type', 'button')
+    expect(row).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('reports the selected state through aria-pressed', () => {
+    mockChat({ selectedDataSources: new Set(['atlas_rag:public-docs']) })
+    render(<DataSourcesSelector />)
+
+    expect(screen.getByRole('button', { name: /public-docs/ })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('toggles a source from the keyboard', () => {
+    const toggleDataSource = vi.fn()
+    mockChat({ toggleDataSource })
+    render(<DataSourcesSelector />)
+
+    const row = screen.getByRole('button', { name: /public-docs/ })
+    row.focus()
+    expect(row).toHaveFocus()
+    // A real button fires click for both Enter and Space; jsdom does not
+    // synthesise that, so assert the activation path directly.
+    fireEvent.click(row)
+    expect(toggleDataSource).toHaveBeenCalledWith('atlas_rag:public-docs')
+  })
+
+  it('keeps an out-of-boundary source focusable and marked aria-disabled', () => {
+    const toggleDataSource = vi.fn()
+    mockChat({
+      toggleDataSource,
+      currentModel: 'public-model',
+      features: { compliance_levels: true, rag: true, tools: true },
+    })
+    render(<DataSourcesSelector />)
+
+    const row = screen.getByRole('button', { name: /internal-docs/ })
+    expect(row).toHaveAttribute('aria-disabled', 'true')
+    expect(row).not.toBeDisabled()
+    fireEvent.click(row)
+    expect(toggleDataSource).not.toHaveBeenCalled()
+  })
+
+  it('leaves an already-selected out-of-boundary source deselectable', () => {
+    const toggleDataSource = vi.fn()
+    mockChat({
+      toggleDataSource,
+      currentModel: 'public-model',
+      selectedDataSources: new Set(['atlas_rag:internal-docs']),
+      features: { compliance_levels: true, rag: true, tools: true },
+    })
+    render(<DataSourcesSelector />)
+
+    const row = screen.getByRole('button', { name: /internal-docs/ })
+    expect(row).not.toHaveAttribute('aria-disabled')
+    fireEvent.click(row)
+    expect(toggleDataSource).toHaveBeenCalledWith('atlas_rag:internal-docs')
+  })
+})
+
+describe('SettingsPanel - the opened tab is scrolled into view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it('scrolls the tab the panel opens on into the strip', () => {
+    mockChat()
+    const scrolled = []
+    const original = Element.prototype.scrollIntoView
+    Element.prototype.scrollIntoView = function scrollIntoViewSpy(opts) {
+      scrolled.push({ id: this.id, opts })
+    }
+    try {
+      render(
+        <ThemeProvider>
+          <SettingsPanel isOpen onClose={vi.fn()} initialTab="admin" />
+        </ThemeProvider>
+      )
+      expect(scrolled.some(s => s.id === 'settings-tab-admin')).toBe(true)
+      expect(scrolled.find(s => s.id === 'settings-tab-admin').opts)
+        .toEqual({ block: 'nearest', inline: 'nearest' })
+    } finally {
+      Element.prototype.scrollIntoView = original
+    }
+  })
+
+  it('scrolls the Data Sources tab into view when it is selected', () => {
+    mockChat()
+    const scrolled = []
+    const original = Element.prototype.scrollIntoView
+    Element.prototype.scrollIntoView = function scrollIntoViewSpy() { scrolled.push(this.id) }
+    try {
+      render(
+        <ThemeProvider>
+          <SettingsPanel isOpen onClose={vi.fn()} />
+        </ThemeProvider>
+      )
+      scrolled.length = 0
+      fireEvent.click(screen.getByRole('tab', { name: /Data Sources/ }))
+      expect(scrolled).toContain('settings-tab-dataSources')
+    } finally {
+      Element.prototype.scrollIntoView = original
+    }
+  })
+})


### PR DESCRIPTION
Two follow-ups to #889, which moved the data source picker out of the Tools & Integrations tab into its own **Data Sources** tab. Both were found by driving the merged main build in a browser.

## 1. The Data Sources tab was not keyboard-operable

Source rows were click-only `<div>`s with no `role`, `tabindex`, or key handler. That was survivable in the left-hand Sources drawer, but the new tab promotes the picker into the Tools and Settings modal — a focus-trapped ARIA tabs pattern whose every other tab (Tools, Prompts, General, Admin) is fully keyboard-operable.

Measured on `main` with the panel open on the Data Sources tab:

```
rowCount: 5, rowTag: "DIV", rowRole: null, rowTabIndex: null
focusableInPanel: ["INPUT:Search data sources...", "BUTTON:Enable All", "BUTTON:Clear All"]
```

A keyboard user could reach the tab and then not toggle a single source — "Enable All" / "Clear All" were the only way in, and they are all-or-nothing.

The rows are now real `<button type="button">` toggles carrying `aria-pressed`. Out-of-boundary rows use `aria-disabled` rather than the `disabled` attribute, so the compliance-boundary explanation in their `title` stays discoverable, and an already-selected out-of-boundary row remains deselectable exactly as before. The drawer picks this up too, since both render the same `DataSourcesSelector`.

## 2. The tab strip did not scroll the opened tab into view

The strip is `overflow-x-auto`, and opening the panel straight onto a tab (`initialTab` / the `atlas:open-settings` event) only moved `activeTab` — nothing scrolled. Adding a sixth tab in second position pushed General, User Info and Admin past the right edge on a narrow window.

At a 400px viewport, dispatching `atlas:open-settings` with `{tab:'admin'}` on `main`:

```
scrollLeft: 0, selected: "Admin", selLeft: 590, selRight: 689, stripRight: 400, offscreen: true
```

The Admin panel rendered under a strip parked at the far left with no tab visibly selected. After the fix, the same probe returns `scrollLeft: 289, offscreen: false`. Arrow-key navigation was already fine — `focus()` scrolls on its own — so only the programmatic open path changed. The call is guarded because jsdom does not implement `scrollIntoView`.

## Verification

- `npx vitest run` — **790 passed / 70 files** (783 on `main` before this change, plus the 7 new tests).
- `npx eslint` clean on the three touched files.
- New `frontend/src/test/data-sources-tab-keyboard.test.jsx` covers `aria-pressed` on/off, keyboard activation, the `aria-disabled` out-of-boundary row staying focusable and inert, the selected out-of-boundary row staying deselectable, and `scrollIntoView` firing for both the opened tab and a clicked one.
- Live browser (Playwright, dev server against a local backend): the Data Sources tab now exposes **8** focusable elements instead of 3; focusing the first row and pressing <kbd>Enter</kbd> flips it to `aria-pressed="true"`; the Sources drawer renders 5 row buttons with matching state; and the tab renders unchanged visually at 1400px and scrolls correctly at 400px with no horizontal page overflow.

Also re-exercised and found working on `main`, unchanged here: the `+N more` dataset pill strip, the "Data Sources:" chat-bar shortcut routing to the new tab, selection persisting across panel close/reopen, and the unsaved-tool-changes guard still firing when the panel is closed from the Data Sources tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ie5mYAwYzq9ahbq9WXAY6