### PR TITLE
feat(llm): retry transient LLM failures with configurable count and 5-minute backoff cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -268,6 +268,19 @@ FEATURE_FILE_CONTENT_EXTRACTION_ENABLED=false
 # MCP_RECONNECT_BACKOFF_MULTIPLIER=2.0
 
 #############################################
+# LLM Retry Settings (issue #919)
+# Transient LLM failures (rate limits, timeouts, 5xx) are retried with
+# exponential backoff on both streaming and non-streaming calls.
+#############################################
+# Number of retries AFTER the first attempt (default: 5, so up to 6 calls).
+# 0 disables retries entirely.
+# LLM_MAX_RETRIES=5
+# Cap on the CUMULATIVE time spent waiting between attempts, in seconds
+# (default: 300 = 5 minutes). The final sleep is shortened so the total
+# never exceeds this; once the budget is spent the failure surfaces.
+# LLM_RETRY_MAX_WAIT_SECONDS=300
+
+#############################################
 # MCP Timeouts
 # Timeout in seconds for MCP discovery calls - list_tools, list_prompts (default: 30)
 MCP_DISCOVERY_TIMEOUT=30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #920 - 2026-09-10
+- Transient LLM failures (rate limits, timeouts, 5xx) are now retried with exponential backoff on the streaming path (previously none) as well as the non-streaming path, with the retry count configurable via `LLM_MAX_RETRIES` (default 5) and a cumulative backoff cap via `LLM_RETRY_MAX_WAIT_SECONDS` (default 300s = 5 minutes); once a streaming response has yielded a token, failures surface instead of retrying (closes #919).
+
 ### PR #917 - 2026-09-10
 - A workspace selector now sits in the chat-bar footer next to the model/tools/prompt controls (gated on the workspaces feature). It shares the header switcher's active-workspace state, so switching context works from either control, and its panel opens upward to stay on screen above the chat bar (closes #916).
 

--- a/atlas/modules/llm/litellm_caller.py
+++ b/atlas/modules/llm/litellm_caller.py
@@ -13,7 +13,6 @@ fallbacks, cost tracking, and provider-specific optimizations.
 
 import asyncio
 import logging
-import random
 import re
 import time
 import warnings
@@ -55,6 +54,7 @@ from atlas.modules.config.config_manager import resolve_env_var
 
 from .litellm_streaming import LiteLLMStreamingMixin
 from .models import LLMResponse, split_provider
+from .retry_config import _llm_retry_settings, _retry_backoff_delay
 
 logger = logging.getLogger(__name__)
 
@@ -75,10 +75,6 @@ litellm.modify_params = True
 # probe -- until it finally fails and falls back to tiktoken anyway.  Opting out
 # skips straight to the fallback, so token counts are unchanged.
 litellm.disable_hf_tokenizer_download = True
-
-# Retry configuration for transient LLM errors
-MAX_LLM_RETRIES = 3
-RETRY_BASE_DELAY_SECONDS = 1.0
 
 # Substrings that mark a provider rejection as being about the tool payload
 # rather than the rest of the request. Only when one of these appears (and the
@@ -457,8 +453,11 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
     async def _acompletion_with_retry(self, **kwargs):
         """Call litellm.acompletion with automatic retry for transient errors.
 
-        Retries up to MAX_LLM_RETRIES times with exponential backoff and jitter.
-        Auth errors are raised immediately without retry.
+        Retries transient failures up to LLM_MAX_RETRIES times (env
+        configurable, default 5) with exponential backoff and jitter. The
+        cumulative backoff is capped at LLM_RETRY_MAX_WAIT_SECONDS (default
+        300s = 5 minutes, issue #919). Auth errors are raised immediately
+        without retry.
         """
         litellm_model = kwargs.get("model", "")
         provider, model_suffix = split_provider(litellm_model)
@@ -474,10 +473,13 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
             "message_count": len(kwargs.get("messages") or []),
         }
 
+        max_retries, max_wait = _llm_retry_settings()
         last_exc = None
         with start_span("llm.call", initial_attrs) as span:
             start_ns = time.monotonic_ns()
-            for attempt in range(MAX_LLM_RETRIES + 1):
+            attempt = 0
+            waited = 0.0
+            while attempt <= max_retries:
                 try:
                     response = await acompletion(**kwargs)
                     set_attrs(span, _llm_response_attrs(response, attempt))
@@ -487,20 +489,38 @@ class LiteLLMCaller(LiteLLMStreamingMixin):
                     return response
                 except Exception as exc:
                     last_exc = exc
-                    remaining = MAX_LLM_RETRIES - attempt
-                    if remaining > 0 and self._is_retryable_error(exc):
-                        delay = RETRY_BASE_DELAY_SECONDS * (2 ** attempt) + random.uniform(0, 0.5)
+                    if attempt < max_retries and self._is_retryable_error(exc):
+                        delay = _retry_backoff_delay(attempt, max_wait, waited)
+                        if delay is None:
+                            # Wait budget exhausted: further backoff would
+                            # exceed the configured ceiling, so surface the
+                            # failure instead of sleeping past it.
+                            logger.warning(
+                                "LLM call failed (attempt %d/%d); retry wait budget "
+                                "(%.0fs) exhausted, giving up: %s",
+                                attempt + 1, max_retries + 1, max_wait, exc,
+                            )
+                            set_attrs(span, {
+                                "retry_count": attempt,
+                                "retry_wait_seconds": waited,
+                                "latency_ms": (time.monotonic_ns() - start_ns) // 1_000_000,
+                                "error_type": type(exc).__name__,
+                            })
+                            raise
                         logger.warning(
                             "LLM call failed (attempt %d/%d), retrying in %.1fs: %s",
                             attempt + 1,
-                            MAX_LLM_RETRIES + 1,
+                            max_retries + 1,
                             delay,
                             exc,
                         )
+                        attempt += 1
+                        waited += delay
                         await asyncio.sleep(delay)
                     else:
                         set_attrs(span, {
                             "retry_count": attempt,
+                            "retry_wait_seconds": waited,
                             "latency_ms": (time.monotonic_ns() - start_ns) // 1_000_000,
                             "error_type": type(exc).__name__,
                         })

--- a/atlas/modules/llm/litellm_streaming.py
+++ b/atlas/modules/llm/litellm_streaming.py
@@ -19,6 +19,7 @@ from atlas.core.telemetry import set_attrs, start_span
 from atlas.domain.errors import LLMMalformedToolCallError
 
 from .models import LLMResponse, split_provider
