### PR TITLE
fix(llm): send per-model reasoning_effort so GPT-5.6 models can use tools

### DIFF
--- a/atlas/config/llmconfig.yml
+++ b/atlas/config/llmconfig.yml
@@ -44,6 +44,25 @@ models:
       calling, and up to 1M tokens of context. It is ideal for classification,
       autocompletion, and fast lightweight tasks where latency matters more than
       peak reasoning quality. Context window: 1M tokens. Output limit: 32K tokens.
+  gpt-5.6-luna:
+    model_url: "https://api.openai.com/v1/chat/completions"
+    model_name: "gpt-5.6-luna"
+    api_key: "${OPENAI_API_KEY}"
+    compliance_level: "External"
+    supports_tools: true
+    # Required, not optional. Without it every tool-carrying request to this
+    # model is rejected with HTTP 400: "Function tools with reasoning_effort are
+    # not supported for gpt-5.6-luna in /v1/chat/completions. To use function
+    # tools, use /v1/responses or set reasoning_effort to 'none'." The same
+    # setting also makes the model accept the non-default temperature this
+    # backend always sends. The other GPT-5.6 models (gpt-5.6-sol,
+    # gpt-5.6-terra) return the same error and need the same line.
+    reasoning_effort: "none"
+    model_card: >
+      GPT-5.6 Luna is the low-cost member of OpenAI's GPT-5.6 reasoning family.
+      Reasoning effort is pinned to "none" here because function tools are
+      rejected on /v1/chat/completions at any other effort level; raise it only
+      if this deployment moves tool calls to /v1/responses.
   groq-gpt-oss-120b:
     model_url: "https://api.groq.com/openai/v1"
     model_name: "openai/gpt-oss-120b"

--- a/atlas/config/llmconfig.yml
+++ b/atlas/config/llmconfig.yml
@@ -57,12 +57,22 @@ models:
     # setting also makes the model accept the non-default temperature this
     # backend always sends. The other GPT-5.6 models (gpt-5.6-sol,
     # gpt-5.6-terra) return the same error and need the same line.
+    #
+    # The other route that 400 offers -- moving tool calls to /v1/responses --
+    # is not available to this entry. ATLAS builds every request through
+    # LiteLLMCaller._get_model_kwargs against the chat/completions URL above,
+    # and /v1/responses rejects the unconditional `temperature` that method
+    # always sends ("Unsupported parameter: 'temperature' is not supported with
+    # this model."). Raise the effort here only if this deployment has moved
+    # tool calls to /v1/responses and stopped sending `temperature`.
     reasoning_effort: "none"
     model_card: >
-      GPT-5.6 Luna is the low-cost member of OpenAI's GPT-5.6 reasoning family.
-      Reasoning effort is pinned to "none" here because function tools are
-      rejected on /v1/chat/completions at any other effort level; raise it only
-      if this deployment moves tool calls to /v1/responses.
+      GPT-5.6 Luna is the low-cost, low-latency member of OpenAI's GPT-5.6
+      family and supports tool/function calling. Reasoning is switched off for
+      this model in ATLAS: replies come back without the extended reasoning pass
+      the family is otherwise capable of, which makes them faster and cheaper.
+      Best for: quick tool-using chat and lightweight tasks. Choose a reasoning
+      model instead for work that needs step-by-step analysis.
   groq-gpt-oss-120b:
     model_url: "https://api.groq.com/openai/v1"
     model_name: "openai/gpt-oss-120b"

--- a/atlas/modules/config/models.py
+++ b/atlas/modules/config/models.py
@@ -15,7 +15,7 @@ Dependency direction: ``config_loader`` -> ``settings`` -> ``models``.
 
 import os
 import re
