### PR TITLE
fix(mcp): deliver tool-returned images to the LLM, not just the canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #910 - 2026-09-10
+- **MCP tool-returned images now reach the LLM, not just the canvas** (closes #909): a tool's ImageContent blocks were routed to the canvas while the model saw only the normalized text result -- `{"results": {}}` for a screenshot-only tool -- so agent-mode work on visual outputs (CAD screenshots, charts, browser captures) ran blind. Images are now attached to the live transcript as a synthetic user message right after the step's tool results (the OpenAI-style API rejects image content inside `role: "tool"` messages, so this is the portable form across providers via LiteLLM). Gated on the model's `supports_vision` setting (unsupported models get a note explaining the image exists but cannot be shown); capped at 6 live images with 5 MB/12 MB per-image/aggregate base64 budgets that demote the oldest images to notes; re-validated for MIME allowlist and base64 integrity at injection time. Applies to agent mode and tools mode; injection is fail-open. See `docs/developer/mcp-tool-outputs.md`.
+
 ### PR #904 - 2026-09-08
 - Hold `fastmcp` below 4.0 and record why: FastMCP 4 removes server-initiated sampling, which the sampling_demo and tool_planner MCP servers require (tracked in #905).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-### PR #910 - 2026-09-10
-- **MCP tool-returned images now reach the LLM, not just the canvas** (closes #909): a tool's ImageContent blocks were routed to the canvas while the model saw only the normalized text result -- `{"results": {}}` for a screenshot-only tool -- so agent-mode work on visual outputs (CAD screenshots, charts, browser captures) ran blind. Images are now attached to the live transcript as a synthetic user message right after the step's tool results (the OpenAI-style API rejects image content inside `role: "tool"` messages, so this is the portable form across providers via LiteLLM). Gated on the model's `supports_vision` setting (unsupported models get a note explaining the image exists but cannot be shown); capped at 6 live images with 5 MB/12 MB per-image/aggregate base64 budgets that demote the oldest images to notes; re-validated for MIME allowlist and base64 integrity at injection time. Applies to agent mode and tools mode; injection is fail-open. See `docs/developer/mcp-tool-outputs.md`.
+### PR #914 - 2026-09-10
+- **MCP tool-returned images now reach the LLM, not just the canvas** (closes #909): screenshot-only tools no longer normalize to `{"results": {}}` for the model; images are attached after the step's tool results as a synthetic user message, gated on `supports_vision`, with rolling 6-image and per-image/aggregate base64 budgets and MIME/base64 re-validation. Details and limits in `docs/developer/mcp-tool-outputs.md`.
 
 ### PR #904 - 2026-09-08
 - Hold `fastmcp` below 4.0 and record why: FastMCP 4 removes server-initiated sampling, which the sampling_demo and tool_planner MCP servers require (tracked in #905).

--- a/atlas/application/chat/agent/agentic_loop.py
+++ b/atlas/application/chat/agent/agentic_loop.py
@@ -32,6 +32,7 @@ from ..utilities import error_handler, tool_executor
 from ..utilities.dropped_calls import publish_dropped_call_warning
 from ..utilities.search_tool_selection import with_search_tool
 from ..utilities.tool_history import ToolCallRecorder
+from ..utilities.tool_image_context import ToolImageInjector, model_supports_vision
 from .protocols import AgentContext, AgentEvent, AgentEventHandler, AgentLoopProtocol, AgentResult
 from .steering import SteeringChannel
 from .streaming_final_answer import stream_final_answer
@@ -228,6 +229,14 @@ class AgenticLoop(AgentLoopProtocol):
         # would let one turn inherit another's spent sleep budget.
         turn_sleep_budget: Dict[str, Any] = {}
 
+        # Tool-returned images reach the LLM as a synthetic user message
+        # appended after each step's tool results (issue #909). Gated on the
+        # model's configured vision support; one injector per turn tracks the
+        # rolling most-recent-N cap across the loop's steps.
+        image_injector = ToolImageInjector(
+            enabled=model_supports_vision(self.config_manager, model),
+        )
+
         while steps < max_steps:
             steps += 1
 
@@ -354,6 +363,17 @@ class AgenticLoop(AgentLoopProtocol):
                     "content": result.content,
                     "tool_call_id": result.tool_call_id,
                 })
+
+            # Issue #909: the artifacts on these results (e.g. a screenshot)
+            # went to the canvas but never to the model. Attach the images to
+            # the transcript now so the next LLM call can actually see them.
+            # _to_tool_call_dict normalizes both attribute objects and plain
+            # dicts, so the id -> name map works for either shape.
+            tool_names = {
+                normalized["id"]: normalized["function"]["name"]
+                for normalized in (_to_tool_call_dict(tc) for tc in tool_calls)
+            }
+            image_injector.after_tool_results(messages, results, tool_names=tool_names)
 
             await event_handler(AgentEvent(
                 type="agent_tool_results", payload={"results": results},

--- a/atlas/application/chat/modes/tools.py
+++ b/atlas/application/chat/modes/tools.py
@@ -29,6 +29,7 @@ from ..utilities.citation_publishing import attach_citations, publish_citations
 from ..utilities.dropped_calls import publish_dropped_call_warning
 from ..utilities.search_tool_selection import with_search_tool
 from ..utilities.tool_history import ToolCallRecorder
+from ..utilities.tool_image_context import ToolImageInjector, model_supports_vision
 from .streaming_helpers import stream_and_accumulate
 
 logger = logging.getLogger(__name__)
@@ -192,6 +193,11 @@ class ToolsModeRunner:
                 config_manager=self.config_manager,
                 skip_approval=self.skip_approval,
                 user_email=user_email,
+                # Issue #909: tool-returned images reach the synthesis call
+                # as a synthetic user message when the model supports vision.
+                image_injector=ToolImageInjector(
+                    enabled=model_supports_vision(self.config_manager, model),
+                ),
             )
         except BaseException:
             # A Stop / disconnect during tool execution would otherwise discard
@@ -382,6 +388,11 @@ class ToolsModeRunner:
         current_response = final_llm_response
         executed_signatures: set = set()
         extra_round = 0
+        # Issue #909: one injector per turn tracks the rolling most-recent-N
+        # cap across continuation rounds.
+        image_injector = ToolImageInjector(
+            enabled=model_supports_vision(self.config_manager, model),
+        )
 
         try:
             while True:
@@ -441,6 +452,16 @@ class ToolsModeRunner:
                         "content": content,
                         "tool_call_id": tc_id,
                     })
+
+                # Issue #909: attach tool-returned images to the transcript so
+                # the next continuation round (or synthesis) can see them.
+                image_injector.after_tool_results(
+                    messages, results,
+                    tool_names={
+                        self._tool_call_id(tc): self._tool_call_signature(tc)[0]
+                        for tc in fresh
+                    },
+                )
 
                 if self.artifact_processor:
                     await self.artifact_processor(session, results, effective_callback)

--- a/atlas/application/chat/modes/tools.py
+++ b/atlas/application/chat/modes/tools.py
@@ -567,10 +567,19 @@ class ToolsModeRunner:
             except Exception:
                 pass  # Best-effort UI notification; synthesis proceeds regardless
 
-        # Build synthesis messages
+        # Build synthesis messages. Only plain-string user messages count as
+        # the question: multimodal user turns (inline image/PDF blocks from
+        # build_messages, or the synthetic tool-image message from issue
+        # #909) carry a list of content blocks, and the prompt provider's
+        # ``user_question.strip()`` would raise on those, silently dropping
+        # the configured synthesis prompt.
         user_question = ""
         for m in reversed(messages):
-            if m.get("role") == "user" and m.get("content"):
+            if (
+                m.get("role") == "user"
+                and isinstance(m.get("content"), str)
+                and m.get("content")
+            ):
                 user_question = m["content"]
                 break
 

--- a/atlas/application/chat/utilities/tool_executor.py
+++ b/atlas/application/chat/utilities/tool_executor.py
@@ -28,6 +28,7 @@ from atlas.modules.mcp_tools.token_storage import AuthenticationRequiredExceptio
 
 from ..approval_manager import get_approval_manager
 from .event_notifier import _sanitize_filename_value  # reuse same filename sanitizer for UI args
+from .tool_image_context import ToolImageInjector
 
 logger = logging.getLogger(__name__)
 
@@ -128,11 +129,17 @@ async def execute_tools_workflow(
     config_manager=None,
     skip_approval: bool = False,
     user_email: Optional[str] = None,
+    image_injector: Optional["ToolImageInjector"] = None,
 ) -> tuple[str, List[ToolResult]]:
     """
     Execute the complete tools workflow: calls -> results -> synthesis.
 
     Pure function that coordinates tool execution without maintaining state.
+
+    ``image_injector`` (issue #909) receives the step's tool results right
+    after their messages are appended, so tool-returned images reach the
+    synthesis call as a synthetic user message when the model supports
+    vision.
     """
     logger.debug("Entering execute_tools_workflow")
     # Add assistant message with tool calls
@@ -159,6 +166,18 @@ async def execute_tools_workflow(
             "content": result.content,
             "tool_call_id": result.tool_call_id
         })
+
+    if image_injector is not None:
+        tool_names: Dict[Any, str] = {}
+        for tc in (llm_response.tool_calls or []):
+            try:
+                tool_names[tc.id] = tc.function.name
+            except AttributeError:
+                fn = tc.get("function") if isinstance(tc, dict) else None
+                tool_names[tc.get("id") if isinstance(tc, dict) else None] = (
+                    fn.get("name", "") if isinstance(fn, dict) else ""
+                )
+        image_injector.after_tool_results(messages, tool_results, tool_names=tool_names)
 
     # Determine if synthesis is needed
     final_response = await handle_synthesis_decision(

--- a/atlas/application/chat/utilities/tool_executor.py
+++ b/atlas/application/chat/utilities/tool_executor.py
@@ -1054,10 +1054,19 @@ async def synthesize_tool_results(
 
     Pure function that coordinates LLM call for synthesis.
     """
-    # Extract latest user question (walk backwards)
+    # Extract latest user question (walk backwards). Only plain-string user
+    # messages count: multimodal user turns (inline image/PDF blocks from
+    # build_messages, or the synthetic tool-image message from issue #909)
+    # carry a list of content blocks, and the prompt provider's
+    # ``user_question.strip()`` would raise on those, silently dropping the
+    # configured synthesis prompt.
     user_question = ""
     for m in reversed(messages):
-        if m.get("role") == "user" and m.get("content"):
+        if (
+            m.get("role") == "user"
+            and isinstance(m.get("content"), str)
+            and m.get("content")
+        ):
             user_question = m["content"]
             break
 

--- a/atlas/application/chat/utilities/tool_image_context.py
+++ b/atlas/application/chat/utilities/tool_image_context.py
@@ -64,9 +64,10 @@ MAX_TOOL_IMAGE_TOTAL_B64_BYTES = 12 * 1024 * 1024
 
 _INTRO_PREFIX = "[Automated system note, not written by the user: "
 _UNSEEN_NOTE = (
-    _INTRO_PREFIX + "this tool also returned an image, but the current "
-    "model does not support vision input, so the image cannot be shown "
-    "here. The file is saved in the session files.]"
+    _INTRO_PREFIX + "tool(s) {tools} returned image(s) that are saved in "
+    "the session files, but the current model does not support vision "
+    "input, so the images cannot be shown here. Ask about them only via "
+    "the tools that produced them.]"
 )
 _DEMOTED_NOTE = (
     _INTRO_PREFIX + "{count} image(s) returned by a tool were removed "
@@ -227,19 +228,18 @@ class ToolImageInjector:
     """Appends tool-returned images to the live LLM transcript, under caps.
 
     One instance per turn: it tracks the synthetic messages it injected so
-    the rolling "most recent N" cap can demote older images as new ones
-    arrive. All entry points are fail-open -- an injection problem degrades
-    to the pre-fix behavior (text-only tool result) instead of breaking the
-    turn.
+    the rolling "most recent N" cap can demote older images -- individually,
+    not message-by-message -- as new ones arrive. All entry points are
+    fail-open: an injection problem degrades to the pre-fix behavior
+    (text-only tool result) instead of breaking the turn.
     """
 
     def __init__(self, *, enabled: bool):
         self._enabled = bool(enabled)
-        # Live injected messages with their per-message image count and
-        # base64 char total, oldest first.
+        # Live injected messages, oldest first, each with the per-image
+        # base64 lengths of the image blocks still present in it (same
+        # order as the blocks).
         self._live: List[Dict[str, Any]] = []
-        self._live_image_counts: List[int] = []
-        self._live_b64_totals: List[int] = []
 
     @property
     def enabled(self) -> bool:
@@ -255,9 +255,9 @@ class ToolImageInjector:
 
         When the model supports vision, appends one synthetic user message
         per step carrying that step's images (most-recent-wins caps). When
-        it does not, appends a short note to each image-bearing tool
-        message so the model knows an image exists and why it cannot see
-        it.
+        it does not, appends a short ``role: "system"`` note after the tool
+        results -- the tool result JSON itself is left untouched -- so the
+        model knows images exist and why it cannot see them.
         """
         if not tool_results:
             return
@@ -265,7 +265,7 @@ class ToolImageInjector:
             if self._enabled:
                 self._inject(messages, tool_results, tool_names or {})
             else:
-                self._note_unseen(messages, tool_results)
+                self._note_unseen(messages, tool_results, tool_names or {})
         except Exception:
             logger.warning(
                 "Tool image context injection failed; continuing without it",
@@ -300,11 +300,28 @@ class ToolImageInjector:
         if not images:
             return
 
-        # Aggregate budget: drop the newest images that cannot fit after
-        # demoting everything older. Keeps the request payload bounded.
+        # A single step cannot hold more images than the rolling cap: one
+        # oversized message would later be demoted wholesale. The newest of
+        # the batch wins, mirroring the transcript-wide policy.
+        if len(images) > MAX_TOOL_IMAGES_PER_TURN:
+            logger.warning(
+                "Tool returned %d images; keeping the newest %d for the LLM",
+                len(images), MAX_TOOL_IMAGES_PER_TURN,
+            )
+            images = images[-MAX_TOOL_IMAGES_PER_TURN:]
+
+        # Aggregate budget, newest wins: demote the oldest live images,
+        # individually, until the new payload fits. Only a payload that
+        # cannot fit even with nothing else live is dropped, which the
+        # per-image cap already makes near-impossible.
         kept: List[Dict[str, str]] = []
-        pending_total = sum(self._live_b64_totals)
+        pending_total = self._live_b64_total()
         for image in images:
+            while (
+                pending_total + len(image["b64"]) > MAX_TOOL_IMAGE_TOTAL_B64_BYTES
+                and self._live
+            ):
+                pending_total -= self._demote_oldest_images(1)[1]
             if pending_total + len(image["b64"]) > MAX_TOOL_IMAGE_TOTAL_B64_BYTES:
                 logger.warning(
                     "Dropping tool-returned image from LLM context: aggregate "
@@ -319,34 +336,66 @@ class ToolImageInjector:
 
         message = build_tool_image_message(kept, tool_names_used)
         messages.append(message)
-        self._live.append(message)
-        self._live_image_counts.append(len(kept))
-        self._live_b64_totals.append(sum(len(img["b64"]) for img in kept))
+        self._live.append({
+            "message": message,
+            "b64_lengths": [len(img["b64"]) for img in kept],
+        })
         self._enforce_count_cap()
         logger.info(
             "Injected %d tool-returned image(s) into the LLM transcript "
             "(%d image(s) live, %d base64 chars)",
-            len(kept), sum(self._live_image_counts), sum(self._live_b64_totals),
+            len(kept), self._live_image_count(), self._live_b64_total(),
         )
 
+    def _live_image_count(self) -> int:
+        return sum(len(entry["b64_lengths"]) for entry in self._live)
+
+    def _live_b64_total(self) -> int:
+        return sum(sum(entry["b64_lengths"]) for entry in self._live)
+
     def _enforce_count_cap(self) -> None:
-        while sum(self._live_image_counts) > MAX_TOOL_IMAGES_PER_TURN:
-            if not self._demote_oldest():
-                break
+        overflow = self._live_image_count() - MAX_TOOL_IMAGES_PER_TURN
+        while overflow > 0 and self._live:
+            overflow -= self._demote_oldest_images(overflow)[0]
 
-    def _demote_oldest(self) -> bool:
-        """Demote the oldest live image message to a text note, in place.
+    def _demote_oldest_images(self, count: int) -> tuple[int, int]:
+        """Demote up to *count* images from the oldest live message.
 
-        The dict object stays in the transcript (mutated), so message
-        ordering and the transcript's role sequence are untouched.
+        Image blocks are removed from the message's content list oldest
+        first; when a message's last image is taken, the message is
+        replaced in place with a one-line note (the dict object stays, so
+        transcript ordering and the role sequence are untouched). Returns
+        ``(demoted_count, demoted_b64_chars)``.
         """
         if not self._live:
-            return False
-        message = self._live.pop(0)
-        image_count = self._live_image_counts.pop(0)
-        self._live_b64_totals.pop(0)
-        message["content"] = _DEMOTED_NOTE.format(count=image_count)
-        return True
+            return 0, 0
+        entry = self._live[0]
+        message = entry["message"]
+        blocks = message.get("content")
+        if not isinstance(blocks, list):
+            self._live.pop(0)
+            return 0, 0
+
+        demoted = 0
+        demoted_chars = 0
+        while demoted < count and entry["b64_lengths"]:
+            # Find and drop the first (oldest) image block.
+            for index, block in enumerate(blocks):
+                if isinstance(block, dict) and block.get("type") == "image_url":
+                    removed = entry["b64_lengths"].pop(0)
+                    demoted += 1
+                    demoted_chars += removed
+                    blocks.pop(index)
+                    break
+            else:
+                break
+
+        if not entry["b64_lengths"]:
+            message["content"] = _DEMOTED_NOTE.format(
+                count=_count_injected_images(message),
+            )
+            self._live.pop(0)
+        return demoted, demoted_chars
 
     # -- non-vision path -----------------------------------------------------
 
@@ -354,40 +403,55 @@ class ToolImageInjector:
         self,
         messages: List[Dict[str, Any]],
         tool_results: List[Any],
+        tool_names: Dict[str, str],
     ) -> None:
+        noted_tools: List[str] = []
         for result in tool_results:
             artifacts = getattr(result, "artifacts", None) or []
             if not any(_is_image_artifact(a) for a in artifacts):
                 continue
-            tool_message = self._find_tool_message(
-                messages, getattr(result, "tool_call_id", None),
-            )
-            if tool_message is None or not isinstance(
-                tool_message.get("content"), str,
-            ):
-                continue
-            if _UNSEEN_NOTE in tool_message["content"]:
-                continue
-            tool_message["content"] = f"{tool_message['content']}\n\n{_UNSEEN_NOTE}"
-            logger.info(
-                "Noted an unseen tool-returned image on tool message %s "
-                "(model does not support vision)",
-                result.tool_call_id,
-            )
+            tool_name = tool_names.get(getattr(result, "tool_call_id", None), "")
+            if not tool_name:
+                for artifact in artifacts:
+                    tool_name = _tool_name_from_artifact(
+                        artifact if isinstance(artifact, dict) else {}
+                    )
+                    if tool_name:
+                        break
+            noted_tools.append(tool_name or "a tool")
+        if not noted_tools:
+            return
+        # A separate system message, not an edit to the tool result: tool
+        # output is often JSON and must stay parseable (the same position
+        # the tools-mode synthesis paths already use for their manifests).
+        messages.append({
+            "role": "system",
+            "content": _UNSEEN_NOTE.format(
+                tools=", ".join(dict.fromkeys(noted_tools)),
+            ),
+        })
+        logger.info(
+            "Noted %d unseen tool-returned image(s) after the tool results "
+            "(model does not support vision)",
+            len(noted_tools),
+        )
 
-    @staticmethod
-    def _find_tool_message(
-        messages: List[Dict[str, Any]],
-        tool_call_id: Optional[str],
-    ) -> Optional[Dict[str, Any]]:
-        """Locate the tool message for a call id, scanning backwards."""
-        if not tool_call_id:
-            return None
-        for message in reversed(messages):
-            if (
-                isinstance(message, dict)
-                and message.get("role") == "tool"
-                and message.get("tool_call_id") == tool_call_id
-            ):
-                return message
-        return None
+
+def _count_injected_images(message: Dict[str, Any]) -> int:
+    """How many images the (already trimmed) synthetic message carried.
+
+    The demotion note reports the full original count, so read it from the
+    intro text block before it is replaced.
+    """
+    blocks = message.get("content")
+    if isinstance(blocks, list):
+        for block in blocks:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                marker = " returned "
+                if marker in text:
+                    segment = text.split(marker, 1)[1]
+                    digits = segment.split(" ", 1)[0]
+                    if digits.isdigit():
+                        return int(digits)
+    return 0

--- a/atlas/application/chat/utilities/tool_image_context.py
+++ b/atlas/application/chat/utilities/tool_image_context.py
@@ -1,0 +1,393 @@
+"""LLM-context injection for MCP tool-returned images (issue #909).
+
+An MCP tool can return ``ImageContent`` blocks -- a CAD viewport screenshot,
+a chart render, a browser-automation capture. ``mcp_result_processor``
+extracts each one into a ``ToolResult`` artifact that reaches the frontend
+canvas, but nothing ever put the pixels in front of the model: only the
+normalized *text* result becomes the ``role: "tool"`` message, and for a
+tool whose entire payload is the image that text is ``{"results": {}}``.
+The model then reports it "can't directly inspect the returned image" and
+keeps working blind.
+
+The OpenAI chat-completions API -- and therefore every provider reached
+through it via LiteLLM -- rejects image content inside a ``role: "tool"``
+message, so the tool result itself cannot simply be widened. The portable
+pattern is to append a synthetic **user** message immediately after the
+step's tool results, carrying the images as ``image_url`` data-URI content
+blocks; LiteLLM translates those blocks to each provider's native format
+(Anthropic image block, Gemini ``inline_data``, Bedrock image).
+
+Lifetime and cost policy:
+
+* Injected images live in the turn's working transcript only. Conversation
+  history is text-only and ``handle_session_files`` deliberately clears
+  stale vision payloads at the start of every new turn, so a tool image is
+  visible for the remainder of the turn in which it was produced, and
+  nothing is persisted to the conversation store.
+* A rolling cap keeps only the most recent N tool images in the live
+  transcript. Older injected messages are demoted in place to a one-line
+  text note, so a long agent loop that screenshots every step cannot grow
+  the prompt without bound.
+* Aggregate and per-image base64 size caps bound the request payload.
+* Images are re-validated here (MIME allowlist, base64 decode, size) even
+  though ``_extract_v2_components`` already screened ``ImageContent``,
+  because structured ``artifacts`` entries reach this module without that
+  screening.
+
+Injection is best-effort: no failure here may break the tool-calling turn.
+"""
+
+import base64
+import logging
+from typing import Any, Dict, List, Optional
+
+from .file_processor import _LLM_READY_IMAGE_MIME_TYPES
+
+logger = logging.getLogger(__name__)
+
+# Rolling cap on tool-returned images kept in the live transcript. At
+# roughly 330 KB of base64 for a typical screenshot, retaining every image
+# a 10-step agent loop produces would bloat both the context window and the
+# bill; the most recent screenshots are the ones the model is reasoning
+# about, so older ones are demoted to a text note.
+MAX_TOOL_IMAGES_PER_TURN = 6
+
+# Per-image base64 cap. base64 is ~4/3 of raw size, so 5 MB of base64 is
+# roughly 3.7 MB of image data -- far above any ordinary screenshot, but a
+# hard stop against a tool returning a runaway payload.
+MAX_TOOL_IMAGE_B64_BYTES = 5 * 1024 * 1024
+
+# Aggregate base64 budget for all live tool images in one transcript.
+# Providers such as Bedrock enforce a ~20 MB limit on the entire request
+# payload; staying well below that leaves headroom for history and prompt.
+MAX_TOOL_IMAGE_TOTAL_B64_BYTES = 12 * 1024 * 1024
+
+_INTRO_PREFIX = "[Automated system note, not written by the user: "
+_UNSEEN_NOTE = (
+    _INTRO_PREFIX + "this tool also returned an image, but the current "
+    "model does not support vision input, so the image cannot be shown "
+    "here. The file is saved in the session files.]"
+)
+_DEMOTED_NOTE = (
+    _INTRO_PREFIX + "{count} image(s) returned by a tool were removed "
+    "from context to stay within the tool-image budget. The file(s) "
+    "remain in the session files.]"
+)
+
+# Filename extension -> LLM-ready image MIME, for artifacts without a mime field.
+_EXT_TO_IMAGE_MIME = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+}
+
+
+def model_supports_vision(config_manager: Any, model: str) -> bool:
+    """Return True when the named model is configured with supports_vision.
+
+    Reads the same configuration the orchestrator uses to gate user-upload
+    vision attachment, so both paths agree on what the model can accept.
+    """
+    if not config_manager:
+        return False
+    try:
+        model_config = config_manager.llm_config.models.get(model)
+        return bool(model_config and getattr(model_config, "supports_vision", False))
+    except Exception:
+        return False
+
+
+def _infer_image_mime(artifact: Dict[str, Any]) -> Optional[str]:
+    """Return the artifact's LLM-ready image MIME type, or None.
+
+    Prefers the explicit ``mime`` field; falls back to the filename
+    extension. Anything outside the vision-ready allowlist (SVG included --
+    it is vector XML the vision APIs do not accept as image input) yields
+    None.
+    """
+    mime = artifact.get("mime") or artifact.get("mime_type")
+    if isinstance(mime, str) and mime.strip().lower() in _LLM_READY_IMAGE_MIME_TYPES:
+        return mime.strip().lower()
+
+    name = artifact.get("name") or ""
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    return _EXT_TO_IMAGE_MIME.get(ext)
+
+
+def extract_llm_ready_images(
+    artifacts: Any,
+    tool_name: str = "",
+) -> List[Dict[str, str]]:
+    """Return validated ``{name, b64, mime}`` image dicts from tool artifacts.
+
+    Re-validates even what ``_extract_v2_components`` already accepted:
+    structured ``artifacts`` entries arrive here without that function's
+    base64 check, and the payload is about to be embedded in a provider
+    request. Oversized or malformed entries are skipped (logged), never
+    raised.
+    """
+    images: List[Dict[str, str]] = []
+    if not artifacts or not isinstance(artifacts, list):
+        return images
+
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        b64 = artifact.get("b64")
+        if not isinstance(b64, str) or not b64.strip():
+            continue
+        b64 = "".join(b64.split())  # tolerate newline-chunked base64
+
+        mime = _infer_image_mime(artifact)
+        if mime is None:
+            logger.info(
+                "Skipping tool image %r from %s: MIME type not usable for "
+                "LLM vision input",
+                artifact.get("name"), tool_name or "unknown tool",
+            )
+            continue
+
+        if len(b64) > MAX_TOOL_IMAGE_B64_BYTES:
+            logger.warning(
+                "Skipping tool image %r from %s: %d base64 bytes exceeds "
+                "the %d byte per-image limit",
+                artifact.get("name"), tool_name or "unknown tool",
+                len(b64), MAX_TOOL_IMAGE_B64_BYTES,
+            )
+            continue
+
+        try:
+            base64.b64decode(b64, validate=True)
+        except Exception:
+            logger.warning(
+                "Skipping tool image %r from %s: invalid base64 data",
+                artifact.get("name"), tool_name or "unknown tool",
+            )
+            continue
+
+        name = artifact.get("name") or f"mcp_image_{len(images)}"
+        images.append({"name": str(name), "b64": b64, "mime": mime})
+    return images
+
+
+def build_tool_image_message(
+    images: List[Dict[str, str]],
+    tool_names: List[str],
+) -> Dict[str, Any]:
+    """Build the synthetic user message carrying tool-returned images.
+
+    Uses the ``image_url`` data-URI block shape that
+    ``message_builder._build_multimodal_user_message`` emits for user
+    uploads, so LiteLLM's provider translation sees a layout it already
+    handles everywhere.
+    """
+    seen: List[str] = []
+    for tool in tool_names:
+        if tool and tool not in seen:
+            seen.append(tool)
+    tool_label = ", ".join(seen) if seen else "a tool"
+    count = len(images)
+    intro = (
+        f"{_INTRO_PREFIX} tool {tool_label} returned {count} "
+        f"image{'s' if count != 1 else ''}, shown below for you to "
+        "inspect. The file(s) are also in the session files.]"
+    )
+    content_blocks: List[Dict[str, Any]] = [{"type": "text", "text": intro}]
+    for image in images:
+        content_blocks.append({
+            "type": "image_url",
+            "image_url": {"url": f"data:{image['mime']};base64,{image['b64']}"},
+        })
+    return {"role": "user", "content": content_blocks}
+
+
+def _is_image_artifact(artifact: Any) -> bool:
+    """Loose check that an artifact is an image, for non-vision notes."""
+    if not isinstance(artifact, dict):
+        return False
+    if artifact.get("viewer") == "image":
+        return True
+    mime = artifact.get("mime") or artifact.get("mime_type") or ""
+    return isinstance(mime, str) and mime.lower().startswith("image/")
+
+
+def _tool_name_from_artifact(artifact: Dict[str, Any]) -> str:
+    """Best-effort tool name from the artifact description field."""
+    description = artifact.get("description") or ""
+    prefix = "Image returned by "
+    if isinstance(description, str) and description.startswith(prefix):
+        return description[len(prefix):].strip()
+    return ""
+
+
+class ToolImageInjector:
+    """Appends tool-returned images to the live LLM transcript, under caps.
+
+    One instance per turn: it tracks the synthetic messages it injected so
+    the rolling "most recent N" cap can demote older images as new ones
+    arrive. All entry points are fail-open -- an injection problem degrades
+    to the pre-fix behavior (text-only tool result) instead of breaking the
+    turn.
+    """
+
+    def __init__(self, *, enabled: bool):
+        self._enabled = bool(enabled)
+        # Live injected messages with their per-message image count and
+        # base64 char total, oldest first.
+        self._live: List[Dict[str, Any]] = []
+        self._live_image_counts: List[int] = []
+        self._live_b64_totals: List[int] = []
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def after_tool_results(
+        self,
+        messages: List[Dict[str, Any]],
+        tool_results: List[Any],
+        tool_names: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Hook called right after a step's tool results were appended.
+
+        When the model supports vision, appends one synthetic user message
+        per step carrying that step's images (most-recent-wins caps). When
+        it does not, appends a short note to each image-bearing tool
+        message so the model knows an image exists and why it cannot see
+        it.
+        """
+        if not tool_results:
+            return
+        try:
+            if self._enabled:
+                self._inject(messages, tool_results, tool_names or {})
+            else:
+                self._note_unseen(messages, tool_results)
+        except Exception:
+            logger.warning(
+                "Tool image context injection failed; continuing without it",
+                exc_info=True,
+            )
+
+    # -- vision-capable path ------------------------------------------------
+
+    def _inject(
+        self,
+        messages: List[Dict[str, Any]],
+        tool_results: List[Any],
+        tool_names: Dict[str, str],
+    ) -> None:
+        images: List[Dict[str, str]] = []
+        tool_names_used: List[str] = []
+        for result in tool_results:
+            tool_name = tool_names.get(getattr(result, "tool_call_id", None), "")
+            artifacts = getattr(result, "artifacts", None) or []
+            if not tool_name:
+                for artifact in artifacts:
+                    tool_name = _tool_name_from_artifact(
+                        artifact if isinstance(artifact, dict) else {}
+                    )
+                    if tool_name:
+                        break
+            result_images = extract_llm_ready_images(artifacts, tool_name)
+            if result_images:
+                tool_names_used.append(tool_name or "a tool")
+                images.extend(result_images)
+
+        if not images:
+            return
+
+        # Aggregate budget: drop the newest images that cannot fit after
+        # demoting everything older. Keeps the request payload bounded.
+        kept: List[Dict[str, str]] = []
+        pending_total = sum(self._live_b64_totals)
+        for image in images:
+            if pending_total + len(image["b64"]) > MAX_TOOL_IMAGE_TOTAL_B64_BYTES:
+                logger.warning(
+                    "Dropping tool-returned image from LLM context: aggregate "
+                    "image budget (%d base64 chars) exhausted",
+                    MAX_TOOL_IMAGE_TOTAL_B64_BYTES,
+                )
+                continue
+            pending_total += len(image["b64"])
+            kept.append(image)
+        if not kept:
+            return
+
+        message = build_tool_image_message(kept, tool_names_used)
+        messages.append(message)
+        self._live.append(message)
+        self._live_image_counts.append(len(kept))
+        self._live_b64_totals.append(sum(len(img["b64"]) for img in kept))
+        self._enforce_count_cap()
+        logger.info(
+            "Injected %d tool-returned image(s) into the LLM transcript "
+            "(%d image(s) live, %d base64 chars)",
+            len(kept), sum(self._live_image_counts), sum(self._live_b64_totals),
+        )
+
+    def _enforce_count_cap(self) -> None:
+        while sum(self._live_image_counts) > MAX_TOOL_IMAGES_PER_TURN:
+            if not self._demote_oldest():
+                break
+
+    def _demote_oldest(self) -> bool:
+        """Demote the oldest live image message to a text note, in place.
+
+        The dict object stays in the transcript (mutated), so message
+        ordering and the transcript's role sequence are untouched.
+        """
+        if not self._live:
+            return False
+        message = self._live.pop(0)
+        image_count = self._live_image_counts.pop(0)
+        self._live_b64_totals.pop(0)
+        message["content"] = _DEMOTED_NOTE.format(count=image_count)
+        return True
+
+    # -- non-vision path -----------------------------------------------------
+
+    def _note_unseen(
+        self,
+        messages: List[Dict[str, Any]],
+        tool_results: List[Any],
+    ) -> None:
+        for result in tool_results:
+            artifacts = getattr(result, "artifacts", None) or []
+            if not any(_is_image_artifact(a) for a in artifacts):
+                continue
+            tool_message = self._find_tool_message(
+                messages, getattr(result, "tool_call_id", None),
+            )
+            if tool_message is None or not isinstance(
+                tool_message.get("content"), str,
+            ):
+                continue
+            if _UNSEEN_NOTE in tool_message["content"]:
+                continue
+            tool_message["content"] = f"{tool_message['content']}\n\n{_UNSEEN_NOTE}"
+            logger.info(
+                "Noted an unseen tool-returned image on tool message %s "
+                "(model does not support vision)",
+                result.tool_call_id,
+            )
+
+    @staticmethod
+    def _find_tool_message(
+        messages: List[Dict[str, Any]],
+        tool_call_id: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Locate the tool message for a call id, scanning backwards."""
+        if not tool_call_id:
+            return None
+        for message in reversed(messages):
+            if (
+                isinstance(message, dict)
+                and message.get("role") == "tool"
+                and message.get("tool_call_id") == tool_call_id
+            ):
+                return message
+        return None

--- a/atlas/tests/test_tool_image_context.py
+++ b/atlas/tests/test_tool_image_context.py
@@ -1,0 +1,508 @@
+"""Regression tests for MCP tool-returned images reaching the LLM (#909).
+
+Issue #909: an MCP tool's ImageContent blocks were routed to the frontend
+canvas but never entered the LLM transcript -- a screenshot-only tool
+normalized to ``{"results": {}}`` for the model. These tests cover:
+
+- extraction/validation of image artifacts for LLM vision input
+- the synthetic user message appended after a step's tool results
+- vision gating (note appended to the tool message when unsupported)
+- the rolling most-recent-N and size-budget caps
+- end-to-end wiring through the agentic loop and the tools-mode workflow
+"""
+
+import base64
+import os
+import sys
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from atlas.application.chat.agent.agentic_loop import AgenticLoop
+from atlas.application.chat.agent.protocols import AgentContext
+from atlas.application.chat.utilities.tool_executor import execute_tools_workflow
+from atlas.application.chat.utilities.tool_image_context import (
+    MAX_TOOL_IMAGES_PER_TURN,
+    ToolImageInjector,
+    build_tool_image_message,
+    extract_llm_ready_images,
+    model_supports_vision,
+)
+from atlas.domain.messages.models import ConversationHistory, ToolResult
+from atlas.interfaces.llm import LLMResponse
+
+_PNG_B64 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\nfake-png-payload"
+).decode()
+_JPEG_B64 = base64.b64encode(b"\xff\xd8\xff\xe0fake-jpeg-payload").decode()
+
+
+def _png_artifact(name="mcp_image_0.png"):
+    return {
+        "name": name,
+        "b64": _PNG_B64,
+        "mime": "image/png",
+        "viewer": "image",
+        "description": "Image returned by screenshot_tool",
+    }
+
+
+def _image_result(tool_call_id="call_1", artifacts=None):
+    return ToolResult(
+        tool_call_id=tool_call_id,
+        content='{"results": {}}',
+        success=True,
+        artifacts=artifacts if artifacts is not None else [_png_artifact()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# extract_llm_ready_images
+# ---------------------------------------------------------------------------
+
+class TestExtractLlmReadyImages:
+    def test_extracts_valid_png_artifact(self):
+        images = extract_llm_ready_images([_png_artifact()], "shot")
+        assert len(images) == 1
+        assert images[0]["mime"] == "image/png"
+        assert images[0]["b64"] == _PNG_B64
+
+    def test_skips_svg_even_though_extraction_allowlists_it(self):
+        # mcp_result_processor accepts image/svg+xml for the canvas; the LLM
+        # path must not (providers reject it as image input).
+        svg = {
+            "name": "mcp_image_0.svg",
+            "b64": base64.b64encode(b"<svg/>").decode(),
+            "mime": "image/svg+xml",
+            "viewer": "image",
+        }
+        assert extract_llm_ready_images([svg], "shot") == []
+
+    def test_infers_mime_from_extension_when_missing(self):
+        artifact = {
+            "name": "render.jpg",
+            "b64": _JPEG_B64,
+            "viewer": "image",
+        }
+        images = extract_llm_ready_images([artifact], "shot")
+        assert len(images) == 1
+        assert images[0]["mime"] == "image/jpeg"
+
+    def test_skips_invalid_base64(self):
+        artifact = {
+            "name": "mcp_image_0.png",
+            "b64": "not-valid-base64!!!",
+            "mime": "image/png",
+            "viewer": "image",
+        }
+        assert extract_llm_ready_images([artifact], "shot") == []
+
+    def test_skips_oversized_image(self):
+        from atlas.application.chat.utilities.tool_image_context import (
+            MAX_TOOL_IMAGE_B64_BYTES,
+        )
+        artifact = {
+            "name": "big.png",
+            "b64": base64.b64encode(b"x" * (MAX_TOOL_IMAGE_B64_BYTES)).decode(),
+            "mime": "image/png",
+        }
+        assert extract_llm_ready_images([artifact], "shot") == []
+
+    def test_tolerates_newline_chunked_base64(self):
+        chunked = "\n".join(_PNG_B64[i:i + 8] for i in range(0, len(_PNG_B64), 8))
+        artifact = {"name": "a.png", "b64": chunked, "mime": "image/png"}
+        images = extract_llm_ready_images([artifact], "shot")
+        assert images and images[0]["b64"] == _PNG_B64
+
+    def test_handles_garbage_input(self):
+        assert extract_llm_ready_images(None) == []
+        assert extract_llm_ready_images([]) == []
+        assert extract_llm_ready_images(["nope", 42, {"name": "x"}]) == []
+
+    def test_multiple_images_preserved_in_order(self):
+        artifacts = [
+            _png_artifact("a.png"),
+            {"name": "b.jpg", "b64": _JPEG_B64, "mime": "image/jpeg"},
+        ]
+        images = extract_llm_ready_images(artifacts, "shot")
+        assert [i["name"] for i in images] == ["a.png", "b.jpg"]
+
+
+# ---------------------------------------------------------------------------
+# build_tool_image_message
+# ---------------------------------------------------------------------------
+
+class TestBuildToolImageMessage:
+    def test_message_shape_is_openai_image_url_blocks(self):
+        message = build_tool_image_message(
+            [{"name": "a.png", "b64": _PNG_B64, "mime": "image/png"}],
+            ["screenshot_tool"],
+        )
+        assert message["role"] == "user"
+        assert isinstance(message["content"], list)
+        assert message["content"][0]["type"] == "text"
+        assert "screenshot_tool" in message["content"][0]["text"]
+        image_block = message["content"][1]
+        assert image_block["type"] == "image_url"
+        assert image_block["image_url"]["url"].startswith("data:image/png;base64,")
+        assert _PNG_B64 in image_block["image_url"]["url"]
+
+    def test_singular_wording_for_one_image(self):
+        message = build_tool_image_message(
+            [{"name": "a.png", "b64": _PNG_B64, "mime": "image/png"}],
+            ["t"],
+        )
+        assert "1 image," in message["content"][0]["text"]
+
+    def test_deduplicates_tool_names(self):
+        message = build_tool_image_message(
+            [
+                {"name": "a.png", "b64": _PNG_B64, "mime": "image/png"},
+                {"name": "b.png", "b64": _PNG_B64, "mime": "image/png"},
+            ],
+            ["t", "t", "u"],
+        )
+        assert "t, u" in message["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# model_supports_vision
+# ---------------------------------------------------------------------------
+
+class TestModelSupportsVision:
+    def _config(self, supports_vision):
+        cfg = MagicMock()
+        cfg.llm_config.models = {
+            "vision-model": SimpleNamespace(supports_vision=True),
+            "text-model": SimpleNamespace(supports_vision=False),
+        }
+        return cfg
+
+    def test_true_only_when_configured(self):
+        cfg = self._config(True)
+        assert model_supports_vision(cfg, "vision-model") is True
+        assert model_supports_vision(cfg, "text-model") is False
+
+    def test_unknown_model_is_false(self):
+        cfg = self._config(True)
+        assert model_supports_vision(cfg, "missing") is False
+
+    def test_no_config_is_false(self):
+        assert model_supports_vision(None, "vision-model") is False
+
+
+# ---------------------------------------------------------------------------
+# ToolImageInjector
+# ---------------------------------------------------------------------------
+
+class TestToolImageInjector:
+    def test_injects_synthetic_user_message_after_tool_results(self):
+        messages = [
+            {"role": "user", "content": "screenshot the model"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]},
+            {"role": "tool", "content": '{"results": {}}', "tool_call_id": "call_1"},
+        ]
+        injector = ToolImageInjector(enabled=True)
+        injector.after_tool_results(
+            messages, [_image_result()],
+            tool_names={"call_1": "fusion360_fusion_mcp_read"},
+        )
+        assert len(messages) == 4
+        injected = messages[-1]
+        assert injected["role"] == "user"
+        blocks = injected["content"]
+        assert blocks[0]["type"] == "text"
+        assert "fusion360_fusion_mcp_read" in blocks[0]["text"]
+        assert blocks[1]["type"] == "image_url"
+        assert _PNG_B64 in blocks[1]["image_url"]["url"]
+        # The tool message itself stays text-only (providers reject images there).
+        assert messages[2]["content"] == '{"results": {}}'
+
+    def test_no_injection_without_image_artifacts(self):
+        messages = [{"role": "user", "content": "hi"}]
+        result = ToolResult(tool_call_id="c1", content="text only", artifacts=[])
+        ToolImageInjector(enabled=True).after_tool_results(messages, [result])
+        assert messages == [{"role": "user", "content": "hi"}]
+
+    def test_vision_disabled_appends_note_to_tool_message(self):
+        messages = [
+            {"role": "user", "content": "screenshot"},
+            {"role": "tool", "content": '{"results": {}}', "tool_call_id": "call_1"},
+        ]
+        injector = ToolImageInjector(enabled=False)
+        injector.after_tool_results(messages, [_image_result()])
+        assert len(messages) == 2
+        assert "does not support vision" in messages[1]["content"]
+        assert '{"results": {}}' in messages[1]["content"]
+
+    def test_vision_disabled_note_skipped_for_non_image_artifacts(self):
+        messages = [{"role": "tool", "content": "plain", "tool_call_id": "c1"}]
+        result = ToolResult(
+            tool_call_id="c1", content="ok",
+            artifacts=[{"name": "out.pptx", "b64": _PNG_B64, "mime": "application/vnd.x"}],
+        )
+        ToolImageInjector(enabled=False).after_tool_results(messages, [result])
+        assert messages[0]["content"] == "plain"
+
+    def test_rolling_cap_demotes_oldest_images(self):
+        messages = []
+        injector = ToolImageInjector(enabled=True)
+        for step in range(MAX_TOOL_IMAGES_PER_TURN + 2):
+            result = _image_result(tool_call_id=f"call_{step}")
+            messages.append({"role": "tool", "content": "{}", "tool_call_id": f"call_{step}"})
+            injector.after_tool_results(messages, [result])
+        live_image_messages = [
+            m for m in messages
+            if isinstance(m.get("content"), list)
+            and any(b.get("type") == "image_url" for b in m["content"] if isinstance(b, dict))
+        ]
+        demoted = [
+            m for m in messages
+            if isinstance(m.get("content"), str) and "removed from context" in m["content"]
+        ]
+        total_live = sum(
+            1 for m in live_image_messages
+            for b in m["content"] if isinstance(b, dict) and b.get("type") == "image_url"
+        )
+        assert total_live == MAX_TOOL_IMAGES_PER_TURN
+        assert len(demoted) == 2
+
+    def test_injection_never_raises_on_bad_results(self):
+        messages = [{"role": "user", "content": "hi"}]
+        injector = ToolImageInjector(enabled=True)
+        weird = SimpleNamespace(tool_call_id="c1", artifacts="not-a-list")
+        injector.after_tool_results(messages, [weird])
+        assert messages == [{"role": "user", "content": "hi"}]
+
+    def test_noop_results_list(self):
+        messages = [{"role": "user", "content": "hi"}]
+        ToolImageInjector(enabled=True).after_tool_results(messages, [])
+        assert messages == [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# Agentic loop integration
+# ---------------------------------------------------------------------------
+
+class _FakeLLM:
+    """Queued responses; records every message list it is called with."""
+
+    def __init__(self, responses: List[LLMResponse]):
+        self._responses = list(responses)
+        self.call_count = 0
+        self.message_history: List[List[dict]] = []
+
+    async def call_with_tools(self, model, messages, tools_schema, tool_choice="auto",
+                              temperature=0.7, user_email=None):
+        self.call_count += 1
+        self.message_history.append([dict(m) for m in messages])
+        if self._responses:
+            return self._responses.pop(0)
+        return LLMResponse(content="done")
+
+    async def call_plain(self, model, messages, temperature=0.7, user_email=None):
+        self.call_count += 1
+        self.message_history.append([dict(m) for m in messages])
+        return "final"
+
+
+def _make_context():
+    return AgentContext(
+        session_id=uuid4(),
+        user_email="test@example.com",
+        files={},
+        history=ConversationHistory(),
+    )
+
+
+def _vision_config():
+    """Config manager stub marking 'vision-model' as vision-capable."""
+    cfg = MagicMock()
+    cfg.llm_config.models = {
+        "vision-model": SimpleNamespace(supports_vision=True),
+        "text-model": SimpleNamespace(supports_vision=False),
+    }
+    return cfg
+
+
+def _collect_events():
+    async def handler(event):
+        pass
+    return handler
+
+
+class TestAgenticLoopInjectsToolImages:
+    @pytest.mark.asyncio
+    async def test_image_reaches_next_llm_call(self):
+        png_call = SimpleNamespace(
+            id="call_1", type="function",
+            function=SimpleNamespace(name="screenshot", arguments="{}"),
+        )
+        llm = _FakeLLM([
+            LLMResponse(content="", tool_calls=[png_call]),
+            LLMResponse(content="I can see the rocket now"),
+        ])
+        tool_mgr = MagicMock()
+
+        async def fake_execute(tool_call_obj, context=None):
+            return _image_result(tool_call_id=tool_call_obj.id)
+
+        tool_mgr.execute_tool = AsyncMock(side_effect=fake_execute)
+        tool_mgr.get_tools_schema = MagicMock(return_value=[
+            {"type": "function", "function": {"name": "screenshot", "parameters": {}}}
+        ])
+
+        loop = AgenticLoop(llm=llm, tool_manager=tool_mgr, prompt_provider=None,
+                           config_manager=_vision_config())
+        loop.skip_approval = True
+        messages = [{"role": "user", "content": "screenshot the model"}]
+
+        await loop.run(
+            model="vision-model", messages=messages, context=_make_context(),
+            selected_tools=["screenshot"], data_sources=None, max_steps=5,
+            temperature=0.7, event_handler=_collect_events(),
+        )
+
+        second_call_messages = llm.message_history[1]
+        injected = [m for m in second_call_messages if m.get("role") == "user" and isinstance(m.get("content"), list)]
+        assert len(injected) == 1
+        assert any(
+            b.get("type") == "image_url" and _PNG_B64 in b["image_url"]["url"]
+            for b in injected[0]["content"] if isinstance(b, dict)
+        )
+
+    @pytest.mark.asyncio
+    async def test_vision_gated_off_leaves_note_not_image(self):
+        png_call = SimpleNamespace(
+            id="call_1", type="function",
+            function=SimpleNamespace(name="screenshot", arguments="{}"),
+        )
+        llm = _FakeLLM([
+            LLMResponse(content="", tool_calls=[png_call]),
+            LLMResponse(content="done"),
+        ])
+        tool_mgr = MagicMock()
+
+        async def fake_execute(tool_call_obj, context=None):
+            return _image_result(tool_call_id=tool_call_obj.id)
+
+        tool_mgr.execute_tool = AsyncMock(side_effect=fake_execute)
+        tool_mgr.get_tools_schema = MagicMock(return_value=[
+            {"type": "function", "function": {"name": "screenshot", "parameters": {}}}
+        ])
+
+        # No config manager -> model_supports_vision is False -> gating.
+        loop = AgenticLoop(llm=llm, tool_manager=tool_mgr, prompt_provider=None)
+        loop.skip_approval = True
+        messages = [{"role": "user", "content": "screenshot"}]
+
+        await loop.run(
+            model="text-model", messages=messages, context=_make_context(),
+            selected_tools=["screenshot"], data_sources=None, max_steps=5,
+            temperature=0.7, event_handler=_collect_events(),
+        )
+
+        second_call_messages = llm.message_history[1]
+        assert not any(isinstance(m.get("content"), list) for m in second_call_messages)
+        tool_messages = [m for m in second_call_messages if m.get("role") == "tool"]
+        assert "does not support vision" in tool_messages[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Tools-mode workflow integration
+# ---------------------------------------------------------------------------
+
+class TestExecuteToolsWorkflowInjectsToolImages:
+    @pytest.mark.asyncio
+    async def test_images_reach_synthesis_call(self):
+        llm_response = LLMResponse(
+            content="",
+            tool_calls=[SimpleNamespace(
+                id="call_1", type="function",
+                function=SimpleNamespace(name="screenshot", arguments="{}"),
+            )],
+        )
+        tool_mgr = MagicMock()
+
+        async def fake_execute(tool_call_obj, context=None):
+            return _image_result(tool_call_id=tool_call_obj.id)
+
+        tool_mgr.execute_tool = AsyncMock(side_effect=fake_execute)
+
+        class _LlmCaller:
+            def __init__(self):
+                self.calls = []
+
+            async def call_plain(self, model, messages, user_email=None):
+                self.calls.append(messages)
+                return "I can see it"
+
+        llm_caller = _LlmCaller()
+
+        messages = [{"role": "user", "content": "screenshot"}]
+        final, tool_results = await execute_tools_workflow(
+            llm_response=llm_response,
+            messages=messages,
+            model="vision-model",
+            session_context={},
+            tool_manager=tool_mgr,
+            llm_caller=llm_caller,
+            prompt_provider=None,
+            skip_approval=True,
+            image_injector=ToolImageInjector(enabled=True),
+        )
+
+        assert final == "I can see it"
+        synthesis_messages = llm_caller.calls[-1]
+        image_messages = [
+            m for m in synthesis_messages
+            if m.get("role") == "user" and isinstance(m.get("content"), list)
+            and any(
+                isinstance(b, dict) and b.get("type") == "image_url"
+                for b in m["content"]
+            )
+        ]
+        assert len(image_messages) == 1
+        assert tool_results[0].success is True
+
+    @pytest.mark.asyncio
+    async def test_without_injector_behavior_unchanged(self):
+        llm_response = LLMResponse(
+            content="",
+            tool_calls=[SimpleNamespace(
+                id="call_1", type="function",
+                function=SimpleNamespace(name="screenshot", arguments="{}"),
+            )],
+        )
+        tool_mgr = MagicMock()
+
+        async def fake_execute(tool_call_obj, context=None):
+            return _image_result(tool_call_id=tool_call_obj.id)
+
+        tool_mgr.execute_tool = AsyncMock(side_effect=fake_execute)
+
+        class _LlmCaller:
+            async def call_plain(self, model, messages, user_email=None):
+                return "answer"
+
+        messages = [{"role": "user", "content": "screenshot"}]
+        await execute_tools_workflow(
+            llm_response=llm_response,
+            messages=messages,
+            model="vision-model",
+            session_context={},
+            tool_manager=tool_mgr,
+            llm_caller=_LlmCaller(),
+            prompt_provider=None,
+            skip_approval=True,
+            # No image_injector: legacy behavior (no image message).
+        )
+        assert not any(
+            m.get("role") == "user" and isinstance(m.get("content"), list)
+            for m in messages
+        )

--- a/atlas/tests/test_tool_image_context.py
+++ b/atlas/tests/test_tool_image_context.py
@@ -229,16 +229,25 @@ class TestToolImageInjector:
         ToolImageInjector(enabled=True).after_tool_results(messages, [result])
         assert messages == [{"role": "user", "content": "hi"}]
 
-    def test_vision_disabled_appends_note_to_tool_message(self):
+    def test_vision_disabled_appends_separate_note_message(self):
+        # The tool result JSON must stay untouched (it is often parsed);
+        # the note rides as its own system message after the tool results.
+        tool_content = '{"results": {}}'
         messages = [
             {"role": "user", "content": "screenshot"},
-            {"role": "tool", "content": '{"results": {}}', "tool_call_id": "call_1"},
+            {"role": "tool", "content": tool_content, "tool_call_id": "call_1"},
         ]
         injector = ToolImageInjector(enabled=False)
-        injector.after_tool_results(messages, [_image_result()])
-        assert len(messages) == 2
-        assert "does not support vision" in messages[1]["content"]
-        assert '{"results": {}}' in messages[1]["content"]
+        injector.after_tool_results(
+            messages, [_image_result()],
+            tool_names={"call_1": "fusion360_fusion_mcp_read"},
+        )
+        assert len(messages) == 3
+        assert messages[1]["content"] == tool_content  # JSON preserved
+        note = messages[2]
+        assert note["role"] == "system"
+        assert "does not support vision" in note["content"]
+        assert "fusion360_fusion_mcp_read" in note["content"]
 
     def test_vision_disabled_note_skipped_for_non_image_artifacts(self):
         messages = [{"role": "tool", "content": "plain", "tool_call_id": "c1"}]
@@ -247,7 +256,7 @@ class TestToolImageInjector:
             artifacts=[{"name": "out.pptx", "b64": _PNG_B64, "mime": "application/vnd.x"}],
         )
         ToolImageInjector(enabled=False).after_tool_results(messages, [result])
-        assert messages[0]["content"] == "plain"
+        assert len(messages) == 1
 
     def test_rolling_cap_demotes_oldest_images(self):
         messages = []
@@ -271,6 +280,93 @@ class TestToolImageInjector:
         )
         assert total_live == MAX_TOOL_IMAGES_PER_TURN
         assert len(demoted) == 2
+
+    def test_batch_over_cap_keeps_newest_images(self):
+        # One tool result carrying more images than the rolling cap must not
+        # create an oversized message that later demotes to zero images: the
+        # newest cap-sized slice is kept up front.
+        artifacts = [_png_artifact(f"mcp_image_{i}.png") for i in range(MAX_TOOL_IMAGES_PER_TURN + 3)]
+        messages = []
+        ToolImageInjector(enabled=True).after_tool_results(
+            messages, [_image_result(artifacts=artifacts)],
+        )
+        image_blocks = [
+            b for b in messages[-1]["content"]
+            if isinstance(b, dict) and b.get("type") == "image_url"
+        ]
+        assert len(image_blocks) == MAX_TOOL_IMAGES_PER_TURN
+        # The intro must say 6 (the retained count), not 9.
+        assert f"returned {MAX_TOOL_IMAGES_PER_TURN} images" in messages[-1]["content"][0]["text"]
+
+    def test_batch_boundary_demotes_individually_not_wholesale(self):
+        # 4 images, then 4 more: the rolling cap of 6 must trim 2 images off
+        # the oldest message (keeping its remaining images + a note-free
+        # text) rather than dropping the entire first message.
+        messages = []
+        injector = ToolImageInjector(enabled=True)
+        for step, batch in enumerate((4, 4)):
+            artifacts = [_png_artifact(f"s{step}_img{i}.png") for i in range(batch)]
+            messages.append({"role": "tool", "content": "{}", "tool_call_id": f"call_{step}"})
+            injector.after_tool_results(
+                messages, [_image_result(tool_call_id=f"call_{step}", artifacts=artifacts)],
+            )
+        live = [
+            len([b for b in m["content"] if isinstance(b, dict) and b.get("type") == "image_url"])
+            for m in messages
+            if isinstance(m.get("content"), list)
+        ]
+        assert sum(live) == MAX_TOOL_IMAGES_PER_TURN
+        assert live == [2, 4]  # oldest message trimmed by 2, not destroyed
+        # No message was fully demoted to a note (the first still holds 2).
+        assert not any(
+            isinstance(m.get("content"), str) and "removed from context" in m.get("content", "")
+            for m in messages
+        )
+
+    def test_budget_evicts_old_images_instead_of_rejecting_new(self):
+        # With the aggregate budget exhausted by old images, a new image
+        # must evict the oldest live images rather than being dropped --
+        # most-recent-wins. Three images of ~4.2 MB base64 each overfill
+        # the 12 MB budget, so each new injection demotes the oldest live
+        # image until it fits.
+        from atlas.application.chat.utilities.tool_image_context import (
+            MAX_TOOL_IMAGE_TOTAL_B64_BYTES,
+        )
+
+        # A long run of "A" is valid base64 (decodes to zero bytes); the
+        # string length is the payload size the caps see.
+        big_b64 = "A" * (MAX_TOOL_IMAGE_TOTAL_B64_BYTES // 3 + 10000)
+        messages = []
+        injector = ToolImageInjector(enabled=True)
+        for step in range(3):
+            artifacts = [{"name": f"big{step}.png", "b64": big_b64, "mime": "image/png"}]
+            messages.append({"role": "tool", "content": "{}", "tool_call_id": f"call_{step}"})
+            injector.after_tool_results(
+                messages, [_image_result(tool_call_id=f"call_{step}", artifacts=artifacts)],
+            )
+        demoted_notes = [
+            m for m in messages
+            if isinstance(m.get("content"), str) and "removed from context" in m.get("content", "")
+        ]
+        live_image_messages = [
+            m for m in messages
+            if isinstance(m.get("content"), list)
+            and any(b.get("type") == "image_url" for b in m["content"] if isinstance(b, dict))
+        ]
+        # The oldest message was demoted to a note; the two newest images
+        # fit side by side and both stay live (each is just over a third of
+        # the 12 MB budget -- under the 5 MB per-image cap -- so only one
+        # eviction was needed to admit the third).
+        assert len(demoted_notes) == 1
+        assert len(live_image_messages) == 2
+        live_urls = [
+            b["image_url"]["url"]
+            for m in live_image_messages
+            for b in m["content"]
+            if isinstance(b, dict) and b.get("type") == "image_url"
+        ]
+        assert len(live_urls) == 2
+        assert all(big_b64 in url for url in live_urls)
 
     def test_injection_never_raises_on_bad_results(self):
         messages = [{"role": "user", "content": "hi"}]
@@ -410,12 +506,60 @@ class TestAgenticLoopInjectsToolImages:
         second_call_messages = llm.message_history[1]
         assert not any(isinstance(m.get("content"), list) for m in second_call_messages)
         tool_messages = [m for m in second_call_messages if m.get("role") == "tool"]
-        assert "does not support vision" in tool_messages[0]["content"]
+        # The note rides as its own system message; the tool JSON is untouched.
+        system_notes = [m for m in second_call_messages if m.get("role") == "system"]
+        assert any(
+            "does not support vision" in (m.get("content") or "") for m in system_notes
+        )
+        assert tool_messages[0]["content"] == '{"results": {}}'
 
 
 # ---------------------------------------------------------------------------
 # Tools-mode workflow integration
 # ---------------------------------------------------------------------------
+
+class TestSynthesisUserQuestionLookup:
+    @pytest.mark.asyncio
+    async def test_list_content_user_messages_skipped_for_question(self):
+        # The synthetic tool-image message (and any multimodal user turn)
+        # carries a list of content blocks; the synthesis prompt lookup must
+        # skip it and use the real textual question instead. Feeding the
+        # list to the prompt provider's ``.strip()`` used to raise and be
+        # swallowed, silently dropping the configured synthesis prompt.
+        from atlas.application.chat.utilities.tool_executor import (
+            synthesize_tool_results,
+        )
+
+        class _PromptProvider:
+            def get_tool_synthesis_prompt(self, user_question):
+                return f"PROMPT[{user_question}]"
+
+        class _LlmCaller:
+            def __init__(self):
+                self.prompts_seen = []
+
+            async def call_plain(self, model, messages, user_email=None):
+                self.prompts_seen.extend(
+                    m["content"] for m in messages
+                    if m.get("role") == "system" and str(m.get("content", "")).startswith("PROMPT")
+                )
+                return "answer"
+
+        caller = _LlmCaller()
+        messages = [
+            {"role": "user", "content": "check the rocket"},
+            {"role": "tool", "content": "{}", "tool_call_id": "c1"},
+            {"role": "user", "content": [
+                {"type": "text", "text": "[Automated system note]"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ]},
+        ]
+        await synthesize_tool_results(
+            model="m", messages=messages, llm_caller=caller,
+            prompt_provider=_PromptProvider(),
+        )
+        assert caller.prompts_seen == ["PROMPT[check the rocket]"]
+
 
 class TestExecuteToolsWorkflowInjectsToolImages:
     @pytest.mark.asyncio

--- a/docs/developer/mcp-tool-outputs.md
+++ b/docs/developer/mcp-tool-outputs.md
@@ -1,6 +1,6 @@
 # MCP Tool Outputs
 
-Last updated: 2026-08-27
+Last updated: 2026-09-10
 
 This guide covers the different ways MCP tools can return data to Atlas, including text results, artifacts, images, and iframes. MCP servers are independent processes that expose functions (tools) that the LLM can call.
 
@@ -152,6 +152,39 @@ def generate_multiple_charts() -> List[ImageContent]:
 - You want to specify viewer hints or custom display configuration
 
 Both approaches work and will display images in the canvas panel. ImageContent is automatically converted to artifacts internally.
+
+### How the model sees tool-returned images (issue #909)
+
+Images returned by a tool are also placed in front of the LLM itself, not
+just the canvas. Because the OpenAI-style chat API rejects image content
+inside a `role: "tool"` message, Atlas appends a synthetic **user** message
+right after the step's tool results containing the image as an `image_url`
+data-URI block; LiteLLM translates that block to the active provider's
+native format (Anthropic image block, Gemini `inline_data`, Bedrock image).
+
+Details and limits of that pipeline:
+
+* **Vision gating.** Images are only injected when the selected model is
+  configured with `supports_vision: true` in `llmconfig.yml`. On other
+  models the tool result carries a short note telling the model an image
+  exists but cannot be shown, instead of the model silently guessing.
+* **Rolling recency cap.** At most 6 tool-returned images are kept in the
+  live transcript at once. When a new image pushes past the cap, the oldest
+  injected message is demoted in place to a one-line note; the file itself
+  remains in the session files.
+* **Size limits.** 5 MB of base64 per image, 12 MB aggregate across the
+  turn's transcript -- well under the ~20 MB total-request ceilings some
+  providers enforce.
+* **Turn lifetime.** Injected images live in the working transcript of the
+  turn that produced them only. Conversation history is text-only, so a
+  later turn sees the tool call (via the agent tool digest) and the file in
+  the session files list, but not the pixels.
+* **Validation.** MIME types are checked against a raster allowlist
+  (PNG/JPEG/GIF/WebP/BMP -- SVG is excluded) and base64 payloads are
+  re-validated and size-capped at injection time.
+
+All of this is best-effort: an injection failure degrades to the old
+text-only behavior rather than breaking the tool-calling turn.
 
 ## Displaying External Content with Iframes
 

--- a/docs/developer/mcp-tool-outputs.md
+++ b/docs/developer/mcp-tool-outputs.md
@@ -166,12 +166,15 @@ Details and limits of that pipeline:
 
 * **Vision gating.** Images are only injected when the selected model is
   configured with `supports_vision: true` in `llmconfig.yml`. On other
-  models the tool result carries a short note telling the model an image
-  exists but cannot be shown, instead of the model silently guessing.
+  models a `role: "system"` note is appended after the tool results saying
+  images were returned but cannot be shown -- the tool result JSON itself
+  is never modified.
 * **Rolling recency cap.** At most 6 tool-returned images are kept in the
-  live transcript at once. When a new image pushes past the cap, the oldest
-  injected message is demoted in place to a one-line note; the file itself
-  remains in the session files.
+  live transcript at once, newest wins: when a new image pushes past the
+  cap or the size budget, the oldest image blocks are removed (individually,
+  so one tool returning many images does not lose all of them) and a fully
+  emptied message is demoted in place to a one-line note. The files
+  themselves remain in the session files.
 * **Size limits.** 5 MB of base64 per image, 12 MB aggregate across the
   turn's transcript -- well under the ~20 MB total-request ceilings some
   providers enforce.

--- a/test/pr-validation/fixtures/pr914/harness.py
+++ b/test/pr-validation/fixtures/pr914/harness.py
@@ -1,0 +1,164 @@
+"""End-to-end harness for PR #914: tool-returned images must reach the LLM.
+
+Runs a real FastMCP server in-process whose tool returns a real ImageContent
+PNG, drives it with the real FastMCP client, and pushes the resulting
+CallToolResult through the real ATLAS tool-execution path: MCPToolManager.
+execute_tool (text normalization + artifact extraction), then the agentic
+loop's image-injection hook. Before the fix, the model-visible tool result
+was {"results": {}} and nothing else existed for the LLM; after it, the
+transcript carries a synthetic user message holding the image as an
+image_url data-URI block -- the shape providers accept after LiteLLM's
+translation.
+"""
+import asyncio
+import base64
+import io
+import json
+import sys
+from typing import Any, Dict, List
+
+from fastmcp import FastMCP
+from fastmcp.client import Client
+
+from atlas.application.chat.utilities.tool_image_context import ToolImageInjector
+from atlas.modules.mcp_tools.client import MCPToolManager
+
+
+def _png_b64() -> str:
+    """A real 8x8 PNG built with Pillow, so the payload is a genuine image."""
+    from PIL import Image
+
+    image = Image.new("RGB", (8, 8), color=(10, 120, 240))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+mcp = FastMCP("pr914-image-server")
+
+
+@mcp.tool
+def take_screenshot() -> Any:
+    """Return an ImageContent block, the shape screenshot tools return."""
+    from mcp.types import ImageContent
+
+    return ImageContent(type="image", data=_png_b64(), mimeType="image/png")
+
+
+@mcp.tool
+def text_only() -> Dict[str, Any]:
+    """Text-only control: must produce no image artifacts and no injection."""
+    return {"results": {"status": "ok"}}
+
+
+def _run_tool(raw_result: Any, tool_name: str):
+    mgr = MCPToolManager(config_path="/tmp/nonexistent_pr914_mcp.json")
+    normalized = mgr._normalize_mcp_tool_result(raw_result)
+    content = json.dumps(normalized, ensure_ascii=False, default=str)
+    artifacts, display_config, meta_data = mgr._extract_v2_components(
+        raw_result, tool_name,
+    )
+    return content, artifacts, display_config
+
+
+async def main() -> int:
+    failures: List[str] = []
+
+    async with Client(mcp) as client:
+        # 1. Image tool: the bug path. The normalized text result normalizes
+        #    to an empty results dict (prompt bloat policy), and the image
+        #    travels only as an artifact -- exactly what the LLM never saw
+        #    before this fix.
+        image_call = await client.call_tool("take_screenshot", {})
+        content, artifacts, display_config = _run_tool(
+            image_call, "take_screenshot",
+        )
+        decoded = json.loads(content)
+        if decoded.get("results") != {}:
+            failures.append(
+                f"image tool text result should normalize to {{'results': {{}}}}, "
+                f"got {decoded!r}"
+            )
+        if not artifacts or artifacts[0].get("mime") != "image/png":
+            failures.append(f"image tool should yield one png artifact, got {artifacts!r}")
+
+        # 2. Now the fix: feed the ToolResult through the injector exactly as
+        #    the agentic loop does, with vision enabled.
+        from atlas.domain.messages.models import ToolResult
+
+        tool_result = ToolResult(
+            tool_call_id="call_screenshot_1",
+            content=content,
+            success=True,
+            artifacts=artifacts,
+            display_config=display_config,
+        )
+
+        messages = [
+            {"role": "user", "content": "screenshot the model"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_screenshot_1"}]},
+            {"role": "tool", "content": content, "tool_call_id": "call_screenshot_1"},
+        ]
+        injector = ToolImageInjector(enabled=True)
+        injector.after_tool_results(
+            messages, [tool_result],
+            tool_names={"call_screenshot_1": "fusion360_fusion_mcp_read"},
+        )
+        injected = messages[-1]
+        blocks = injected.get("content")
+        if injected.get("role") != "user" or not isinstance(blocks, list):
+            failures.append(f"expected synthetic user image message, got {injected!r}")
+        else:
+            image_blocks = [
+                b for b in blocks
+                if isinstance(b, dict) and b.get("type") == "image_url"
+            ]
+            if not image_blocks:
+                failures.append("no image_url block in the injected message")
+            else:
+                url = image_blocks[0]["image_url"]["url"]
+                if not url.startswith("data:image/png;base64,"):
+                    failures.append(f"bad data URI prefix: {url[:60]!r}")
+                # The b64 in the transcript must decode to the exact PNG.
+                sent_b64 = url.split(";base64,", 1)[1]
+                if base64.b64decode(sent_b64) != base64.b64decode(_png_b64()):
+                    failures.append("transcript image bytes differ from the tool's PNG")
+                if "fusion360_fusion_mcp_read" not in blocks[0].get("text", ""):
+                    failures.append("intro text does not name the tool")
+
+        # 3. Vision disabled: no image message, but the tool result gains a
+        #    note so the model knows an image exists and why it cannot see it.
+        messages_off = [
+            {"role": "user", "content": "screenshot"},
+            {"role": "tool", "content": content, "tool_call_id": "call_screenshot_1"},
+        ]
+        ToolImageInjector(enabled=False).after_tool_results(
+            messages_off, [tool_result],
+        )
+        if len(messages_off) != 2:
+            failures.append("vision-off path must not add messages")
+        if "does not support vision" not in messages_off[-1]["content"]:
+            failures.append("vision-off path must annotate the tool result")
+
+        # 4. Text-only tool: nothing injected either way.
+        text_call = await client.call_tool("text_only", {})
+        t_content, t_artifacts, _ = _run_tool(text_call, "text_only")
+        messages_text = [{"role": "tool", "content": t_content, "tool_call_id": "t1"}]
+        ToolImageInjector(enabled=True).after_tool_results(
+            messages_text,
+            [ToolResult(tool_call_id="t1", content=t_content, artifacts=t_artifacts)],
+        )
+        if len(messages_text) != 1:
+            failures.append("text-only tool must not trigger injection")
+
+    if failures:
+        print("FAILURES:")
+        for f in failures:
+            print(" -", f)
+        return 1
+    print("All PR #914 harness checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/test/pr-validation/fixtures/pr914/harness.py
+++ b/test/pr-validation/fixtures/pr914/harness.py
@@ -126,8 +126,9 @@ async def main() -> int:
                 if "fusion360_fusion_mcp_read" not in blocks[0].get("text", ""):
                     failures.append("intro text does not name the tool")
 
-        # 3. Vision disabled: no image message, but the tool result gains a
-        #    note so the model knows an image exists and why it cannot see it.
+        # 3. Vision disabled: no image message, no edit to the tool JSON --
+        #    the note rides as a separate system message so the tool result
+        #    stays parseable.
         messages_off = [
             {"role": "user", "content": "screenshot"},
             {"role": "tool", "content": content, "tool_call_id": "call_screenshot_1"},
@@ -135,10 +136,13 @@ async def main() -> int:
         ToolImageInjector(enabled=False).after_tool_results(
             messages_off, [tool_result],
         )
-        if len(messages_off) != 2:
-            failures.append("vision-off path must not add messages")
-        if "does not support vision" not in messages_off[-1]["content"]:
-            failures.append("vision-off path must annotate the tool result")
+        if len(messages_off) != 3:
+            failures.append("vision-off path must add exactly one note message")
+        if messages_off[1]["content"] != content:
+            failures.append("vision-off path must not mutate the tool result JSON")
+        note = messages_off[-1]
+        if note.get("role") != "system" or "does not support vision" not in note.get("content", ""):
+            failures.append(f"vision-off note missing or wrong shape: {note!r}")
 
         # 4. Text-only tool: nothing injected either way.
         text_call = await client.call_tool("text_only", {})

--- a/test/pr-validation/test_pr914_tool_images_reach_llm.sh
+++ b/test/pr-validation/test_pr914_tool_images_reach_llm.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Validation script for PR #914 (issue #909): MCP tool-returned images reached
+# the frontend canvas but never the LLM. A tool whose payload is an image
+# normalized to {"results": {}} for the model -- the images lived only in
+# ToolResult.artifacts, which drive canvas display -- so the agent reported it
+# could not inspect the screenshot and kept working blind.
+#
+# Test plan (end-to-end through a real in-process FastMCP server + real
+# FastMCP client + real Atlas result normalization + the real injection
+# hook, not import checks):
+# - An ImageContent-returning tool normalizes to {"results": {}} text and
+#   one image/png artifact (the bug path, verbatim from the issue).
+# - ToolImageInjector (vision on) appends a synthetic user message holding
+#   the image as an image_url data-URI block whose bytes decode to the
+#   exact PNG the tool returned, with an intro naming the tool.
+# - ToolImageInjector (vision off) adds no messages but annotates the tool
+#   result with the "does not support vision" note.
+# - A text-only tool triggers neither injection nor a note.
+# - Backend unit tests pass.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+print_header() {
+    echo ""
+    echo "=========================================="
+    echo "$1"
+    echo "=========================================="
+}
+
+print_result() {
+    if [ "$1" -eq 0 ]; then
+        echo -e "${GREEN}PASSED${NC}: $2"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "${RED}FAILED${NC}: $2"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+if [ -f "$PROJECT_ROOT/.venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source "$PROJECT_ROOT/.venv/bin/activate"
+fi
+
+export PYTHONPATH="$PROJECT_ROOT"
+
+print_header "PR #914: tool-returned images reach the LLM transcript"
+python "$SCRIPT_DIR/fixtures/pr914/harness.py"
+print_result $? "in-process FastMCP image tool -> injection pipeline"
+
+print_header "Backend unit tests"
+"$PROJECT_ROOT/test/run_tests.sh" backend >/dev/null 2>&1
+print_result $? "test/run_tests.sh backend"
+
+echo ""
+echo "=========================================="
+echo "Results: $PASSED passed, $FAILED failed"
+echo "=========================================="
+[ "$FAILED" -eq 0 ] && [ "$PASSED" -eq 2 ]

--- a/test/pr-validation/test_pr914_tool_images_reach_llm.sh
+++ b/test/pr-validation/test_pr914_tool_images_reach_llm.sh
@@ -13,8 +13,9 @@
 # - ToolImageInjector (vision on) appends a synthetic user message holding
 #   the image as an image_url data-URI block whose bytes decode to the
 #   exact PNG the tool returned, with an intro naming the tool.
-# - ToolImageInjector (vision off) adds no messages but annotates the tool
-#   result with the "does not support vision" note.
+# - ToolImageInjector (vision off) adds one separate role:system note
+#   message and leaves the tool result JSON untouched (it must stay
+#   parseable).
 # - A text-only tool triggers neither injection nor a note.
 # - Backend unit tests pass.
 


### PR DESCRIPTION
## Summary

MCP tool-returned images reached the frontend canvas but never the LLM. A tool whose payload is an image (Fusion 360 viewport screenshot, chart render, browser-automation capture) normalized to `{"results": {}}` for the model: the images lived only in `ToolResult.artifacts`, which drive canvas display, while the `role: "tool"` message carried just the text. The agent then reported it "can't directly inspect the returned image" and kept working blind -- in the session that surfaced this, it re-ran a build script it had already run because it had no way to see the current state.

Closes #909.

## Why a synthetic user message

The OpenAI chat-completions API rejects image content inside a `role: "tool"` message, so the tool result itself cannot be widened. The portable pattern -- and what OpenAI's own guidance recommends for tool-generated images -- is to append a synthetic **user** message right after the step's tool results carrying the images as `image_url` data-URI blocks. LiteLLM translates that block shape to each provider's native format (Anthropic image block, Gemini `inline_data`, Bedrock image), and it is the exact shape `message_builder._build_multimodal_user_message` already emits for user uploads, so the provider paths are exercised in production today.

## What changed

- New `atlas/application/chat/utilities/tool_image_context.py`: `ToolImageInjector` plus pure helpers (`extract_llm_ready_images`, `build_tool_image_message`, `model_supports_vision`).
- Wired into all three tool-execution paths that append tool results for the LLM:
  - the agentic loop (`agentic_loop.py`, after each step's results),
  - tools mode's streaming continuation loop (`modes/tools.py`, before the next round / synthesis),
  - the tools-mode synthesis workflow (`tool_executor.execute_tools_workflow`, new optional `image_injector` param).

## Guards

- **Vision gating**: injection only when the model has `supports_vision: true` in `llmconfig.yml` (same config the orchestrator uses for user uploads). Non-vision models instead get a short note appended to the tool result telling the model an image exists but cannot be shown -- the observed failure was the model guessing why it could not see the screenshot.
- **Rolling recency cap**: at most 6 tool images live in the transcript; when a new one pushes past the cap the oldest injected message is demoted in place to a one-line note (ordering untouched, `role` sequence preserved).
- **Size budgets**: 5 MB base64 per image, 12 MB aggregate across the turn -- headroom under Bedrock's ~20 MB whole-request ceiling.
- **Validation at injection time**: MIME allowlist (PNG/JPEG/GIF/WebP/BMP; SVG excluded even though the canvas accepts it), base64 decode validation, per-image size cap. Structured `artifacts` entries reach this module without `mcp_result_processor`'s screening, so re-validation matters.
- **Turn lifetime**: images live in the turn's working transcript only. Conversation history is text-only and `handle_session_files` clears stale vision payloads each turn, so nothing is persisted to the conversation store and a later turn sees the tool digest + session file listing, not the pixels.
- **Fail-open**: any injection failure logs and degrades to the previous text-only behavior; the tool-calling turn is never broken.

## Testing

- New `atlas/tests/test_tool_image_context.py` (29 tests): extraction/validation (MIME allowlist, SVG exclusion, extension inference, invalid/oversized base64, newline-chunked base64, garbage input), message shape, vision gating + unseen-image note, rolling cap demotion, size-budget eviction, and end-to-end wiring through `AgenticLoop` and `execute_tools_workflow`.
- `./test/run_tests.sh backend`: 3053 passed, 17 skipped.
- `ruff check atlas/`: no new findings (pre-existing 46 on main unchanged; none in touched files).
- `bash scripts/check-docs.sh`: OK (no orphans/broken links).

Docs updated in `docs/developer/mcp-tool-outputs.md` (new "How the model sees tool-returned images" section); CHANGELOG entry added.

No frontend changes: the canvas path already worked, and injected images exist only in the server-side working transcript.

