### PR TITLE
feat(auth): allow admins and groups to be configured statically (closes #910)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,22 @@ APP_NAME=ATLAS
 # Default: X-User-Email
 # AUTH_USER_HEADER=X-User-Email
 
+# Static authorization (no external authorization service required).
+# Consulted after AUTH_GROUP_CHECK_URL and before the debug-only mock table,
+# so it works with DEBUG_MODE=false. Matching is case-insensitive and
+# whitespace-tolerant. See docs/admin/authentication.md.
+#
+# Comma-separated identities granted ADMIN_GROUP (the common case):
+# ADMIN_USERS=alice@example.org,bob@example.org
+#
+# Arbitrary groups, for scoping MCP servers/models via their `groups` lists:
+# AUTH_STATIC_GROUPS=admin:alice@example.org,bob@example.org;mcp_advanced:alice@example.org
+#
+# With DEBUG_MODE=false, no AUTH_GROUP_CHECK_URL and neither of the above set,
+# every user is in `users` and no other group -- admin is unreachable by anyone
+# and group-restricted servers are hidden from everyone. Atlas logs a startup
+# warning in that case.
+
 # Admin test user for development/test auth flows.
 # Used by tests and debug-mode mock admin authorization.
 # Default: admin@example.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #911 - 2026-09-09
+- **Admins and groups can be configured statically, without an external authorization service** (closes #910): `ADMIN_USERS=alice@example.org,bob@example.org` grants `ADMIN_GROUP`, and `AUTH_STATIC_GROUPS=admin:alice@example.org;mcp_advanced:alice@example.org` generalizes that to arbitrary groups, so a `groups` restriction on an MCP server or model is meaningful outside debug mode. Static membership is consulted after `AUTH_GROUP_CHECK_URL` (a real authorization service stays authoritative) and before the debug-only mock table, so it works with `DEBUG_MODE=false` -- previously that combination collapsed to "everyone is in `users`, nobody is in anything else", leaving admin unreachable by every identity. Matching is case-insensitive and whitespace-tolerant since the values come from IdP claims; malformed entries are skipped with a warning rather than failing startup. Atlas now also logs a startup warning when `DEBUG_MODE=false`, no `AUTH_GROUP_CHECK_URL` and no static config are all true, which used to be silent.
+
 ### PR #904 - 2026-09-08
 - Hold `fastmcp` below 4.0 and record why: FastMCP 4 removes server-initiated sampling, which the sampling_demo and tool_planner MCP servers require (tracked in #905).
 

--- a/atlas/core/auth.py
+++ b/atlas/core/auth.py
@@ -114,16 +114,27 @@ async def is_user_in_group(user_id: str, group_id: str) -> bool:
         # unlike the mock table -- available outside debug mode. Without it, a
         # deployment with no external authorizer has no way to make anyone an
         # admin or to scope an MCP server to a subset of users (issue #910).
-        # Values come from IdP claims and hand-edited config, so both sides are
-        # normalized to stripped lowercase.
-        static_members = app_settings.static_group_members.get(
-            (group_id or "").strip().lower()
-        )
-        if static_members and (user_id or "").strip().lower() in static_members:
-            return True
+        #
+        # Group names arrive from hand-edited config (the `groups` lists on
+        # MCP servers and models) and identities from IdP claims, so casing
+        # and stray whitespace are noise everywhere below -- not only in the
+        # static table.
+        normalized_group = (group_id or "").strip().lower()
+
+        # Gated on ``auth_url`` alone, not on the ``auth_url and api_key`` pair
+        # that selects the branch above: a deployment that configures an
+        # endpoint but whose API key is missing (a failed secret injection, a
+        # misspelled variable) lands here, and granting static admin in that
+        # window would preserve access precisely when the authoritative service
+        # has dropped out. Failing closed there is the whole point of calling
+        # the endpoint authoritative.
+        if not auth_url:
+            static_members = app_settings.static_group_members.get(normalized_group)
+            if static_members and (user_id or "").strip().lower() in static_members:
+                return True
 
         # Everybody is in the users group by default
-        if (group_id == "users"):
+        if normalized_group == "users":
             return True
         # Mock group membership is only available in debug mode
         if not app_settings.debug_mode:

--- a/atlas/core/auth.py
+++ b/atlas/core/auth.py
@@ -50,8 +50,13 @@ async def is_user_in_group(user_id: str, group_id: str) -> bool:
        is on outside debug mode / a development environment -- so the bypass can
        only ever override the mock table below, never a real authorization service.
     2. External endpoint: when ``AUTH_GROUP_CHECK_URL`` and ``AUTH_GROUP_CHECK_API_KEY``
-       are configured, query the HTTP authorization service for membership.
-    3. Mock table (fallback for local development): everyone is in the ``users``
+       are configured, query the HTTP authorization service for membership. A real
+       authorization service is authoritative: the static config below is not
+       consulted as an additional grant when an endpoint is configured.
+    3. Static config: ``ADMIN_USERS`` and ``AUTH_STATIC_GROUPS`` grant membership
+       without an external service, in production mode as well as debug. Matching
+       is case-insensitive and whitespace-tolerant.
+    4. Mock table (fallback for local development): everyone is in the ``users``
        group; the debug-only mock table grants admin to the configured test users.
 
     Args:
@@ -104,6 +109,19 @@ async def is_user_in_group(user_id: str, group_id: str) -> bool:
             logger.error(f"Error during external auth check: {e}", exc_info=True)
             return False
     else:
+        # Statically configured membership (ADMIN_USERS / AUTH_STATIC_GROUPS).
+        # Checked before the ``users`` short-circuit and the mock table, and --
+        # unlike the mock table -- available outside debug mode. Without it, a
+        # deployment with no external authorizer has no way to make anyone an
+        # admin or to scope an MCP server to a subset of users (issue #910).
+        # Values come from IdP claims and hand-edited config, so both sides are
+        # normalized to stripped lowercase.
+        static_members = app_settings.static_group_members.get(
+            (group_id or "").strip().lower()
+        )
+        if static_members and (user_id or "").strip().lower() in static_members:
+            return True
+
         # Everybody is in the users group by default
         if (group_id == "users"):
             return True

--- a/atlas/modules/config/settings.py
+++ b/atlas/modules/config/settings.py
@@ -2,12 +2,64 @@
 
 import logging
 import sys
-from typing import Optional
+from typing import Dict, FrozenSet, Optional
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, PrivateAttr, model_validator
 from pydantic_settings import BaseSettings
 
 logger = logging.getLogger(__name__)
+
+
+def parse_static_groups(
+    static_groups: str,
+    admin_users: str = "",
+    admin_group: str = "admin",
+) -> Dict[str, FrozenSet[str]]:
+    """Parse statically configured group membership into a lookup table.
+
+    ``static_groups`` uses ``group:user1,user2;group2:user3`` -- semicolons
+    separate groups, a colon separates the group name from its members, and
+    commas separate members. ``admin_users`` is sugar for a single
+    ``<admin_group>:`` entry, so a deployment that only needs admins never has
+    to learn the longer syntax; the two are unioned when both are set.
+
+    Group names and user identifiers are lower-cased and stripped, because the
+    values come from IdP claims and from hand-edited config, where casing and
+    stray whitespace are not meaningful.
+
+    Malformed entries are skipped with a warning rather than raising: a typo in
+    one group should not take the deployment down, and denying access is the
+    safe direction.
+    """
+    table: Dict[str, set] = {}
+
+    def _add(group: str, members) -> None:
+        group = group.strip().lower()
+        if not group:
+            return
+        cleaned = {m.strip().lower() for m in members}
+        cleaned.discard("")
+        if not cleaned:
+            return
+        table.setdefault(group, set()).update(cleaned)
+
+    for entry in (static_groups or "").split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            logger.warning(
+                "Ignoring malformed AUTH_STATIC_GROUPS entry (expected "
+                "'group:user1,user2'): %r",
+                entry,
+            )
+            continue
+        group, _, members = entry.partition(":")
+        _add(group, members.split(","))
+
+    _add(admin_group, (admin_users or "").split(","))
+
+    return {group: frozenset(members) for group, members in table.items()}
 
 
 def build_db_url_from_parts(
@@ -291,6 +343,23 @@ class AppSettings(BaseSettings):
         default="admin@example.com",
         validation_alias="ADMIN_TEST_USER",
         description="Admin test user for development/test auth flows"
+    )
+    admin_users: str = Field(
+        default="",
+        validation_alias="ADMIN_USERS",
+        description=(
+            "Comma-separated identities granted ADMIN_GROUP without an external "
+            "authorization service. Sugar for a single AUTH_STATIC_GROUPS entry."
+        ),
+    )
+    auth_static_groups: str = Field(
+        default="",
+        validation_alias="AUTH_STATIC_GROUPS",
+        description=(
+            "Statically configured group membership: "
+            "'group:user1,user2;group2:user3'. Consulted after "
+            "AUTH_GROUP_CHECK_URL and before the debug-only mock table."
+        ),
     )
     auth_group_check_url: Optional[str] = Field(default=None, validation_alias="AUTH_GROUP_CHECK_URL")
     auth_group_check_api_key: Optional[str] = Field(default=None, validation_alias="AUTH_GROUP_CHECK_API_KEY")
@@ -888,6 +957,48 @@ class AppSettings(BaseSettings):
                 "local development convenience only and must never be enabled in production."
             )
         return self
+
+    @model_validator(mode='after')
+    def warn_when_no_authorization_source_configured(self):
+        """Warn when nothing can ever grant a group outside ``users``.
+
+        With DEBUG_MODE=false, no AUTH_GROUP_CHECK_URL and no static config,
+        ``is_user_in_group`` collapses to a single bit: everyone is in
+        ``users`` and nobody is in anything else. Admin routes are then
+        unreachable by every identity, and ``groups:`` on an MCP server hides
+        that server from everyone. That used to be entirely silent.
+        """
+        if (
+            not self.debug_mode
+            and not self.auth_group_check_url
+            and not self.static_group_members
+        ):
+            logger.warning(
+                "No authorization source is configured (DEBUG_MODE=false, no "
+                "AUTH_GROUP_CHECK_URL, no ADMIN_USERS/AUTH_STATIC_GROUPS). Every "
+                "user is in the 'users' group and in no other group, so admin "
+                "routes are unreachable and any MCP server with a 'groups' "
+                "restriction is hidden from everyone. Set ADMIN_USERS=you@example.org "
+                "to grant admin, or configure AUTH_GROUP_CHECK_URL."
+            )
+        return self
+
+    @property
+    def static_group_members(self) -> Dict[str, FrozenSet[str]]:
+        """Statically configured membership, normalized and cached.
+
+        Parsed lazily and memoized: ``is_user_in_group`` consults this on every
+        authorization check, and the source strings only change when settings
+        are rebuilt (``config_manager.reload_configs`` constructs a new
+        ``AppSettings``, which starts with an empty cache).
+        """
+        if self._static_group_members_cache is None:
+            self._static_group_members_cache = parse_static_groups(
+                self.auth_static_groups, self.admin_users, self.admin_group
+            )
+        return self._static_group_members_cache
+
+    _static_group_members_cache: Optional[Dict[str, FrozenSet[str]]] = PrivateAttr(default=None)
 
     model_config = {
         "env_file": "../.env",

--- a/atlas/modules/config/settings.py
+++ b/atlas/modules/config/settings.py
@@ -983,6 +983,8 @@ class AppSettings(BaseSettings):
             )
         return self
 
+    _static_group_members_cache: Optional[Dict[str, FrozenSet[str]]] = PrivateAttr(default=None)
+
     @property
     def static_group_members(self) -> Dict[str, FrozenSet[str]]:
         """Statically configured membership, normalized and cached.
@@ -998,7 +1000,6 @@ class AppSettings(BaseSettings):
             )
         return self._static_group_members_cache
 
-    _static_group_members_cache: Optional[Dict[str, FrozenSet[str]]] = PrivateAttr(default=None)
 
     model_config = {
         "env_file": "../.env",

--- a/atlas/modules/config/settings.py
+++ b/atlas/modules/config/settings.py
@@ -1000,7 +1000,6 @@ class AppSettings(BaseSettings):
             )
         return self._static_group_members_cache
 
-
     model_config = {
         "env_file": "../.env",
         "env_file_encoding": "utf-8",

--- a/atlas/tests/test_core_auth.py
+++ b/atlas/tests/test_core_auth.py
@@ -402,3 +402,42 @@ def test_warns_when_no_authorization_source_is_configured(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger="atlas.modules.config.settings"):
         AppSettings(debug_mode=False, auth_group_check_url=None, ADMIN_USERS="alice@example.org")
     assert "No authorization source is configured" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_users_group_short_circuit_is_case_and_whitespace_tolerant(monkeypatch):
+    """``Users`` / `` users `` in a hand-edited ``groups`` list must still hit
+    the default-users short-circuit instead of denying everyone (Copilot review
+    on PR #911): group-name tolerance cannot stop at the static table."""
+    _production_static_env(monkeypatch)
+    config_manager.reload_configs()
+
+    from atlas.core.auth import is_user_in_group
+
+    assert await is_user_in_group("nobody@example.org", "Users") is True
+    assert await is_user_in_group("nobody@example.org", " users ") is True
+
+
+@pytest.mark.asyncio
+async def test_static_config_ignored_when_authorizer_url_set_without_api_key(monkeypatch):
+    """An endpoint configured without a usable API key must fail closed.
+
+    ``AUTH_GROUP_CHECK_URL`` without ``AUTH_GROUP_CHECK_API_KEY`` -- a failed
+    secret injection, a misspelled variable -- does not take the external
+    branch. If static config were consulted there, a listed admin would keep
+    admin exactly while the authoritative service is unreachable, which is the
+    opposite of what "the endpoint is authoritative" promises.
+    """
+    monkeypatch.setenv("DEBUG_MODE", "false")
+    monkeypatch.setenv("FEATURE_AGENT_PORTAL_ENABLED", "false")
+    monkeypatch.delenv("SKIP_AUTHORIZATION_CHECKS", raising=False)
+    monkeypatch.setenv("ADMIN_USERS", "alice@example.org")
+    monkeypatch.setenv("AUTH_GROUP_CHECK_URL", "https://auth.example.com/check")
+    monkeypatch.delenv("AUTH_GROUP_CHECK_API_KEY", raising=False)
+    config_manager.reload_configs()
+
+    from atlas.core.auth import is_user_in_group
+
+    assert await is_user_in_group("alice@example.org", "admin") is False
+    # The unrelated default is unchanged: everyone is still in ``users``.
+    assert await is_user_in_group("alice@example.org", "users") is True

--- a/atlas/tests/test_core_auth.py
+++ b/atlas/tests/test_core_auth.py
@@ -1,4 +1,5 @@
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -262,3 +263,142 @@ def test_skip_authorization_checks_boot_path_refuses_to_start(monkeypatch):
     finally:
         # Leave the cache clean so the next test reconstructs with restored env.
         config_manager.reload_configs()
+
+
+# ---------------------------------------------------------------------------
+# Statically configured groups (issue #910)
+# ---------------------------------------------------------------------------
+
+
+def _production_static_env(monkeypatch):
+    """Production-shaped env with no external authorizer and no mock table."""
+    monkeypatch.setenv("DEBUG_MODE", "false")
+    monkeypatch.setenv("FEATURE_AGENT_PORTAL_ENABLED", "false")
+    monkeypatch.delenv("SKIP_AUTHORIZATION_CHECKS", raising=False)
+    _disable_external_authorizer(monkeypatch)
+
+
+def test_parse_static_groups_normalizes_and_merges_admin_users():
+    from atlas.modules.config.settings import parse_static_groups
+
+    table = parse_static_groups(
+        " Admin : Alice@Example.ORG , bob@example.org ; mcp_advanced:alice@example.org ",
+        admin_users="Carol@Example.org, ,",
+        admin_group="admin",
+    )
+
+    assert table == {
+        "admin": frozenset({"alice@example.org", "bob@example.org", "carol@example.org"}),
+        "mcp_advanced": frozenset({"alice@example.org"}),
+    }
+
+
+def test_parse_static_groups_skips_malformed_entries_without_raising():
+    """A typo in one entry must not take the deployment down, and must not
+    silently become a group named after the whole entry."""
+    from atlas.modules.config.settings import parse_static_groups
+
+    table = parse_static_groups("no-colon-here;;good:a@b.com;empty_group:  ,")
+
+    assert table == {"good": frozenset({"a@b.com"})}
+
+
+def test_admin_users_sugar_targets_the_configured_admin_group(monkeypatch):
+    """ADMIN_USERS is sugar for a single ``<ADMIN_GROUP>:`` entry, so a renamed
+    admin group must be honoured rather than a literal "admin"."""
+    # Dev-only preview flag; AppSettings refuses to build with it on outside
+    # debug mode.
+    monkeypatch.setenv("FEATURE_AGENT_PORTAL_ENABLED", "false")
+
+    # ``admin_group``/``debug_mode`` have no validation alias, so they must be
+    # passed by field name; ``ADMIN_USERS`` does, so it is passed by alias.
+    settings = AppSettings(
+        debug_mode=False,
+        admin_group="atlas_admins",
+        ADMIN_USERS="alice@example.org",
+    )
+
+    assert settings.static_group_members == {"atlas_admins": frozenset({"alice@example.org"})}
+
+
+@pytest.mark.asyncio
+async def test_static_admin_users_grants_admin_in_production_mode(monkeypatch):
+    """The core of issue #910: with DEBUG_MODE=false and no authorizer, a listed
+    admin is an admin -- previously nobody could be."""
+    _production_static_env(monkeypatch)
+    monkeypatch.setenv("ADMIN_USERS", "alice@example.org,bob@example.org")
+    config_manager.reload_configs()
+
+    from atlas.core.auth import is_user_in_group
+
+    admin_group = config_manager.app_settings.admin_group
+    assert await is_user_in_group("alice@example.org", admin_group) is True
+    assert await is_user_in_group("bob@example.org", admin_group) is True
+    assert await is_user_in_group("mallory@example.org", admin_group) is False
+
+
+@pytest.mark.asyncio
+async def test_static_matching_is_case_insensitive_and_whitespace_tolerant(monkeypatch):
+    """Identities arrive from IdP claims, where casing and padding are noise."""
+    _production_static_env(monkeypatch)
+    monkeypatch.setenv("ADMIN_USERS", "  Alice@Example.ORG ")
+    config_manager.reload_configs()
+
+    from atlas.core.auth import is_user_in_group
+
+    admin_group = config_manager.app_settings.admin_group
+    assert await is_user_in_group("ALICE@example.org", admin_group) is True
+    assert await is_user_in_group(" alice@example.org ", admin_group) is True
+    assert await is_user_in_group("alice@example.org", admin_group.upper()) is True
+
+
+@pytest.mark.asyncio
+async def test_static_groups_scope_arbitrary_groups_in_production_mode(monkeypatch):
+    """``groups:`` on an MCP server is meaningless outside debug mode unless
+    arbitrary groups can be configured statically."""
+    _production_static_env(monkeypatch)
+    monkeypatch.setenv(
+        "AUTH_STATIC_GROUPS", "admin:alice@example.org;mcp_advanced:alice@example.org,dev@example.org"
+    )
+    config_manager.reload_configs()
+
+    from atlas.core.auth import is_user_in_group
+
+    assert await is_user_in_group("dev@example.org", "mcp_advanced") is True
+    assert await is_user_in_group("dev@example.org", "admin") is False
+    assert await is_user_in_group("alice@example.org", "admin") is True
+    # Unlisted users keep the pre-existing behaviour: users-only.
+    assert await is_user_in_group("nobody@example.org", "mcp_advanced") is False
+    assert await is_user_in_group("nobody@example.org", "users") is True
+
+
+@pytest.mark.asyncio
+async def test_external_authorizer_wins_over_static_config(monkeypatch):
+    """A real authorization service stays authoritative: static config must not
+    add grants behind its back."""
+    monkeypatch.setenv("DEBUG_MODE", "false")
+    monkeypatch.setenv("FEATURE_AGENT_PORTAL_ENABLED", "false")
+    monkeypatch.setenv("ADMIN_USERS", "alice@example.org")
+    monkeypatch.setenv("AUTH_GROUP_CHECK_URL", "https://auth.example.com/check")
+    monkeypatch.setenv("AUTH_GROUP_CHECK_API_KEY", "key")
+    config_manager.reload_configs()
+
+    from atlas.core.auth import is_user_in_group
+
+    patcher, _client = _patched_authorizer(False)
+    with patcher:
+        assert await is_user_in_group("alice@example.org", "admin") is False
+
+
+def test_warns_when_no_authorization_source_is_configured(monkeypatch, caplog):
+    """The silent-collapse case from issue #910 should say so at startup."""
+    monkeypatch.setenv("FEATURE_AGENT_PORTAL_ENABLED", "false")
+
+    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.settings"):
+        AppSettings(debug_mode=False, auth_group_check_url=None)
+    assert "No authorization source is configured" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="atlas.modules.config.settings"):
+        AppSettings(debug_mode=False, auth_group_check_url=None, ADMIN_USERS="alice@example.org")
+    assert "No authorization source is configured" not in caplog.text

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -270,6 +270,34 @@ You can configure the application to call an external HTTP endpoint to check for
         }
         ```
 
+### Static Configuration: `ADMIN_USERS` / `AUTH_STATIC_GROUPS`
+
+For deployments that do not run an authorization service, group membership can be configured statically. This is consulted **after** `AUTH_GROUP_CHECK_URL` and **before** the debug-only mock table, and — unlike the mock table — it works with `DEBUG_MODE=false`.
+
+**Admins only** (the common case):
+
+```
+ADMIN_USERS=alice@example.org,bob@example.org
+```
+
+Everyone listed satisfies a check against `ADMIN_GROUP` (whatever it is named).
+
+**Arbitrary groups**, which is what makes a `groups` restriction on an MCP server or a `required_groups` model meaningful outside debug mode:
+
+```
+AUTH_STATIC_GROUPS=admin:alice@example.org,bob@example.org;mcp_advanced:alice@example.org
+```
+
+Semicolons separate groups, a colon separates the group name from its members, and commas separate members. `ADMIN_USERS` is exactly sugar for a single `<ADMIN_GROUP>:` entry; when both are set the memberships are unioned.
+
+Notes:
+
+- **Matching is case-insensitive and whitespace-tolerant** on both group names and identities, since the values come from IdP claims and hand-edited config.
+- **An external authorizer stays authoritative.** When `AUTH_GROUP_CHECK_URL` is configured, its verdict is final and the static config is not consulted as an additional grant.
+- **Static config only ever grants.** Users not listed keep the existing behaviour — they are in `users` and nothing else.
+- A malformed `AUTH_STATIC_GROUPS` entry is skipped with a warning rather than failing startup; the effect is denial, not a partially-parsed grant.
+- If `DEBUG_MODE=false`, no `AUTH_GROUP_CHECK_URL` is set, and neither variable is configured, Atlas logs a startup warning: in that combination no user can be an admin and any group-restricted MCP server is hidden from everyone.
+
 If `AUTH_GROUP_CHECK_URL` is not set, the application will fall back to the mock implementation in `atlas/core/auth.py`.
 
 When using the mock implementation (no external endpoint configured), **all users are treated as part of the `users` group by default**. This ensures that basic, non-privileged features remain available even without an authorization service. Higher-privilege groups such as `admin` require explicit membership via your real authorization system. The mock group table (which grants admin access to the configured test user) is **only active when `DEBUG_MODE=true`**. In production mode, no admin privileges are granted via the mock — only the default `users` group is available.

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -282,7 +282,7 @@ ADMIN_USERS=alice@example.org,bob@example.org
 
 Everyone listed satisfies a check against `ADMIN_GROUP` (whatever it is named).
 
-**Arbitrary groups**, which is what makes a `groups` restriction on an MCP server or a `required_groups` model meaningful outside debug mode:
+**Arbitrary groups**, which is what makes a `groups` restriction on an MCP server or model meaningful outside debug mode:
 
 ```
 AUTH_STATIC_GROUPS=admin:alice@example.org,bob@example.org;mcp_advanced:alice@example.org
@@ -293,7 +293,7 @@ Semicolons separate groups, a colon separates the group name from its members, a
 Notes:
 
 - **Matching is case-insensitive and whitespace-tolerant** on both group names and identities, since the values come from IdP claims and hand-edited config.
-- **An external authorizer stays authoritative.** When `AUTH_GROUP_CHECK_URL` is configured, its verdict is final and the static config is not consulted as an additional grant.
+- **An external authorizer stays authoritative.** When `AUTH_GROUP_CHECK_URL` is configured, its verdict is final and the static config is not consulted as an additional grant. This holds even if `AUTH_GROUP_CHECK_API_KEY` is missing: an endpoint configured without a usable key fails closed rather than falling back to static grants.
 - **Static config only ever grants.** Users not listed keep the existing behaviour — they are in `users` and nothing else.
 - A malformed `AUTH_STATIC_GROUPS` entry is skipped with a warning rather than failing startup; the effect is denial, not a partially-parsed grant.
 - If `DEBUG_MODE=false`, no `AUTH_GROUP_CHECK_URL` is set, and neither variable is configured, Atlas logs a startup warning: in that combination no user can be an admin and any group-restricted MCP server is hidden from everyone.


### PR DESCRIPTION
## Problem

With `DEBUG_MODE=false` and no `AUTH_GROUP_CHECK_URL`, `is_user_in_group` collapses to a single bit: everyone is in `users`, nobody is in anything else. So no identity can be an admin, and `groups:` on an MCP server hides that server from *every* user. The only workaround — `ADMIN_GROUP=users` — grants admin to every authenticated identity and does nothing for tool scoping. This got more visible with OIDC login (#891), which makes `DEBUG_MODE=false` reasonable without an authorization service.

## Change

Statically configured membership, consulted **after** the external endpoint and **before** the debug-only mock table, so it works in production mode:

```bash
ADMIN_USERS=alice@example.org,bob@example.org
AUTH_STATIC_GROUPS=admin:alice@example.org,bob@example.org;mcp_advanced:alice@example.org
```

`ADMIN_USERS` is sugar for a single `<ADMIN_GROUP>:` entry (the configured admin group, not a literal `admin`); the two are unioned when both are set.

Resolution order is now: dev bypass → `AUTH_GROUP_CHECK_URL` → static config → mock table (debug only) → `users`.

Details:
- Matching is case-insensitive and whitespace-tolerant on both group names and identities — the values come from IdP claims and hand-edited config.
- **A real authorization service stays authoritative**: when `AUTH_GROUP_CHECK_URL` is configured, its verdict is final and static config is not consulted as an extra grant.
- Static config only ever grants; unlisted users keep the existing behaviour.
- A malformed `AUTH_STATIC_GROUPS` entry is skipped with a warning rather than failing startup — the effect is denial, not a partial grant.
- New startup warning when `DEBUG_MODE=false`, no `AUTH_GROUP_CHECK_URL` and no static config are all true (the "admin is unreachable by anyone" combination, previously silent).
- Parsing is memoized per `AppSettings` instance, since `is_user_in_group` runs on every authorization check.

## Tests

9 new tests in `atlas/tests/test_core_auth.py`: parsing/normalization/merge, malformed-entry handling, `ADMIN_USERS` honouring a renamed `ADMIN_GROUP`, admin grant in production mode, case/whitespace tolerance, arbitrary group scoping in production mode, external authorizer winning over static config, and the startup warning firing (and not firing once static config is set).

Verified: `bash test/atlas_tests.sh` → **3039 passed, 17 skipped**. `ruff check` clean on all changed files.

Docs: `docs/admin/authentication.md`, `.env.example`, `CHANGELOG.md`.

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1NvD8q4byDb8R4SVUU16v