-from typing import ClassVar, Dict, List, Literal, Optional
+from typing import ClassVar, Dict, List, Literal, Optional, get_args
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -70,6 +70,16 @@ def resolve_env_var(value: Optional[str], required: bool = True) -> Optional[str
     return value
 
 
+# Reasoning-effort levels LiteLLM will carry on a chat/completions request.
+# Mirrors ``litellm.types.llms.openai.REASONING_EFFORT`` (litellm 1.97.0, the
+# version pinned in uv.lock). Written out here rather than imported so that
+# loading configuration does not depend on a LiteLLM internal type, and so an
+# unusable value is rejected when the config file is read instead of arriving as
+# a provider HTTP 400 in the middle of a user's chat.
+ReasoningEffort = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+REASONING_EFFORT_VALUES: tuple = get_args(ReasoningEffort)
+
+
 class ModelConfig(BaseModel):
     """Configuration for a single LLM model."""
     model_name: str
@@ -105,13 +115,15 @@ class ModelConfig(BaseModel):
     # Whether this model supports tool/function calling.
     # When false, tools are stripped from requests and the user is warned.
     supports_tools: bool = True
-    # Reasoning effort to send with every request to this model, e.g. "none",
-    # "low", "medium", "high". Left unset for models that have no reasoning
-    # control, which is every model shipped before the GPT-5.6 family: the key
-    # is then omitted entirely and the payload is byte-identical to today's.
-    # Required for OpenAI's GPT-5.6 models, which reject function tools on
-    # /v1/chat/completions unless reasoning effort is explicitly "none".
-    reasoning_effort: Optional[str] = None
+    # Reasoning effort to send with every request to this model. One of
+    # REASONING_EFFORT_VALUES ("none", "minimal", "low", "medium", "high",
+    # "xhigh"); anything else is rejected when the config file is loaded.
+    # Left unset for models that have no reasoning control, which is every model
+    # shipped before the GPT-5.6 family: the key is then omitted entirely and the
+    # payload is byte-identical to today's. Required for OpenAI's GPT-5.6 models,
+    # which reject function tools on /v1/chat/completions unless reasoning effort
+    # is explicitly "none".
+    reasoning_effort: Optional[ReasoningEffort] = None
     # Rich model card text shown in the UI info panel (markdown allowed).
     # Provides details like context window, training info, strengths, etc.
     model_card: Optional[str] = None
@@ -131,6 +143,41 @@ class ModelConfig(BaseModel):
     # applies when pass_user_as_customer_id is true and the value actually ends
     # with the suffix; otherwise the value is sent unchanged.
     customer_id_strip_suffix: Optional[str] = None
+
+    @field_validator('reasoning_effort', mode='before')
+    @classmethod
+    def validate_reasoning_effort(cls, v):
+        """Reject an unusable reasoning effort while the config file is loading.
+
+        Without this the provider is the first thing to notice: "meduim",
+        "None" and " none" all load without complaint and then come back as an
+        HTTP 400 on a user's first message. Surrounding whitespace is trimmed
+        and a blank value is treated as unset, which is what an operator who
+        clears the field in YAML means.
+        """
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            raise ValueError(
+                f"reasoning_effort must be a string, got {type(v).__name__}. "
+                f"Valid values: {', '.join(REASONING_EFFORT_VALUES)}; omit the key to send none."
+            )
+        normalized = v.strip()
+        if not normalized:
+            return None
+        if normalized not in REASONING_EFFORT_VALUES:
+            hint = ""
+            if normalized.lower() == "none":
+                hint = (
+                    ' Note that "none" must be lowercase and quoted: it means "send '
+                    'reasoning_effort: none", which turns reasoning off. To send no '
+                    "reasoning_effort at all, omit the key."
+                )
+            raise ValueError(
+                f"reasoning_effort must be one of {', '.join(REASONING_EFFORT_VALUES)}, "
+                f"or omitted; got {v!r}.{hint}"
+            )
+        return normalized
 
 
 class LLMConfig(BaseModel):

--- a/atlas/modules/config/models.py
+++ b/atlas/modules/config/models.py
@@ -105,6 +105,13 @@ class ModelConfig(BaseModel):
     # Whether this model supports tool/function calling.
     # When false, tools are stripped from requests and the user is warned.
     supports_tools: bool = True
+    # Reasoning effort to send with every request to this model, e.g. "none",
+    # "low", "medium", "high". Left unset for models that have no reasoning
+    # control, which is every model shipped before the GPT-5.6 family: the key
+    # is then omitted entirely and the payload is byte-identical to today's.
+    # Required for OpenAI's GPT-5.6 models, which reject function tools on
+    # /v1/chat/completions unless reasoning effort is explicitly "none".
+    reasoning_effort: Optional[str] = None
     # Rich model card text shown in the UI info panel (markdown allowed).
     # Provides details like context window, training info, strengths, etc.
     model_card: Optional[str] = None

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -863,6 +863,23 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
         else:
             kwargs["temperature"] = model_config.temperature or 0.7
 
+        # Reasoning effort, when the model's config asks for one. Sent on every
+        # request to that model, so the tool-carrying and plain paths (and their
+        # streaming twins) all get it from this one place. Omitted when unset, so
+        # no already-working model's payload changes.
+        #
+        # This is what makes OpenAI's GPT-5.6 family usable with tools at all:
+        #     Function tools with reasoning_effort are not supported for
+        #     gpt-5.6-luna in /v1/chat/completions. To use function tools, use
+        #     /v1/responses or set reasoning_effort to 'none'.
+        # (GH #756.) It also clears the separate `temperature` rejection those
+        # models return, because with reasoning off they accept a non-default
+        # temperature again -- which matters here because `temperature` above is
+        # unconditional.
+        reasoning_effort = getattr(model_config, "reasoning_effort", None)
+        if reasoning_effort:
+            kwargs["reasoning_effort"] = reasoning_effort
+
         # Resolve API key based on api_key_source
         api_key_source = getattr(model_config, "api_key_source", "system")
         if api_key_source == "user":

--- a/atlas/tests/test_llm_reasoning_effort.py
+++ b/atlas/tests/test_llm_reasoning_effort.py
@@ -16,7 +16,11 @@ Added: GH #756.
 
 from unittest.mock import MagicMock
 
-from atlas.modules.config.config_manager import ModelConfig
+import pytest
+from pydantic import ValidationError
+
+from atlas.modules.config.config_manager import LLMConfig, ModelConfig
+from atlas.modules.config.models import REASONING_EFFORT_VALUES
 from atlas.modules.llm.litellm_caller import LiteLLMCaller
 
 
@@ -78,11 +82,78 @@ class TestShippedConfigCarriesTheSetting:
 
     def test_shipped_gpt_56_entry_pins_effort_none(self):
         """The GPT-5.6 entry in llmconfig.yml is unusable without this line."""
-        import yaml
         from pathlib import Path
+
+        import yaml
 
         config_path = (
             Path(__file__).resolve().parents[1] / "config" / "llmconfig.yml"
         )
         models = yaml.safe_load(config_path.read_text())["models"]
         assert models["gpt-5.6-luna"]["reasoning_effort"] == "none"
+
+
+class TestReasoningEffortIsValidatedAtLoad:
+    """A bad effort must fail when the config file is read, not as a 400 mid-chat.
+
+    Every value below loads without complaint if the field is a bare
+    ``Optional[str]``, and then returns HTTP 400 on the user's first message.
+    """
+
+    @pytest.mark.parametrize("value", REASONING_EFFORT_VALUES)
+    def test_every_documented_level_is_accepted(self, value):
+        config = ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort=value)
+        assert config.reasoning_effort == value
+
+    def test_a_misspelled_level_is_rejected(self):
+        with pytest.raises(ValidationError) as exc:
+            ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort="meduim")
+        message = str(exc.value)
+        assert "meduim" in message
+        for level in REASONING_EFFORT_VALUES:
+            assert level in message
+
+    def test_an_unknown_level_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort="off")
+
+    def test_the_string_None_is_rejected_and_explained(self):
+        """``reasoning_effort: None`` unquoted is the YAML *string* "None"."""
+        with pytest.raises(ValidationError) as exc:
+            ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort="None")
+        message = str(exc.value)
+        assert "omit the key" in message
+
+    def test_a_wrong_case_level_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort="NONE")
+
+    def test_a_non_string_level_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort=5)
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        """A stray space must not reach the provider as part of the value."""
+        config = ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort=" none ")
+        assert config.reasoning_effort == "none"
+
+    def test_a_blank_value_is_unset_not_an_error(self):
+        """Clearing the field in YAML means "send nothing", as before."""
+        config = ModelConfig(model_name="m", model_url="https://x/v1", reasoning_effort="   ")
+        assert config.reasoning_effort is None
+
+    def test_a_bad_level_fails_the_whole_llmconfig(self):
+        """The failure has to reach the operator loading llmconfig.yml."""
+        with pytest.raises(ValidationError):
+            LLMConfig(models={
+                "bad": {
+                    "model_name": "bad",
+                    "model_url": "https://x/v1",
+                    "reasoning_effort": "meduim",
+                },
+            })
+
+    def test_a_rejected_level_never_reaches_the_payload(self):
+        """The end-to-end point of the validator: the 400 cannot be built."""
+        with pytest.raises(ValidationError):
+            _make_caller({"gpt-5.6-luna": {"reasoning_effort": "meduim"}})

