### PR TITLE
fix(config): re-raise a model validation error instead of loading zero models

### DIFF
--- a/atlas/modules/config/config_loader.py
+++ b/atlas/modules/config/config_loader.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
+from pydantic import ValidationError
 
 from .models import (
     FileExtractorsConfig,
@@ -200,6 +201,13 @@ class ConfigManager:
                     self._llm_config = LLMConfig(models={})
                     logger.info("Created empty LLM config (no configuration file found)")
 
+            except ValidationError:
+                # A model entry that fails validation is an intentional
+                # refusal-to-start, the same contract app_settings above states.
+                # Falling back here would swap one bad entry for zero models and
+                # leave only a log line, and would contradict docs/admin/llm-config.md,
+                # which promises a load-time error for an invalid `reasoning_effort`.
+                raise
             except Exception as e:
                 logger.error(f"Failed to parse LLM configuration: {e}", exc_info=True)
                 self._llm_config = LLMConfig(models={})

--- a/atlas/tests/test_llm_reasoning_effort.py
+++ b/atlas/tests/test_llm_reasoning_effort.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import ValidationError
 
-from atlas.modules.config.config_manager import LLMConfig, ModelConfig
+from atlas.modules.config.config_manager import ConfigManager, LLMConfig, ModelConfig
 from atlas.modules.config.models import REASONING_EFFORT_VALUES
 from atlas.modules.llm.litellm_caller import LiteLLMCaller
 
@@ -157,3 +157,60 @@ class TestReasoningEffortIsValidatedAtLoad:
         """The end-to-end point of the validator: the 400 cannot be built."""
         with pytest.raises(ValidationError):
             _make_caller({"gpt-5.6-luna": {"reasoning_effort": "meduim"}})
+
+
+class TestABadEffortReachesTheOperator:
+    """The load-time error documented in docs/admin/llm-config.md must survive the loader.
+
+    ``ConfigManager.llm_config`` builds the whole file with one
+    ``LLMConfig(**data)`` inside a catch-all that falls back to
+    ``LLMConfig(models={})``. Without the ``ValidationError`` re-raise, one typo
+    in one entry loads zero models and leaves only a log line, and the promise
+    that an invalid ``reasoning_effort`` "raises a configuration error when
+    ATLAS loads llmconfig.yml" is not kept.
+    """
+
+    def test_a_typo_raises_instead_of_loading_zero_models(self, monkeypatch):
+        cm = ConfigManager()
+        monkeypatch.setattr(
+            cm,
+            "_load_file_with_error_handling",
+            lambda paths, file_type: {
+                "models": {
+                    "good": {"model_name": "good", "model_url": "https://x/v1"},
+                    "bad": {
+                        "model_name": "bad",
+                        "model_url": "https://x/v1",
+                        "reasoning_effort": "meduim",
+                    },
+                }
+            },
+        )
+        with pytest.raises(ValidationError) as exc:
+            _ = cm.llm_config
+        assert "meduim" in str(exc.value)
+
+    def test_a_missing_file_still_yields_an_empty_config(self, monkeypatch):
+        """The pre-existing no-config-file path is unchanged."""
+        cm = ConfigManager()
+        monkeypatch.setattr(
+            cm, "_load_file_with_error_handling", lambda paths, file_type: None
+        )
+        assert cm.llm_config.models == {}
+
+    def test_a_valid_file_still_loads(self, monkeypatch):
+        cm = ConfigManager()
+        monkeypatch.setattr(
+            cm,
+            "_load_file_with_error_handling",
+            lambda paths, file_type: {
+                "models": {
+                    "gpt-5.6-luna": {
+                        "model_name": "gpt-5.6-luna",
+                        "model_url": "https://x/v1",
+                        "reasoning_effort": "none",
+                    }
+                }
+            },
+        )
+        assert cm.llm_config.models["gpt-5.6-luna"].reasoning_effort == "none"


### PR DESCRIPTION
Follow-up to #893, addressing the first note in the review that landed on it.

#893 documented that an invalid `reasoning_effort` "raises a configuration error when ATLAS loads `llmconfig.yml`" (`docs/admin/llm-config.md`, and the field comment at `atlas/modules/config/models.py:118-125`). It does not. `ConfigManager.llm_config` builds the whole file with one `LLMConfig(**data)` inside a catch-all (`atlas/modules/config/config_loader.py:189-213`) that falls back to `LLMConfig(models={})`, so one typo in one entry loads zero models and leaves only an ERROR log line.

This re-raises `ValidationError` ahead of that catch-all, matching the refusal-to-start contract `app_settings` already states at `config_loader.py:172-176`.

Three tests in `atlas/tests/test_llm_reasoning_effort.py`: the typo raises, a missing config file still yields an empty config, a valid file still loads. The first fails on current `main`.

Verified in a clean container against the repo's `uv.lock`: 98 passed across `test_config_manager`, `test_config_manager_paths` and `test_llm_reasoning_effort`; `ruff check` clean. No provider call.
