### PR TITLE
build(deps): hold fastmcp below 4.0 and document why

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # FastMCP 4 implements MCP 2026-07-28, which removed server-initiated
+      # requests (SEP-2322). That drops Context.sample(), which the
+      # sampling_demo and tool_planner MCP servers depend on. Re-evaluate once
+      # those servers no longer rely on server-initiated sampling.
+      # Tracked in https://github.com/sandialabs/atlas-ui-3/issues/905
+      - dependency-name: "fastmcp"
+        update-types:
+          - "version-update:semver-major"
 
   # Python dependencies (file-extractor-mock)
   - package-ecosystem: "pip"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #904 - 2026-09-08
+- Hold `fastmcp` below 4.0 and record why: FastMCP 4 removes server-initiated sampling, which the sampling_demo and tool_planner MCP servers require (tracked in #905).
+
 ### PR #901 - 2026-09-08
 - Sign browser session cookies with SHA-256 so OIDC and Globus authentication work on FIPS-hardened systems where SHA-1 is unavailable.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ dependencies = [
     "cryptography>=44.0.0,<51.0.0",
     "duckdb-engine>=0.17.0,<1.0.0",
     "fastapi>=0.115.0,<1.0.0",
+    # Pinned below 4.0: FastMCP 4 implements MCP 2026-07-28, which removed
+    # server-initiated requests (SEP-2322). That deletes Context.sample() and
+    # leaves no back-channel for sampling/createMessage, so the sampling_demo
+    # and tool_planner servers cannot work. Raising this cap requires first
+    # redesigning those servers to stop relying on server-initiated sampling.
+    # Tracked in https://github.com/sandialabs/atlas-ui-3/issues/905
     "fastmcp[tasks]>=3.4.3,<4.0.0",
     "httpx>=0.28.1,<1.0.0",
     "itsdangerous>=2.0.0,<3.0.0",


### PR DESCRIPTION
## Why

Dependabot #895 widened the `fastmcp` constraint to `>=3.4.3,<5.0.0`. That bump cannot pass CI: it fails 7 tests in `atlas/tests/test_sampling_integration.py` with

```
fastmcp.exceptions.ToolError: Error calling tool 'summarize_text': 'Context' object has no attribute 'sample'
```

This is not a rename. FastMCP 4 implements MCP protocol `2026-07-28`, which removed **server-initiated requests** (SEP-2322). `Context.sample()` is deleted from the server-authoring API, and reaching the wire directly through the SDK session raises:

```
Cannot send 'sampling/createMessage': this transport context has no back-channel for server-initiated requests.
```

There is no client-side knob to negotiate a handshake-era protocol version — neither `fastmcp.Client` nor `mcp.ClientSession` exposes a protocol-version pin — so there is no drop-in migration. FastMCP's own `server/providers/proxy.py` documents the same constraint: "server-initiated sampling is not part of FastMCP's server-authoring API ... this path only ever runs when both legs of the proxy speak the handshake era."

Atlas depends on server-initiated sampling in `atlas/mcp/sampling_demo/main.py` (11 call sites), `atlas/mcp/tool_planner/main.py`, and the sampling-routing plumbing in `MCPToolManager`. Raising the cap would silently break a shipped feature, so the major bump needs a redesign of those servers first, not a constraint change.

## What this PR does

- Documents the `<4.0.0` cap in `pyproject.toml` so the reason is next to the pin.
- Adds a Dependabot `ignore` rule for `fastmcp` major updates on the root pip ecosystem, so the same unmergeable PR is not reopened weekly.
- Links #905 (the migration off server-initiated sampling) from both, so the cap has a tracked off-ramp.

No dependency versions change. #895 is closed.

## Scope of the ignore rule

Deliberately root-only. `mocks/mcp-http-mock` has its own ecosystem block and was already widened to `<5.0.0` by merged #896 — it uses no `Context` and no sampling, so 4.x is safe there. `mocks/wormhole-mcp-mock` and `atlas/mcp/code-executor-v2` use only `ctx.session_id` and have no Dependabot entry at all.

## Reproduction

Against `fastmcp==4.0.3` in a clean venv:

```python
# srv.py
from fastmcp import FastMCP, Context
mcp = FastMCP("demo")

@mcp.tool
async def summarize_text(text: str, ctx: Context) -> str:
    from mcp import types as mcp_types
    result = await ctx.session.create_message(
        messages=[mcp_types.SamplingMessage(
            role="user",
            content=mcp_types.TextContent(type="text", text=text))],
        max_tokens=512,
        related_request_id=ctx.origin_request_id,
    )
    return result.content.text

if __name__ == "__main__":
    mcp.run()
```

```python
# cli.py
import asyncio, sys
from fastmcp import Client
from fastmcp.client.transports import StdioTransport
from mcp.types import CreateMessageResult, TextContent

async def h(messages, params=None, context=None):
    return CreateMessageResult(role="assistant",
                               content=TextContent(type="text", text="SUMMARY OK"),
                               model="t")

async def main():
    c = Client(StdioTransport(command=sys.executable, args=["srv.py"]), sampling_handler=h)
    async with c:
        print(await c.call_tool("summarize_text", {"text": "hello world"}))

asyncio.run(main())
```

`python cli.py` raises the `NoBackChannelError` quoted above. Also confirm `"sample" not in dir(fastmcp.Context)`.

## Verification

`PYTHONPATH=$(pwd) .venv/bin/python -m pytest atlas/tests/test_sampling_integration.py -q` → `11 passed` on the current pin.