--- a/atlas/tests/test_llm_reasoning_effort.py
+++ b/atlas/tests/test_llm_reasoning_effort.py
@@ -1,0 +1,88 @@
+"""Unit tests for per-model reasoning effort in the LiteLLM payload.
+
+OpenAI's GPT-5.6 family rejects every tool-carrying request on
+/v1/chat/completions unless reasoning effort is explicitly set:
+
+    Function tools with reasoning_effort are not supported for gpt-5.6-luna in
+    /v1/chat/completions. To use function tools, use /v1/responses or set
+    reasoning_effort to 'none'.
+
+``ModelConfig.reasoning_effort`` carries the setting and ``_get_model_kwargs``
+forwards it, so every call path (plain, tools, and both streaming twins) picks
+it up from one place and no model that leaves it unset changes at all.
+
+Added: GH #756.
+"""
+
+from unittest.mock import MagicMock
+
+from atlas.modules.config.config_manager import ModelConfig
+from atlas.modules.llm.litellm_caller import LiteLLMCaller
+
+
+def _make_caller(models_dict):
+    """Build a LiteLLMCaller with a mocked LLMConfig."""
+    mock_config = MagicMock()
+    mock_models = {}
+    for name, overrides in models_dict.items():
+        defaults = {
+            "model_name": name,
+            "model_url": "https://api.openai.com/v1/chat/completions",
+            "api_key": "sk-test",
+            "api_key_source": "system",
+        }
+        defaults.update(overrides)
+        mock_models[name] = ModelConfig(**defaults)
+    mock_config.models = mock_models
+    return LiteLLMCaller(llm_config=mock_config)
+
+
+class TestReasoningEffortKwarg:
+    def test_effort_is_sent_when_configured(self):
+        caller = _make_caller({"gpt-5.6-luna": {"reasoning_effort": "none"}})
+        kwargs = caller._get_model_kwargs("gpt-5.6-luna")
+        assert kwargs["reasoning_effort"] == "none"
+
+    def test_key_is_absent_when_not_configured(self):
+        """Every model that predates reasoning control must keep today's payload."""
+        caller = _make_caller({"gpt-4.1": {}})
+        kwargs = caller._get_model_kwargs("gpt-4.1")
+        assert "reasoning_effort" not in kwargs
+
+    def test_empty_string_is_treated_as_unset(self):
+        """An operator blanking the field in YAML must not send an empty effort."""
+        caller = _make_caller({"gpt-4.1": {"reasoning_effort": ""}})
+        kwargs = caller._get_model_kwargs("gpt-4.1")
+        assert "reasoning_effort" not in kwargs
+
+    def test_a_non_none_effort_is_passed_through_unchanged(self):
+        """The field is an operator setting, not a hardcoded 'none' switch."""
+        caller = _make_caller({"reasoner": {"reasoning_effort": "high"}})
+        kwargs = caller._get_model_kwargs("reasoner")
+        assert kwargs["reasoning_effort"] == "high"
+
+    def test_effort_does_not_disturb_the_other_kwargs(self):
+        caller = _make_caller({
+            "gpt-5.6-luna": {"reasoning_effort": "none", "max_tokens": 4096},
+        })
+        kwargs = caller._get_model_kwargs("gpt-5.6-luna", temperature=0.7)
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["max_tokens"] == 4096
+        assert kwargs["api_key"] == "sk-test"
+        assert kwargs["reasoning_effort"] == "none"
+
+
+class TestShippedConfigCarriesTheSetting:
+    def test_model_config_defaults_to_no_effort(self):
+        assert ModelConfig(model_name="m", model_url="https://x/v1").reasoning_effort is None
+
+    def test_shipped_gpt_56_entry_pins_effort_none(self):
+        """The GPT-5.6 entry in llmconfig.yml is unusable without this line."""
+        import yaml
+        from pathlib import Path
+
+        config_path = (
+            Path(__file__).resolve().parents[1] / "config" / "llmconfig.yml"
+        )
+        models = yaml.safe_load(config_path.read_text())["models"]
+        assert models["gpt-5.6-luna"]["reasoning_effort"] == "none"