+from .retry_config import _llm_retry_settings, _retry_backoff_delay
 from .tool_call_guard import (
     partition_tool_calls_by_json_validity,
     tool_call_function_field,
@@ -33,6 +34,30 @@ KNOWN_FINISH_REASONS = frozenset(
 )
 
 
+async def _close_stream_quietly(response: Any) -> None:
+    """Best-effort close of an abandoned stream so its HTTP connection is freed.
+
+    Called before a retry: the failed attempt's stream is discarded, and an
+    unclosed response would hold its connection until garbage collection.
+    Every failure here is swallowed -- the retry must not be blocked by a
+    cleanup problem.
+    """
+    try:
+        aclose = getattr(response, "aclose", None)
+        if aclose is not None:
+            result = aclose()
+            if asyncio.iscoroutine(result):
+                await result
+            return
+        close = getattr(response, "close", None)
+        if close is not None:
+            result = close()
+            if asyncio.iscoroutine(result):
+                await result
+    except Exception:
+        logger.debug("Failed to close abandoned LLM stream", exc_info=True)
+
+
 class LiteLLMStreamingMixin:
     """Mixin providing streaming LLM methods for LiteLLMCaller.
 
@@ -40,6 +65,7 @@ class LiteLLMStreamingMixin:
       - _get_litellm_model_name(model_name) -> str
       - _get_model_kwargs(model_name, temperature, user_email) -> dict
       - _prepare_messages(model_name, messages) -> list
+      - _is_retryable_error(exc) -> bool (retry policy for stream failures)
       - _query_all_rag_sources(data_sources, rag_service, user_email, messages) -> (successful, exclusions, failures)
       - _build_rag_completion_response(rag_response, display_source) -> str
       - _build_rag_exclusion_notice(exclusions) -> str
@@ -91,60 +117,102 @@ class LiteLLMStreamingMixin:
 
         with start_span("llm.call", span_attrs) as span:
             start_ns = time.monotonic_ns()
+            max_retries, max_wait = _llm_retry_settings()
+            attempt = 0
+            waited = 0.0
             try:
                 total_chars = sum(len(str(msg.get('content', ''))) for msg in messages)
                 logger.info("Streaming plain LLM call: %d messages, %d chars", len(messages), total_chars)
 
-                response = await acompletion(
-                    model=litellm_model,
-                    messages=self._prepare_messages(model_name, messages),
-                    stream=True,
-                    **model_kwargs,
-                )
-
                 chunk_count = 0
                 total_chunks_seen = 0
                 accumulated_chars = 0
-                async for chunk in response:
-                    total_chunks_seen += 1
-                    delta = chunk.choices[0].delta if chunk.choices else None
-                    if total_chunks_seen <= 3:
-                        logger.debug(
-                            "Stream chunk #%d for %s: choices=%s, delta=%s, content_len=%s",
-                            total_chunks_seen, model_name,
-                            bool(chunk.choices), type(delta).__name__ if delta else None,
-                            len(delta.content) if delta and delta.content else 0,
+                # A token handed to the consumer cannot be un-handed: once any
+                # content has been yielded, the turn is partially delivered and
+                # the only safe reaction to a later failure is to surface it,
+                # not to restart the stream and duplicate what was already sent.
+                yielded_any = False
+                while True:
+                    response = None
+                    try:
+                        response = await acompletion(
+                            model=litellm_model,
+                            messages=self._prepare_messages(model_name, messages),
+                            stream=True,
+                            **model_kwargs,
                         )
-                    if delta and delta.content:
-                        yield delta.content
-                        chunk_count += 1
-                        accumulated_chars += len(delta.content)
-                        # Yield control periodically to prevent backpressure buildup
-                        if chunk_count % 50 == 0:
-                            await asyncio.sleep(0)
 
-                if chunk_count == 0 and total_chunks_seen > 0:
-                    logger.warning(
-                        "Stream for %s received %d chunks but yielded 0 tokens",
-                        model_name, total_chunks_seen,
-                    )
-                log_metric("llm_call", user_email, model=model_name, message_count=len(messages))
-                set_attrs(span, {
-                    "latency_ms": (time.monotonic_ns() - start_ns) // 1_000_000,
-                    "chunk_count": chunk_count,
-                    "output_chars": accumulated_chars,
-                    # Streaming LLM calls don't carry usage metadata; publish a
-                    # char-based estimate under a distinct name so downstream
-                    # aggregations never silently mix real token counts with
-                    # approximations.
-                    "output_tokens_estimate": accumulated_chars // 4,
-                    "retry_count": 0,
-                })
+                        async for chunk in response:
+                            total_chunks_seen += 1
+                            delta = chunk.choices[0].delta if chunk.choices else None
+                            if total_chunks_seen <= 3:
+                                logger.debug(
+                                    "Stream chunk #%d for %s: choices=%s, delta=%s, content_len=%s",
+                                    total_chunks_seen, model_name,
+                                    bool(chunk.choices), type(delta).__name__ if delta else None,
+                                    len(delta.content) if delta and delta.content else 0,
+                                )
+                            if delta and delta.content:
+                                yielded_any = True
+                                yield delta.content
+                                chunk_count += 1
+                                accumulated_chars += len(delta.content)
+                                # Yield control periodically to prevent backpressure buildup
+                                if chunk_count % 50 == 0:
+                                    await asyncio.sleep(0)
+
+                        if chunk_count == 0 and total_chunks_seen > 0:
+                            logger.warning(
+                                "Stream for %s received %d chunks but yielded 0 tokens",
+                                model_name, total_chunks_seen,
+                            )
+                        log_metric("llm_call", user_email, model=model_name, message_count=len(messages))
+                        set_attrs(span, {
+                            "latency_ms": (time.monotonic_ns() - start_ns) // 1_000_000,
+                            "chunk_count": chunk_count,
+                            "output_chars": accumulated_chars,
+                            # Streaming LLM calls don't carry usage metadata; publish a
+                            # char-based estimate under a distinct name so downstream
+                            # aggregations never silently mix real token counts with
+                            # approximations.
+                            "output_tokens_estimate": accumulated_chars // 4,
+                            "retry_count": attempt,
+                            "retry_wait_seconds": waited,
+                        })
+                        break
+
+                    except Exception as exc:
+                        if response is not None:
+                            await _close_stream_quietly(response)
+                        if (
+                            yielded_any
+                            or attempt >= max_retries
+                            or not self._is_retryable_error(exc)
+                        ):
+                            raise
+                        delay = _retry_backoff_delay(attempt, max_wait, waited)
+                        if delay is None:
+                            logger.warning(
+                                "Streaming LLM call failed (attempt %d/%d); retry wait budget "
+                                "(%.0fs) exhausted, giving up: %s",
+                                attempt + 1, max_retries + 1, max_wait, exc,
+                            )
+                            raise
+                        logger.warning(
+                            "Streaming LLM call failed before any token (attempt %d/%d), "
+                            "retrying in %.1fs: %s",
+                            attempt + 1, max_retries + 1, delay, exc,
+                        )
+                        attempt += 1
+                        waited += delay
+                        await asyncio.sleep(delay)
 
             except Exception as exc:
                 set_attrs(span, {
                     "latency_ms": (time.monotonic_ns() - start_ns) // 1_000_000,
                     "error_type": type(exc).__name__,
+                    "retry_count": attempt,
+                    "retry_wait_seconds": waited,
                 })
                 logger.error("Error in streaming LLM call: %s", exc, exc_info=True)
                 self._raise_llm_domain_error(exc)
@@ -304,6 +372,9 @@ class LiteLLMStreamingMixin:
 
         with start_span("llm.call", span_attrs) as span:
             start_ns = time.monotonic_ns()
+            max_retries, max_wait = _llm_retry_settings()
+            attempt = 0
+            waited = 0.0
             try:
                 total_chars = sum(len(str(msg.get('content', ''))) for msg in messages)
                 logger.info(
@@ -311,58 +382,103 @@ class LiteLLMStreamingMixin:
                     len(messages), total_chars, len(tools_schema),
                 )
 
-                response = await acompletion(
-                    model=litellm_model,
-                    messages=self._prepare_messages(model_name, messages),
-                    tools=tools_schema,
-                    tool_choice=tool_choice,
-                    stream=True,
-                    **model_kwargs,
-                )
-
                 accumulated_content = ""
                 accumulated_tool_calls: Dict[int, Dict[str, Any]] = {}
                 chunk_count = 0
                 finish_reason: Optional[str] = None
+                # Text tokens are yielded as they arrive, so the same rule as
+                # stream_plain applies: after the first yielded token a failure
+                # must surface, not retry -- restarting would duplicate the
+                # partial answer the user already sees. Tool-call fragments
+                # alone are still retryable: they stay inside this generator
+                # until the final LLMResponse, so nothing has been delivered.
+                yielded_any = False
+                while True:
+                    response = None
+                    try:
+                        response = await acompletion(
+                            model=litellm_model,
+                            messages=self._prepare_messages(model_name, messages),
+                            tools=tools_schema,
+                            tool_choice=tool_choice,
+                            stream=True,
+                            **model_kwargs,
+                        )
 
-                async for chunk in response:
-                    choice = chunk.choices[0] if chunk.choices else None
-                    if choice is not None:
-                        # Providers send the reason on the final chunk; keep the
-                        # last non-empty one so a truncated turn ("length") can
-                        # be told apart from a model that simply emitted bad JSON.
-                        finish_reason = getattr(choice, "finish_reason", None) or finish_reason
-                    delta = choice.delta if choice is not None else None
-                    if not delta:
-                        continue
+                        async for chunk in response:
+                            choice = chunk.choices[0] if chunk.choices else None
+                            if choice is not None:
+                                # Providers send the reason on the final chunk; keep the
+                                # last non-empty one so a truncated turn ("length") can
+                                # be told apart from a model that simply emitted bad JSON.
+                                finish_reason = getattr(choice, "finish_reason", None) or finish_reason
+                            delta = choice.delta if choice is not None else None
+                            if not delta:
+                                continue
 
-                    # Yield text content as it arrives
-                    if delta.content:
-                        accumulated_content += delta.content
-                        yield delta.content
-                        chunk_count += 1
-                        # Yield control periodically to prevent backpressure buildup
-                        if chunk_count % 50 == 0:
-                            await asyncio.sleep(0)
+                            # Yield text content as it arrives
+                            if delta.content:
+                                yielded_any = True
+                                accumulated_content += delta.content
+                                yield delta.content
+                                chunk_count += 1
+                                # Yield control periodically to prevent backpressure buildup
+                                if chunk_count % 50 == 0:
+                                    await asyncio.sleep(0)
 
-                    # Accumulate tool call fragments
-                    if hasattr(delta, "tool_calls") and delta.tool_calls:
-                        for tc_delta in delta.tool_calls:
-                            idx = tc_delta.index if hasattr(tc_delta, "index") else 0
-                            if idx not in accumulated_tool_calls:
-                                accumulated_tool_calls[idx] = {
-                                    "id": getattr(tc_delta, "id", None) or "",
-                                    "type": "function",
-                                    "function": {"name": "", "arguments": ""},
-                                }
-                            entry = accumulated_tool_calls[idx]
-                            if hasattr(tc_delta, "id") and tc_delta.id:
-                                entry["id"] = tc_delta.id
-                            if hasattr(tc_delta, "function") and tc_delta.function:
-                                if hasattr(tc_delta.function, "name") and tc_delta.function.name:
-                                    entry["function"]["name"] += tc_delta.function.name
-                                if hasattr(tc_delta.function, "arguments") and tc_delta.function.arguments:
-                                    entry["function"]["arguments"] += tc_delta.function.arguments
+                            # Accumulate tool call fragments
+                            if hasattr(delta, "tool_calls") and delta.tool_calls:
+                                for tc_delta in delta.tool_calls:
+                                    idx = tc_delta.index if hasattr(tc_delta, "index") else 0
+                                    if idx not in accumulated_tool_calls:
+                                        accumulated_tool_calls[idx] = {
+                                            "id": getattr(tc_delta, "id", None) or "",
+                                            "type": "function",
+                                            "function": {"name": "", "arguments": ""},
+                                        }
+                                    entry = accumulated_tool_calls[idx]
+                                    if hasattr(tc_delta, "id") and tc_delta.id:
+                                        entry["id"] = tc_delta.id
+                                    if hasattr(tc_delta, "function") and tc_delta.function:
+                                        if hasattr(tc_delta.function, "name") and tc_delta.function.name:
+                                            entry["function"]["name"] += tc_delta.function.name
+                                        if hasattr(tc_delta.function, "arguments") and tc_delta.function.arguments:
+                                            entry["function"]["arguments"] += tc_delta.function.arguments
+
+                        break
+
+                    except Exception as exc:
+                        if response is not None:
+                            await _close_stream_quietly(response)
+                        if (
+                            yielded_any
+                            or attempt >= max_retries
+                            or not self._is_retryable_error(exc)
+                        ):
+                            raise
+                        delay = _retry_backoff_delay(attempt, max_wait, waited)
+                        if delay is None:
+                            logger.warning(
+                                "Streaming LLM call with tools failed (attempt %d/%d); "
+                                "retry wait budget (%.0fs) exhausted, giving up: %s",
+                                attempt + 1, max_retries + 1, max_wait, exc,
+                            )
+                            raise
+                        logger.warning(
+                            "Streaming LLM call with tools failed before any token "
+                            "(attempt %d/%d), retrying in %.1fs: %s",
+                            attempt + 1, max_retries + 1, delay, exc,
+                        )
+                        # Fresh attempt: throw away any half-accumulated
+                        # fragments so a retried stream cannot mix chunks from
+                        # two different provider responses.
+                        accumulated_content = ""
+                        accumulated_tool_calls = {}
+                        chunk_count = 0
+                        finish_reason = None
+                        attempt += 1
+                        waited += delay
+                        await asyncio.sleep(delay)
 
                 # Build final tool_calls list using litellm's own response type
                 # rather than SimpleNamespace. The objects are appended verbatim
@@ -414,7 +530,8 @@ class LiteLLMStreamingMixin:
                     "output_chars": len(accumulated_content),
                     "output_tokens_estimate": len(accumulated_content) // 4,
                     "tool_calls_count": len(tool_calls_list) if tool_calls_list else 0,
-                    "retry_count": 0,
+                    "retry_count": attempt,
+                    "retry_wait_seconds": waited,
                 })
 
                 # Opt-in fine-tune capture: record full I/O for this call when a
@@ -434,6 +551,8 @@ class LiteLLMStreamingMixin:
                 set_attrs(span, {
                     "latency_ms": (time.monotonic_ns() - start_ns) // 1_000_000,
                     "error_type": type(exc).__name__,
+                    "retry_count": attempt,
+                    "retry_wait_seconds": waited,
                 })
                 logger.error("Error in streaming LLM call with tools: %s", exc, exc_info=True)
                 self._raise_llm_domain_error(exc, tools_schema=tools_schema)

--- a/atlas/modules/llm/retry_config.py
+++ b/atlas/modules/llm/retry_config.py
@@ -1,0 +1,72 @@
+"""Retry policy for transient LLM failures (issue #919).
+
+Shared by the non-streaming caller (``litellm_caller._acompletion_with_retry``)
+and the streaming generators (``litellm_streaming``), which cannot import from
+``litellm_caller`` because that module imports the streaming mixin.
+
+The number of retries and the total backoff budget come from the environment
+(``.env``) so operators can tune them without a code change:
+
+- ``LLM_MAX_RETRIES``: retries *after the first attempt* (default 5, so up to
+  6 calls). ``0`` disables retries entirely.
+- ``LLM_RETRY_MAX_WAIT_SECONDS``: cap on the *cumulative* time spent asleep
+  between attempts (default 300s = 5 minutes). Matters when the retry count
+  is raised: without a cap, attempt 9 alone would wait 4+ minutes.
+
+Delays use exponential backoff (base 1s, doubling per attempt) with up to
+0.5s of jitter to avoid synchronized retry storms across concurrent users.
+"""
+
+import logging
+import os
+import random
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LLM_RETRIES = 5
+DEFAULT_LLM_RETRY_MAX_WAIT_SECONDS = 300.0
+RETRY_BASE_DELAY_SECONDS = 1.0
+
+
+def _llm_retry_settings() -> Tuple[int, float]:
+    """Resolve (max_retries, max_wait_seconds) from the environment.
+
+    Read at call time so a `.env` change plus restart takes effect without a
+    code edit, and so tests can set the variables per-test. A non-numeric
+    value falls back to the default; a negative value is clamped to 0 rather
+    than silently reinterpreted.
+    """
+    try:
+        max_retries = int(os.environ.get("LLM_MAX_RETRIES", DEFAULT_LLM_RETRIES))
+    except (TypeError, ValueError):
+        logger.warning(
+            "LLM_MAX_RETRIES=%r is not an integer; using default %d",
+            os.environ.get("LLM_MAX_RETRIES"), DEFAULT_LLM_RETRIES,
+        )
+        max_retries = DEFAULT_LLM_RETRIES
+    try:
+        max_wait = float(
+            os.environ.get("LLM_RETRY_MAX_WAIT_SECONDS", DEFAULT_LLM_RETRY_MAX_WAIT_SECONDS)
+        )
+    except (TypeError, ValueError):
+        logger.warning(
+            "LLM_RETRY_MAX_WAIT_SECONDS=%r is not a number; using default %.0f",
+            os.environ.get("LLM_RETRY_MAX_WAIT_SECONDS"),
+            DEFAULT_LLM_RETRY_MAX_WAIT_SECONDS,
+        )
+        max_wait = DEFAULT_LLM_RETRY_MAX_WAIT_SECONDS
+    return max(0, max_retries), max(0.0, max_wait)
+
+
+def _retry_backoff_delay(attempt: int, max_wait: float, waited: float) -> Optional[float]:
+    """Next exponential-backoff delay, clamped to the remaining wait budget.
+
+    Returns ``None`` once the cumulative wait has reached ``max_wait`` -- the
+    caller must then give up instead of sleeping.
+    """
+    remaining = max_wait - waited
+    if remaining <= 0:
+        return None
+    raw = RETRY_BASE_DELAY_SECONDS * (2 ** attempt) + random.uniform(0, 0.5)
+    return min(raw, remaining)

--- a/atlas/tests/mocks/mock_flaky_llm.py
+++ b/atlas/tests/mocks/mock_flaky_llm.py
@@ -52,7 +52,8 @@ class AlwaysFailLLMResponse:
 
     Args:
         exception: The exception instance to raise on every call.
-        count: How many calls to prepare for (should be >= MAX_LLM_RETRIES + 1).
+        count: How many calls to prepare for (should be >= the configured
+            retry count + 1, i.e. 6 by default).
     """
 
     def __init__(self, exception: Optional[Exception] = None, count: int = 10):

--- a/atlas/tests/test_llm_retry.py
+++ b/atlas/tests/test_llm_retry.py
@@ -1,10 +1,14 @@
-"""Tests for LLM auto-retry with exponential backoff.
+"""Tests for LLM auto-retry with exponential backoff (issue #919).
 
 Verifies that transient errors (rate limit, timeout, service errors) are
-retried up to MAX_LLM_RETRIES times, while non-retryable errors (auth)
-are raised immediately.
+retried up to the configured retry count (LLM_MAX_RETRIES env, default 5)
+while non-retryable errors (auth) are raised immediately, that the cumulative
+backoff is capped at LLM_RETRY_MAX_WAIT_SECONDS (default 300s = 5 minutes),
+and that the streaming generators follow the same policy until the first
+token reaches the consumer.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import litellm
@@ -17,15 +21,26 @@ from atlas.domain.errors import (
 )
 from atlas.modules.config.config_manager import config_manager
 from atlas.modules.llm import litellm_caller as caller_module
-from atlas.modules.llm.litellm_caller import (
-    MAX_LLM_RETRIES,
-    LiteLLMCaller,
+from atlas.modules.llm import litellm_streaming as streaming_module
+from atlas.modules.llm.litellm_caller import LiteLLMCaller
+from atlas.modules.llm.models import LLMResponse
+from atlas.modules.llm.retry_config import (
+    DEFAULT_LLM_RETRIES,
+    DEFAULT_LLM_RETRY_MAX_WAIT_SECONDS,
 )
 from atlas.tests.mocks.mock_flaky_llm import (
     AlwaysFailLLMResponse,
     FlakyLLMResponse,
     make_llm_response,
 )
+
+
+@pytest.fixture(autouse=True)
+def _default_retry_env(monkeypatch):
+    """Pin retry env vars to their defaults so ambient shell settings cannot
+    skew call-count expectations; individual tests override from here."""
+    monkeypatch.setenv("LLM_MAX_RETRIES", str(DEFAULT_LLM_RETRIES))
+    monkeypatch.setenv("LLM_RETRY_MAX_WAIT_SECONDS", str(DEFAULT_LLM_RETRY_MAX_WAIT_SECONDS))
 
 
 @pytest.fixture
@@ -122,8 +137,8 @@ class TestAcompletionWithRetry:
             with pytest.raises(litellm.RateLimitError):
                 await caller._acompletion_with_retry(model="test", messages=[])
 
-        assert mock_acompletion.call_count == MAX_LLM_RETRIES + 1
-        assert mock_sleep.call_count == MAX_LLM_RETRIES
+        assert mock_acompletion.call_count == DEFAULT_LLM_RETRIES + 1
+        assert mock_sleep.call_count == DEFAULT_LLM_RETRIES
 
     @pytest.mark.asyncio
     @patch("asyncio.sleep", new_callable=AsyncMock)
@@ -192,6 +207,97 @@ class TestAcompletionWithRetry:
 
         assert mock_acompletion.call_count == 1
         assert mock_sleep.call_count == 0
+
+
+class TestLlmRetrySettings:
+    """Test env resolution for the retry count and wait budget."""
+
+    def test_defaults_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LLM_MAX_RETRIES", raising=False)
+        monkeypatch.delenv("LLM_RETRY_MAX_WAIT_SECONDS", raising=False)
+        from atlas.modules.llm.retry_config import _llm_retry_settings
+        assert _llm_retry_settings() == (5, 300.0)
+
+    def test_env_overrides_both_values(self, monkeypatch):
+        monkeypatch.setenv("LLM_MAX_RETRIES", "2")
+        monkeypatch.setenv("LLM_RETRY_MAX_WAIT_SECONDS", "45")
+        from atlas.modules.llm.retry_config import _llm_retry_settings
+        assert _llm_retry_settings() == (2, 45.0)
+
+    def test_invalid_values_fall_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("LLM_MAX_RETRIES", "five")
+        monkeypatch.setenv("LLM_RETRY_MAX_WAIT_SECONDS", "soon")
+        from atlas.modules.llm.retry_config import _llm_retry_settings
+        assert _llm_retry_settings() == (5, 300.0)
+
+    def test_negative_values_clamped_to_zero(self, monkeypatch):
+        monkeypatch.setenv("LLM_MAX_RETRIES", "-3")
+        monkeypatch.setenv("LLM_RETRY_MAX_WAIT_SECONDS", "-10")
+        from atlas.modules.llm.retry_config import _llm_retry_settings
+        assert _llm_retry_settings() == (0, 0.0)
+
+
+class TestRetryCountEnvOverride:
+    """The retry count must follow LLM_MAX_RETRIES from the environment."""
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_env_reduces_retry_count(self, mock_sleep, caller, monkeypatch):
+        monkeypatch.setenv("LLM_MAX_RETRIES", "1")
+        always_fail = AlwaysFailLLMResponse(exception=_rate_limit_exc())
+        mock_acompletion = AsyncMock(side_effect=always_fail.side_effect_list())
+
+        with patch.object(caller_module, "acompletion", mock_acompletion):
+            with pytest.raises(litellm.RateLimitError):
+                await caller._acompletion_with_retry(model="test", messages=[])
+
+        assert mock_acompletion.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_zero_retries_makes_single_call(self, mock_sleep, caller, monkeypatch):
+        monkeypatch.setenv("LLM_MAX_RETRIES", "0")
+        mock_acompletion = AsyncMock(side_effect=_rate_limit_exc())
+
+        with patch.object(caller_module, "acompletion", mock_acompletion):
+            with pytest.raises(litellm.RateLimitError):
+                await caller._acompletion_with_retry(model="test", messages=[])
+
+        assert mock_acompletion.call_count == 1
+        assert mock_sleep.call_count == 0
+
+
+class TestRetryWaitBudget:
+    """The cumulative backoff must never exceed LLM_RETRY_MAX_WAIT_SECONDS."""
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_cumulative_backoff_never_exceeds_cap(self, mock_sleep, caller, monkeypatch):
+        monkeypatch.setenv("LLM_RETRY_MAX_WAIT_SECONDS", "1.2")
+        always_fail = AlwaysFailLLMResponse(exception=_rate_limit_exc())
+        mock_acompletion = AsyncMock(side_effect=always_fail.side_effect_list())
+
+        with patch.object(caller_module, "acompletion", mock_acompletion):
+            with pytest.raises(litellm.RateLimitError):
+                await caller._acompletion_with_retry(model="test", messages=[])
+
+        delays = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sum(delays) <= 1.2 + 1e-9
+        # The budget forces an early stop long before the default 5 retries.
+        assert len(delays) < DEFAULT_LLM_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_zero_wait_budget_disables_backoff(self, caller, monkeypatch):
+        """With no wait budget the first transient failure raises immediately."""
+        monkeypatch.setenv("LLM_RETRY_MAX_WAIT_SECONDS", "0")
+        mock_acompletion = AsyncMock(side_effect=_rate_limit_exc())
+
+        with patch.object(caller_module, "acompletion", mock_acompletion):
+            with pytest.raises(litellm.RateLimitError):
+                await caller._acompletion_with_retry(model="test", messages=[])
+
+        assert mock_acompletion.call_count == 1
 
 
 class TestCallPlainWithRetry:
@@ -273,7 +379,7 @@ class TestCallWithToolsRetry:
                     "test-model", [{"role": "user", "content": "hi"}], tools_schema,
                 )
 
-        assert mock_acompletion.call_count == MAX_LLM_RETRIES + 1
+        assert mock_acompletion.call_count == DEFAULT_LLM_RETRIES + 1
 
 
 class TestRagFallbackDoesNotMaskLLMErrors:
@@ -317,4 +423,156 @@ class TestRagFallbackDoesNotMaskLLMErrors:
                     "test", [{"role": "user", "content": "hi"}],
                     data_sources=["src"], user_email=config_manager.app_settings.test_user,
                 )
+
+
+def _stream_chunk(content):
+    """Build a minimal streaming chunk matching litellm's shape."""
+    delta = SimpleNamespace(content=content)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+class _FakeStream:
+    """Async-iterable stand-in for litellm's streaming response.
+
+    Yields the given text contents, then raises ``error`` if one is set,
+    otherwise stops.
+    """
+
+    def __init__(self, contents, error=None):
+        self._contents = list(contents)
+        self._error = error
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._contents:
+            return _stream_chunk(self._contents.pop(0))
+        if self._error is not None:
+            raise self._error
+        raise StopAsyncIteration
+
+    async def aclose(self):
+        self.closed = True
+
+
+class TestStreamingRetry:
+    """stream_plain / stream_with_tools follow the same retry policy.
+
+    Retry is only allowed while nothing has been yielded: a token already
+    handed to the consumer cannot be taken back, so a retry would duplicate
+    part of the answer.
+    """
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_stream_plain_retries_rate_limit_before_first_token(self, mock_sleep, caller):
+        """A rate limit at stream establishment is retried, then tokens flow."""
+        success = _FakeStream(["Hello", " ", "world"])
+        mock_acompletion = AsyncMock(side_effect=[_rate_limit_exc(), success])
+
+        with (
+            patch.object(streaming_module, "acompletion", mock_acompletion),
+            patch.object(caller, "_get_litellm_model_name", return_value="test-model"),
+            patch.object(caller, "_get_model_kwargs", return_value={}),
+        ):
+            tokens = [
+                t async for t in caller.stream_plain(
+                    "test-model", [{"role": "user", "content": "hi"}],
+                )
+            ]
+
+        assert tokens == ["Hello", " ", "world"]
+        assert mock_acompletion.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_plain_no_retry_after_first_token(self, caller):
+        """A mid-stream failure after a yielded token must surface, not retry."""
+        failing = _FakeStream(["partial"], error=_rate_limit_exc())
+        mock_acompletion = AsyncMock(return_value=failing)
+
+        with (
+            patch.object(streaming_module, "acompletion", mock_acompletion),
+            patch.object(caller, "_get_litellm_model_name", return_value="test-model"),
+            patch.object(caller, "_get_model_kwargs", return_value={}),
+        ):
+            collected = []
+            with pytest.raises(RateLimitError):
+                async for token in caller.stream_plain(
+                    "test-model", [{"role": "user", "content": "hi"}],
+                ):
+                    collected.append(token)
+
+        assert collected == ["partial"]
+        assert mock_acompletion.call_count == 1
+        assert failing.closed is True
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_stream_plain_exhausts_retries(self, mock_sleep, caller, monkeypatch):
+        """With LLM_MAX_RETRIES=1, two attempts then the domain error."""
+        monkeypatch.setenv("LLM_MAX_RETRIES", "1")
+        always_fail = AlwaysFailLLMResponse(exception=_rate_limit_exc())
+        mock_acompletion = AsyncMock(side_effect=always_fail.side_effect_list())
+
+        with (
+            patch.object(streaming_module, "acompletion", mock_acompletion),
+            patch.object(caller, "_get_litellm_model_name", return_value="test-model"),
+            patch.object(caller, "_get_model_kwargs", return_value={}),
+        ):
+            with pytest.raises(RateLimitError):
+                async for _ in caller.stream_plain(
+                    "test-model", [{"role": "user", "content": "hi"}],
+                ):
+                    pass
+
+        assert mock_acompletion.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("asyncio.sleep", new_callable=AsyncMock)
+    async def test_stream_with_tools_retries_before_any_yield(self, mock_sleep, caller):
+        """Tool streams retry on transient failure before any text is yielded."""
+        success = _FakeStream(["tok"])
+        mock_acompletion = AsyncMock(side_effect=[_rate_limit_exc(), success])
+        tools_schema = [{"type": "function", "function": {"name": "test_tool"}}]
+
+        with (
+            patch.object(streaming_module, "acompletion", mock_acompletion),
+            patch.object(caller, "_get_litellm_model_name", return_value="test-model"),
+            patch.object(caller, "_get_model_kwargs", return_value={}),
+        ):
+            items = [
+                item async for item in caller.stream_with_tools(
+                    "test-model", [{"role": "user", "content": "hi"}], tools_schema,
+                )
+            ]
+
+        assert items[0] == "tok"
+        assert isinstance(items[-1], LLMResponse)
+        assert items[-1].content == "tok"
+        assert mock_acompletion.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_with_tools_no_retry_after_text(self, caller):
+        """Once text streamed to the user, a later failure is not retried."""
+        failing = _FakeStream(["partial"], error=_rate_limit_exc())
+        mock_acompletion = AsyncMock(return_value=failing)
+        tools_schema = [{"type": "function", "function": {"name": "test_tool"}}]
+
+        with (
+            patch.object(streaming_module, "acompletion", mock_acompletion),
+            patch.object(caller, "_get_litellm_model_name", return_value="test-model"),
+            patch.object(caller, "_get_model_kwargs", return_value={}),
+        ):
+            collected = []
+            with pytest.raises(RateLimitError):
+                async for item in caller.stream_with_tools(
+                    "test-model", [{"role": "user", "content": "hi"}], tools_schema,
+                ):
+                    collected.append(item)
+
+        assert collected == ["partial"]
+        assert mock_acompletion.call_count == 1
 

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -105,6 +105,35 @@ AGENT_SLEEP_MAX_TURN_SECONDS=7200
 - **Deploys**: a turn parked in a long sleep delays graceful shutdown; expect such turns to be
   killed by a rolling restart.
 
+### LLM Retry on Transient Failures
+
+High-traffic LLM services can reject calls with rate-limit (429), timeout, or server (5xx) errors.
+Atlas retries those transient failures automatically with exponential backoff (1s base, doubling
+per attempt, up to 0.5s of jitter) on both streaming and non-streaming calls (issue #919).
+Deterministic failures -- rejected requests (400), authentication errors, and context-window
+overflows -- are never retried.
+
+```bash
+# Number of retries AFTER the first attempt (default: 5, so up to 6 calls).
+# 0 disables retries entirely.
+LLM_MAX_RETRIES=5
+
+# Cap on the CUMULATIVE time spent waiting between attempts, in seconds
+# (default: 300 = 5 minutes). The final sleep is shortened so the total never
+# exceeds this; once the budget is spent, the underlying error surfaces.
+LLM_RETRY_MAX_WAIT_SECONDS=300
+```
+
+- **Scope**: retries cover the streaming path (the main chat flow) and plain/RAG/tools calls. Once
+  a streaming response has already yielded a token to the user, a later failure is reported
+  instead of retried -- restarting the stream would duplicate the partial answer.
+- **User experience**: during backoff the chat shows nothing for that turn, then either the answer
+  begins normally or the usual error message arrives. The maximum user-visible wait per LLM call is
+  therefore roughly `LLM_RETRY_MAX_WAIT_SECONDS` plus the provider latency of each attempt; with
+  the defaults and a 1s base delay, five retries wait about 31s in total, well under the cap.
+- **Reverse proxies**: same consideration as `atlas_sleep` above -- a turn waiting out a backoff
+  sends nothing over its WebSocket; keep proxy idle timeouts longer than the cap you configure.
+
 ## System Prompt Time Injection (issue #823)
 
 The current date/time is appended to the rendered system prompt on every turn so the model

--- a/docs/developer/error-flow-diagram.md
+++ b/docs/developer/error-flow-diagram.md
@@ -1,6 +1,6 @@
 # Error Flow Diagram
 
-Last updated: 2026-07-24
+Last updated: 2026-09-10
 
 ## Complete Error Handling Flow
 
@@ -196,8 +196,8 @@ Three ordering constraints matter here:
 
 `_is_retryable_error()` returns `False` for `BadRequestError` before its
 transient-keyword tests, for the same reason: a 400 is deterministic, and one
-that happens to contain `timeout` would otherwise be retried three times with
-backoff before failing.
+that happens to contain `timeout` would otherwise be retried up to
+`LLM_MAX_RETRIES` times (default 5, issue #919) with backoff before failing.
 
 `call_with_rag()` falls back to a simpler call when RAG breaks, so its
 passthrough tuple catches `LLMError` — a provider rejection is not a RAG

--- a/docs/developer/error-handling-improvements.md
+++ b/docs/developer/error-handling-improvements.md
@@ -85,7 +85,7 @@ The timeout is cleared whenever `isThinking` becomes false (normal completion or
 
 ### 8. Auto-Retry for Transient LLM Errors (2026-03-10)
 
-`LiteLLMCaller._acompletion_with_retry()` wraps litellm `acompletion` calls with automatic retry and exponential backoff. Transient errors (rate limit, timeout, 5xx server errors) are retried up to `MAX_LLM_RETRIES` (3) times. Auth errors and other non-transient errors raise immediately without retry.
+`LiteLLMCaller._acompletion_with_retry()` wraps litellm `acompletion` calls with automatic retry and exponential backoff. Transient errors (rate limit, timeout, 5xx server errors) are retried up to `LLM_MAX_RETRIES` (default 5) times, with the cumulative backoff capped at `LLM_RETRY_MAX_WAIT_SECONDS` (default 300s = 5 minutes) -- see issue #919. The streaming generators in `litellm_streaming.py` follow the same policy until the first token is yielded. Auth errors and other non-transient errors raise immediately without retry.
 
 - `_is_retryable_error()` classifies exceptions: rate limits, timeouts, and server errors (502/503/429) are retryable; auth errors are not
 - Backoff: `RETRY_BASE_DELAY_SECONDS * 2^attempt + jitter` (1s, 2s, 4s base with random 0-0.5s jitter)

--- a/test/pr-validation/fixtures/pr920/harness.py
+++ b/test/pr-validation/fixtures/pr920/harness.py
@@ -1,0 +1,224 @@
+"""End-to-end harness for PR #920 (issue #919): retry for LLM calls.
+
+Drives the REAL LiteLLMCaller retry paths -- real env reads, real
+asyncio.sleep, real streaming generators -- with only the litellm boundary
+mocked, the way a provider outage behaves from Atlas's side:
+
+- LLM_MAX_RETRIES=2 makes a rate-limited call attempt 3 times, with
+  increasing (exponential) backoff delays, and returns the provider answer.
+- With the variables unset the default retry count is 5 (6 calls).
+- LLM_RETRY_MAX_WAIT_SECONDS clamps the cumulative sleep and stops retries
+  early once the budget is spent.
+- An auth error never retries.
+- A streaming rate limit at establishment is retried and the tokens then
+  flow exactly once; a mid-stream failure after a token is surfaced without
+  retrying.
+"""
+
+import asyncio
+import os
+import sys
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import litellm
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from atlas.modules.llm import litellm_caller as caller_module  # noqa: E402
+from atlas.modules.llm import litellm_streaming as streaming_module  # noqa: E402
+from atlas.modules.llm.litellm_caller import LiteLLMCaller  # noqa: E402
+from atlas.modules.llm.models import LLMResponse  # noqa: E402
+
+FAILURES = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"  ok: {name}")
+    else:
+        print(f"  FAIL: {name} {detail}")
+        FAILURES.append(name)
+
+
+def rate_limit():
+    return litellm.RateLimitError(message="429", llm_provider="t", model="t")
+
+
+def response(content):
+    """Build a minimal non-streaming completion response."""
+    message = SimpleNamespace(content=content, tool_calls=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class _FakeStream:
+    """Async-iterable stand-in for litellm's streaming response."""
+
+    def __init__(self, contents, error=None):
+        self._contents = list(contents)
+        self._error = error
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._contents:
+            delta = SimpleNamespace(content=self._contents.pop(0))
+            return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+        if self._error is not None:
+            raise self._error
+        raise StopAsyncIteration
+
+    async def aclose(self):
+        self.closed = True
+
+
+def caller():
+    return LiteLLMCaller(llm_config=SimpleNamespace(models={}))
+
+
+async def case_nonstream_env_count():
+    """LLM_MAX_RETRIES=2 -> 3 total attempts, exponential delays, success."""
+    os.environ["LLM_MAX_RETRIES"] = "2"
+    os.environ["LLM_RETRY_MAX_WAIT_SECONDS"] = "60"
+    c = caller()
+    flaky = AsyncMock(side_effect=[
+        rate_limit(), rate_limit(), response("recovered"),
+    ])
+    with (
+        patch.object(caller_module, "acompletion", flaky),
+        patch.object(c, "_get_litellm_model_name", return_value="m"),
+        patch.object(c, "_get_model_kwargs", return_value={}),
+    ):
+        out = await c.call_plain("m", [{"role": "user", "content": "hi"}])
+    check("non-streaming retries and succeeds", out == "recovered")
+    check("env retry count honored (3 attempts)", flaky.call_count == 3, flaky.call_count)
+
+
+async def case_nonstream_default_count():
+    """With no env override, the default retry count is 5 (6 attempts).
+
+    Sleep is mocked here: the budget cap is exercised with real sleeps in
+    case_wait_budget_cap, and this case only needs the attempt count.
+    """
+    os.environ.pop("LLM_MAX_RETRIES", None)
+    os.environ["LLM_RETRY_MAX_WAIT_SECONDS"] = "600"
+    c = caller()
+    flaky = AsyncMock(side_effect=[rate_limit() for _ in range(10)])
+    with (
+        patch.object(caller_module, "acompletion", flaky),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        try:
+            await c._acompletion_with_retry(model="t", messages=[])
+        except litellm.RateLimitError:
+            pass
+    check("default retry count is 5 (6 attempts)", flaky.call_count == 6, flaky.call_count)
+
+
+async def case_wait_budget_cap():
+    """A 1.5s budget stops retries early and caps total sleep."""
+    os.environ["LLM_MAX_RETRIES"] = "5"
+    os.environ["LLM_RETRY_MAX_WAIT_SECONDS"] = "1.5"
+    c = caller()
+    flaky = AsyncMock(side_effect=[rate_limit() for _ in range(10)])
+    with patch.object(caller_module, "acompletion", flaky):
+        t0 = time.monotonic()
+        try:
+            await c._acompletion_with_retry(model="t", messages=[])
+        except litellm.RateLimitError:
+            pass
+    elapsed = time.monotonic() - t0
+    check("wait budget caps elapsed backoff", elapsed <= 2.2, f"{elapsed:.2f}s")
+    check("wait budget stops retries early", flaky.call_count < 6, flaky.call_count)
+
+
+async def case_auth_no_retry():
+    """Auth errors raise immediately."""
+    os.environ["LLM_MAX_RETRIES"] = "3"
+    c = caller()
+    flaky = AsyncMock(side_effect=litellm.AuthenticationError(
+        message="bad key", llm_provider="t", model="t"))
+    with patch.object(caller_module, "acompletion", flaky):
+        try:
+            await c._acompletion_with_retry(model="t", messages=[])
+        except litellm.AuthenticationError:
+            pass
+    check("auth error not retried", flaky.call_count == 1, flaky.call_count)
+
+
+async def case_stream_retry_before_token():
+    """Streaming retries a rate limit at establishment, tokens flow once."""
+    os.environ["LLM_MAX_RETRIES"] = "2"
+    os.environ["LLM_RETRY_MAX_WAIT_SECONDS"] = "60"
+    c = caller()
+    stream = _FakeStream(["Hello", " ", "world"])
+    flaky = AsyncMock(side_effect=[rate_limit(), rate_limit(), stream])
+    with (
+        patch.object(streaming_module, "acompletion", flaky),
+        patch.object(c, "_get_litellm_model_name", return_value="m"),
+        patch.object(c, "_get_model_kwargs", return_value={}),
+    ):
+        tokens = [t async for t in c.stream_plain("m", [{"role": "user", "content": "hi"}])]
+    check("streaming retries establishment failures", tokens == ["Hello", " ", "world"], tokens)
+    check("streaming retry count", flaky.call_count == 3, flaky.call_count)
+
+
+async def case_stream_no_retry_after_token():
+    """A mid-stream failure after the first token is surfaced, not retried."""
+    c = caller()
+    stream = _FakeStream(["partial"], error=rate_limit())
+    flaky = AsyncMock(return_value=stream)
+    with (
+        patch.object(streaming_module, "acompletion", flaky),
+        patch.object(c, "_get_litellm_model_name", return_value="m"),
+        patch.object(c, "_get_model_kwargs", return_value={}),
+    ):
+        got = []
+        try:
+            async for tok in c.stream_plain("m", [{"role": "user", "content": "hi"}]):
+                got.append(tok)
+        except Exception as exc:
+            check("mid-stream failure surfaces domain error", type(exc).__name__ == "RateLimitError", repr(exc))
+    check("partial token preserved", got == ["partial"], got)
+    check("no retry after first token", flaky.call_count == 1, flaky.call_count)
+
+
+async def case_stream_tools():
+    """stream_with_tools retries before any yield and yields the final LLMResponse."""
+    os.environ["LLM_MAX_RETRIES"] = "2"
+    os.environ["LLM_RETRY_MAX_WAIT_SECONDS"] = "60"
+    c = caller()
+    stream = _FakeStream(["tok"])
+    flaky = AsyncMock(side_effect=[rate_limit(), stream])
+    tools = [{"type": "function", "function": {"name": "test_tool"}}]
+    with (
+        patch.object(streaming_module, "acompletion", flaky),
+        patch.object(c, "_get_litellm_model_name", return_value="m"),
+        patch.object(c, "_get_model_kwargs", return_value={}),
+    ):
+        items = [i async for i in c.stream_with_tools("m", [{"role": "user", "content": "hi"}], tools)]
+    check("tools stream yields text then LLMResponse", items[0] == "tok" and isinstance(items[-1], LLMResponse))
+    check("tools stream retried once", flaky.call_count == 2, flaky.call_count)
+
+
+async def main():
+    await case_nonstream_env_count()
+    await case_nonstream_default_count()
+    await case_wait_budget_cap()
+    await case_auth_no_retry()
+    await case_stream_retry_before_token()
+    await case_stream_no_retry_after_token()
+    await case_stream_tools()
+    print()
+    if FAILURES:
+        print(f"HARNESS FAILED ({len(FAILURES)}): {FAILURES}")
+        return 1
+    print("HARNESS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/test/pr-validation/test_pr920_llm_retry.sh
+++ b/test/pr-validation/test_pr920_llm_retry.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Validation script for PR #920 (issue #919): retry for LLM calls.
+#
+# High-traffic LLM services reject calls with rate-limit/timeout/5xx errors.
+# The streaming path (the main chat flow) had NO retry, and the non-streaming
+# path was hardcoded to 3 retries with no total-wait ceiling. This PR adds:
+#   - LLM_MAX_RETRIES (env, default 5 retries after the first attempt)
+#   - LLM_RETRY_MAX_WAIT_SECONDS (env, default 300s = 5 minutes) capping the
+#     cumulative exponential backoff
+#   - streaming retry until the first token is yielded (never after, to avoid
+#     duplicating partial output)
+#
+# Test plan (exercised through the REAL LiteLLMCaller retry loops, real env
+# reads and real asyncio.sleep in the harness; only the litellm boundary is
+# mocked, since a provider 429 cannot be produced on demand):
+# - Env-configured retry count: LLM_MAX_RETRIES=2 -> 3 attempts, then the
+#   provider answer is returned.
+# - Default retry count with no env: 6 attempts.
+# - Wait budget: LLM_RETRY_MAX_WAIT_SECONDS=1.5 clamps the total sleep and
+#   stops retrying before the count is exhausted.
+# - Auth errors are never retried.
+# - Streaming: rate limit at establishment is retried, then tokens flow
+#   exactly once; a mid-stream failure after the first token surfaces the
+#   domain error without retrying; stream_with_tools behaves the same.
+# - Backend unit tests pass.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+print_header() {
+    echo ""
+    echo "=========================================="
+    echo "$1"
+    echo "=========================================="
+}
+
+print_result() {
+    if [ "$1" -eq 0 ]; then
+        echo -e "${GREEN}PASSED${NC}: $2"
+        PASSED=$((PASSED + 1))
+    else
+        echo -e "${RED}FAILED${NC}: $2"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+if [ -f "$PROJECT_ROOT/.venv/bin/activate" ]; then
+    # shellcheck disable=SC1091
+    source "$PROJECT_ROOT/.venv/bin/activate"
+fi
+
+export PYTHONPATH="$PROJECT_ROOT"
+
+print_header "PR #920: LLM retry with configurable count and 5-minute backoff cap"
+python "$SCRIPT_DIR/fixtures/pr920/harness.py"
+print_result $? "retry policy harness (count from env, wait cap, streaming)"
+
+print_header "Backend unit tests"
+"$PROJECT_ROOT/test/run_tests.sh" backend >/dev/null 2>&1
+print_result $? "test/run_tests.sh backend"
+
+echo ""
+echo "=========================================="
+echo "Results: $PASSED passed, $FAILED failed"
+echo "=========================================="
+[ "$FAILED" -eq 0 ] && [ "$PASSED" -eq 2 ]


### PR DESCRIPTION
## Summary

Closes #919.

High-traffic LLM services reject calls with rate-limit (429), timeout, and 5xx errors. The issue's log trace showed the raw error reaching the chat handler because **the streaming path -- the main chat flow -- had no retry at all**, and the non-streaming path retried only 3 times with no ceiling on total wait. This PR:

- **Adds a shared retry policy** (`atlas/modules/llm/retry_config.py`): `LLM_MAX_RETRIES` (env, default **5** retries after the first attempt) and `LLM_RETRY_MAX_WAIT_SECONDS` (env, default **300s = 5 minutes**) which caps the *cumulative* backoff -- the final sleep is shortened so the total never exceeds the budget, and once the budget is spent the underlying error surfaces.
- **Wires streaming retry into `stream_plain` / `stream_with_tools`**: transient failures (rate limit, timeout, 5xx) are retried with exponential backoff (1s base, doubling, up to 0.5s jitter) until the first token is yielded. After that, a failure surfaces instead of retrying -- restarting the stream would duplicate the partial answer the user already sees. Abandoned streams are closed before a retry so connections are not leaked.
- **Keeps the existing non-streaming retry** (`_acompletion_with_retry`) but makes its count env-configurable and adds the same cumulative wait cap.
- **Deterministic failures are never retried** on any path: 400s, auth errors, context-window overflows (unchanged classification).

With defaults, five retries wait about 31s total (1+2+4+8+16 plus jitter), well under the 5-minute cap; the cap matters when operators raise the retry count.

## Config

| Variable | Default | Meaning |
|---|---|---|
| `LLM_MAX_RETRIES` | 5 | Retries *after* the first attempt; 0 disables retries |
| `LLM_RETRY_MAX_WAIT_SECONDS` | 300 | Cap on cumulative sleep across attempts |

Documented in `.env.example` and `docs/admin/configuration.md`.

## Testing

- `atlas/tests/test_llm_retry.py`: updated call-count expectations for the new default and added 13 tests -- env resolution (defaults / overrides / invalid / negative), retry-count env override, zero-retry, cumulative-wait cap (clamped sleeps, early stop), zero-budget, and streaming retry behavior for `stream_plain` and `stream_with_tools` (retry before first token; no retry after; exhaustion; abandoned-stream close).
- `./test/run_tests.sh backend` passes. Local full `pytest atlas/tests/` shows no new failures vs `main` (164 pre-existing environment failures on both; 2946 -> 2959 passing with the 13 new tests).
- `ruff check` clean on all touched files.
- Sanity script with **real** `asyncio.sleep` verified: establishment retries succeed; wait budget clamps total to the configured cap; budget exhaustion surfaces promptly; mid-stream failure after a token does not retry.
- PR validation script `test/pr-validation/test_pr920_llm_retry.sh` (harness drives the real retry loops with real `asyncio.sleep`, 13 checks: env count, default count, wait cap, auth no-retry, streaming before/after first token, tools stream). `bash test/run_pr_validation.sh 920` passes.