--- a/docs/admin/llm-config.md
+++ b/docs/admin/llm-config.md
@@ -226,6 +226,8 @@ the sampling context. Restrict access to such MCP servers with the server's own
 *   **`pass_user_as_customer_id`**: (boolean, default `false`) When `true`, the logged-in user's identifier is sent as the `x-litellm-customer-id` HTTP header on each request to the model. A [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/customers) uses this header to attribute spend/usage to the end user (customer). See [LiteLLM Customer ID Header](#litellm-customer-id-header) below.
 *   **`customer_id_strip_suffix`**: (string, optional) An email-domain suffix (e.g. `"@mydomain.com"`) to strip from the reverse-proxy-provided username before it is sent as the `x-litellm-customer-id` header — turning `user@mydomain.com` into `user`. Only applies when `pass_user_as_customer_id` is `true` and the username actually ends with the suffix (matched case-insensitively); otherwise the value is sent unchanged. See [LiteLLM Customer ID Header](#litellm-customer-id-header) below.
 *   **`supports_vision`**: (boolean, default `false`) When `true`, the model accepts image inputs. Users can upload images in the chat UI, and those images are sent as inline base64 content blocks in the user message rather than being described in the text files manifest. Only raster image formats are supported (PNG, JPEG, GIF, WebP); SVG files are excluded. See [Vision Image Support](#vision-image-support-2026-03-23) below.
+*   **`supports_tools`**: (boolean, default `true`) When `false`, tool/function definitions are stripped from requests to this model and the user is warned that tools are unavailable.
+*   **`reasoning_effort`**: (string, optional) The reasoning effort sent with every request to this model. One of `none`, `minimal`, `low`, `medium`, `high`, `xhigh` — an invalid value is rejected when the config file is loaded, not on the first chat. Omit the key (the default) for any model without a reasoning control; the request payload is then unchanged. **OpenAI's GPT-5.6 family requires `"none"` for tool calls** on `/v1/chat/completions`. See [Reasoning Effort](#reasoning-effort) below.
 *   **`compliance_level`**: (string) The security compliance level of this model (e.g., "Public", "Internal"). This is used to filter which models can be used in certain compliance contexts.
 *   **`groups`**: (list of strings, optional) Access-control groups for this model. When omitted or empty (the default), the model is available to everyone. When set, only users who belong to at least one listed group can see or use the model. Enforced at both the model-listing and chat-execution layers. See [Restricting Model Access by Group](#restricting-model-access-by-group-2026-07-10) above.
 
@@ -277,6 +279,39 @@ Behavior notes:
 - If the username does not end with the configured suffix (e.g. a user from a different domain), the full value is sent unchanged.
 - Stripping applies only to the auto-injected logged-in user. A static id pinned via `extra_headers` (point 4 above) is never modified.
 - Leave `customer_id_strip_suffix` unset to send the full username, which is the default.
+
+## Reasoning Effort
+
+Reasoning models expose a knob for how much hidden reasoning to spend before answering. Set it per model with `reasoning_effort`; the value is sent on every request to that model, on all four call paths (plain, tool-carrying, and both streaming variants), because they all build their kwargs in `LiteLLMCaller._get_model_kwargs`.
+
+```yaml
+models:
+  gpt-5.6-luna:
+    model_url: "https://api.openai.com/v1/chat/completions"
+    model_name: "gpt-5.6-luna"
+    api_key: "${OPENAI_API_KEY}"
+    compliance_level: "External"
+    supports_tools: true
+    reasoning_effort: "none"
+```
+
+Accepted values are `none`, `minimal`, `low`, `medium`, `high` and `xhigh` — the set LiteLLM will carry on a chat/completions request. A value outside that set (a typo like `meduim`, or an unquoted `None`, which YAML reads as the *string* `"None"`) raises a configuration error when ATLAS loads `llmconfig.yml`, rather than surfacing as a provider `400` during someone's chat. Surrounding whitespace is trimmed and a blank value is treated as unset.
+
+Omitting the key is the default and the right choice for every model without a reasoning control (GPT-4.1, GPT-4o, the Anthropic, Gemini, Groq and OpenRouter entries): the key is left out of the payload entirely, so nothing about those requests changes.
+
+### GPT-5.6 requires `"none"` for tool calls
+
+OpenAI's GPT-5.6 models (`gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`) reject **every** tool-carrying request on `/v1/chat/completions` unless reasoning effort is explicitly `"none"`:
+
+```
+Function tools with reasoning_effort are not supported for gpt-5.6-luna in
+/v1/chat/completions. To use function tools, use /v1/responses or set
+reasoning_effort to 'none'.
+```
+
+So a GPT-5.6 entry with `supports_tools: true` and no `reasoning_effort` is unusable in agent mode: the request is rejected before any generation. The same setting also makes these models accept the non-default `temperature` ATLAS always sends, which they otherwise reject on its own. Adding `reasoning_effort: "none"` turns reasoning off for that model — a deliberate trade, and worth saying so in the model's `model_card`, since users pick models from that text.
+
+The alternative the error text offers, routing tool calls to `/v1/responses`, is not a drop-in for ATLAS today: that endpoint rejects the unconditional `temperature` these callers send.
 
 ## Vision Image Support (2026-03-23)
 


### PR DESCRIPTION
Addresses #756.

## What breaks

Agent mode on `gpt-5.6-luna` fails before any generation. Every tool carrying request
returns HTTP 400, the string #756 quotes:

```
Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

Recorded with `"status_code": 400` and `"type": "api_status_error"` on 60 of 60 requests.

## Versions and what was exercised

* Repo at `d8245b87dd3befad2c6fde3057199b9217febee2` ("feat: canvas width and orientation
  controls (#754) (#883)"), with `litellm` at the locked 1.97.0 (`uv.lock`).
* Path exercised: agent mode, non streaming. `AgenticLoop._call_llm` at
  `atlas/application/chat/agent/agentic_loop.py:398` calls
  `LiteLLMCaller.call_with_tools` (`atlas/modules/llm/litellm_caller.py:1259`, the
  `_acompletion_with_retry` at `:1289`), whose kwargs come from `_get_model_kwargs`
  (`:848`).
* Payload measured: `{model, messages, tools, tool_choice: "auto", temperature: 0.7,
  max_completion_tokens: 10000}` on `POST https://api.openai.com/v1/chat/completions`.
  That is what LiteLLM 1.97.0 puts on the wire for a `gpt-5` family model: `max_tokens`
  becomes `max_completion_tokens` (`llms/openai/chat/gpt_5_transformation.py:256`) and
  `temperature` is kept rather than dropped, because the model map marks these models as
  supporting `reasoning_effort="none"` and this backend sends no effort
  (`gpt_5_transformation.py:277-282`).
* Baseline model: `gpt-5.4`. Candidate model: `gpt-5.6-luna`, the model #756 names.
* System prompt, the six tool schemas and the tool behaviours all come from this repo at that
  sha (`atlas/config/prompts/system_prompt.md`, six tools from the default stdio MCP servers
  in `atlas/config/mcp.json`). Nothing from this repo was executed on the measuring host.

## Why `gpt-5.5` is not the baseline

`_get_model_kwargs` puts `temperature` in every payload unconditionally
(`atlas/modules/llm/litellm_caller.py:861-864`), defaulting to `0.7`
(`atlas/modules/config/models.py:80`). Direct probes, one 16 token request each, no tools:

| request | `gpt-5.4` | `gpt-5.6-luna` |
| --- | --- | --- |
| chat, no tools, `temperature: 0.7` | 200 | 400 `Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.` |
| chat, tools, `temperature: 0.7` | 200 | 400 function tools / reasoning effort |
| chat, tools, `temperature: 0.7`, `reasoning_effort: "none"` | 200 | 200 |
| `/v1/responses`, tools, `temperature: 0.7` | 200 | 400 `Unsupported parameter: 'temperature' is not supported with this model.` |
| `/v1/responses`, tools, no temperature | not probed | 200 |

So `gpt-5.6-luna` has two independent blockers for this backend, and the function tools one
is returned first and hides the temperature one.

## The Responses API route was tried first, and it does not work on its own

#756 asks for `/v1/responses`. That was the first repair candidate measured, and it failed:
sending the identical payload to `/v1/responses` clears the function tools 400 and
immediately returns `Unsupported parameter: 'temperature' is not supported with this model.`
on 60 of 60 requests.

A Responses migration is still worth doing, but it is not a drop in fix while `temperature`
is unconditional: it has to drop the sampling parameter at the same time. That is a much
larger change than this one, none of it was measured, and it is not in this PR.

## Patch

Reasoning effort becomes a per model registry setting and is forwarded from the single place
every OpenAI bound request already builds its kwargs, so the plain path, the tool path and
both streaming twins all get it:

| call path | file:line | kwargs from |
| --- | --- | --- |
| plain | `atlas/modules/llm/litellm_caller.py:1057` | `_get_model_kwargs`, `:1037` |
| with tools | `atlas/modules/llm/litellm_caller.py:1289` | `_get_model_kwargs`, `:1274` |
| plain, streaming | `atlas/modules/llm/litellm_streaming.py:98` | `_get_model_kwargs`, `:65` |
| with tools, streaming | `atlas/modules/llm/litellm_streaming.py:314` | `_get_model_kwargs`, `:280` |

* `atlas/modules/config/models.py`: `ModelConfig.reasoning_effort`, optional, default `None`.
* `atlas/modules/llm/litellm_caller.py`, in `_get_model_kwargs`:

```python
        reasoning_effort = getattr(model_config, "reasoning_effort", None)
        if reasoning_effort:
            kwargs["reasoning_effort"] = reasoning_effort
```

* `atlas/config/llmconfig.yml`: a `gpt-5.6-luna` entry with `reasoning_effort: "none"`, since
  the file ships no GPT-5.6 entry today.
* `atlas/tests/test_llm_reasoning_effort.py`: 7 unit tests, built the way
  `atlas/tests/test_llm_customer_id_header.py` builds its caller. No network.

A model that leaves the field unset sends the exact payload it sends today, so gpt-4.1,
gpt-4o, the Anthropic, Gemini, Groq and OpenRouter entries are all unchanged. The setting is
an operator choice rather than a hardcoded switch on the model name, because
`reasoning_effort: "none"` does turn reasoning off and a deployment should be able to say so
for itself.

## Before and after

Twelve case behavioural suite over agent mode, deterministic checks only: `no_api_error`,
`tool_called` (with argument subsets where the argument matters), `tool_not_called`,
`turns_at_most`, and regex or substring assertions on the final answer. The tools are the
calculator, the prompts catalog, two `structured_output_demo` tools and two
`username-override-demo` tools, faked in memory from this repo's own tool bodies. Standard
sync tier, 5 reps per case per configuration, thresholds fixed throughout.

| run | model | params | cases | reps |
| --- | --- | --- | --- | --- |
| baseline | `gpt-5.4` | `temperature: 0.7` | 12/12 pass | 60/60 |
| candidate | `gpt-5.6-luna` | `temperature: 0.7` | 0/12 | 0/60 |
| candidate, routed to `/v1/responses` | `gpt-5.6-luna` | `temperature: 0.7` | 0/12 | 0/60 |
| patched | `gpt-5.6-luna` | `temperature: 0.7` plus `reasoning_effort: "none"` | 12/12 pass | 119/120 |

All twelve cases regressed at one sided Fisher exact p = 0.00397 each. No case was flaky and
none was contested. Every one of the 60 candidate reps failed on the function tools 400
above, and every one of the 60 responses route reps failed on the temperature 400.

The patched configuration restored 12 of 12 broken cases across 10 reps each (5 screening
plus 5 verification) and broke 0 previously passing cases. The single non passing rep out of
120 is a brittle assertion in the measuring suite, not a model failure: the model answered
"does **not** have permission" and the suite's regex did not match across the markdown
emphasis. The suite was deliberately left unchanged rather than loosened after the fact.

Zero tokens were billed on either unpatched candidate run, because the request is rejected
before generation, so the break costs nothing to reproduce.

## Limitations

1. This repo's own test suite was not run locally, and the 7 added tests were not executed
   here. The change was written against the pinned sha. No code from this repo ran on the
   measuring host.
2. One call path of four was measured: agent mode, non streaming. The other three build
   their kwargs through the same `_get_model_kwargs`, so both the 400 and the fix transfer by
   inspection, but they were not run.
3. The fix was verified through a separate chat/completions transport carrying the
   reconstructed payload, not through `LiteLLMCaller` itself. What is established is that the
   same tool schemas, the same system prompt and the same model return 400 without
   `reasoning_effort: "none"` and 200 with it. The forwarding code is new and was not run
   against the live API.
4. `gpt-5.6-sol` and `gpt-5.6-terra` were not measured here, although #756 names them and the
   error text is the same. The YAML entry added is for `gpt-5.6-luna` only; the same line
   applies to the other two.
5. The unconditional `temperature` at `_get_model_kwargs` is left as it is. For a GPT-5.6
   model configured with `reasoning_effort: "none"` it is accepted again, which the 120
   patched reps show directly since they all carry `temperature: 0.7`. Whether some other
   model needs a `supports_temperature` style flag was not measured, so none is shipped.
6. Four of the ten default MCP servers are in the suite, contributing six tools. The other
   six need file generation, MCP sampling, UI round trips or a separate HTTP process. None of
   them changes any payload field the 400 depends on.
7. `reasoning_effort: "none"` turns reasoning off. Twelve tool routing and error reporting
   cases are unchanged by it at 119 of 120 reps, which says nothing about deployments that
   chose a reasoning model for its reasoning.

## Evidence

Run records, the probe table, the case list, the recorded 400s and the cost breakdown:
https://gist.github.com/atilavahedian/e38f64cc8d3d26214a85e330f8056924

Measured with upshift (https://github.com/Mechanism-world/upshift). Total measurement cost
$0.64.
