### PR TITLE
refactor(runs): collapse run-event tagging into one authority (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### PR #924 - 2026-09-11
+- The two run-event tagging implementations (`tag_run_event` on the transport callback and `stamp_with_current_run` on the shared publisher) now share one authority, `tag_event`, with the copy-vs-in-place choice made explicit; the publisher hot path still stamps in place and is covered by a test (closes #915).
+
 ### PR #920 - 2026-09-10
 - Transient LLM failures (rate limits, timeouts, 5xx) are now retried with exponential backoff on the streaming path (previously none) as well as the non-streaming path, with the retry count configurable via `LLM_MAX_RETRIES` (default 5) and a cumulative backoff cap via `LLM_RETRY_MAX_WAIT_SECONDS` (default 300s = 5 minutes); once a streaming response has yielded a token, failures surface instead of retrying (closes #919).
 

--- a/atlas/application/chat/runs/context.py
+++ b/atlas/application/chat/runs/context.py
@@ -48,17 +48,49 @@ def clear_current_run() -> None:
     _current_run.set(None)
 
 
+def tag_event(
+    data: Dict[str, Any],
+    run_id: str,
+    conversation_id: str,
+    *,
+    copy: bool = True,
+) -> Dict[str, Any]:
+    """Stamp an outbound event with the run that produced it (issue #884).
+
+    The single authority for the tagging rule; every caller goes through here
+    so the rule cannot drift between code paths (issue #915).
+
+    With several conversations executing at once, a bare event is ambiguous:
+    the client cannot tell whether a token, tool row, file, or completion
+    belongs to the conversation on screen or to one running in the background.
+    Every event a tracked run emits carries both ids so the client can route it
+    -- and, crucially, so it can *drop* events for a conversation it is not
+    displaying instead of splicing them into the visible transcript.
+
+    Existing ids are never overwritten: a producer deeper in the pipeline that
+    already knows its own conversation is more authoritative than the run
+    envelope.
+
+    ``copy`` picks between the two call sites' needs. The turn callback is
+    handed an event it does not own, so it copies. The publisher builds each
+    frame fresh per send and stamps in place, because copying every token event
+    would be wasteful for no benefit.
+    """
+    if not isinstance(data, dict):
+        return data
+    tagged = dict(data) if copy else data
+    tagged.setdefault("run_id", run_id)
+    tagged.setdefault("conversation_id", conversation_id)
+    return tagged
+
+
 def stamp_with_current_run(data: Dict[str, Any]) -> Dict[str, Any]:
     """Add run_id/conversation_id to an outgoing frame, if a run is executing.
 
-    Mutates and returns the frame: it is built fresh per send by the publisher,
-    and copying every token event would be wasteful for no benefit. Existing
-    values win -- a producer that knows its own conversation is more
-    authoritative than the ambient run.
+    Resolves the ambient run and delegates the stamping rule to
+    :func:`tag_event`, in place -- see its ``copy`` note for why.
     """
     context = _current_run.get()
-    if context is None or not isinstance(data, dict):
+    if context is None:
         return data
-    data.setdefault("run_id", context.run_id)
-    data.setdefault("conversation_id", context.conversation_id)
-    return data
+    return tag_event(data, context.run_id, context.conversation_id, copy=False)

--- a/atlas/application/chat/runs/context.py
+++ b/atlas/application/chat/runs/context.py
@@ -18,7 +18,7 @@ adapter stamps outgoing frames from it.
 from __future__ import annotations
 
 from contextvars import ContextVar
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional
 
 
 class RunContext(NamedTuple):

--- a/atlas/application/chat/runs/context.py
+++ b/atlas/application/chat/runs/context.py
@@ -49,12 +49,12 @@ def clear_current_run() -> None:
 
 
 def tag_event(
-    data: Dict[str, Any],
+    data: Any,
     run_id: str,
     conversation_id: str,
     *,
     copy: bool = True,
-) -> Dict[str, Any]:
+) -> Any:
     """Stamp an outbound event with the run that produced it (issue #884).
 
     The single authority for the tagging rule; every caller goes through here
@@ -71,6 +71,10 @@ def tag_event(
     already knows its own conversation is more authoritative than the run
     envelope.
 
+    Anything that is not a dict is returned untouched -- the publisher and the
+    turn callback both forward whatever a producer handed them, and a non-dict
+    frame has nowhere to put the ids.
+
     ``copy`` picks between the two call sites' needs. The turn callback is
     handed an event it does not own, so it copies. The publisher builds each
     frame fresh per send and stamps in place, because copying every token event
@@ -84,7 +88,7 @@ def tag_event(
     return tagged
 
 
-def stamp_with_current_run(data: Dict[str, Any]) -> Dict[str, Any]:
+def stamp_with_current_run(data: Any) -> Any:
     """Add run_id/conversation_id to an outgoing frame, if a run is executing.
 
     Resolves the ambient run and delegates the stamping rule to

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -47,7 +47,7 @@ from atlas.application.chat.runs import (
     RunStatus,
     get_run_registry,
 )
-from atlas.application.chat.runs.context import set_current_run
+from atlas.application.chat.runs.context import set_current_run, tag_event
 from atlas.application.chat.runs.eligibility import turn_is_eligible_for_background_run
 from atlas.application.chat.service import UNSET
 from atlas.core.auth import resolve_user_from_auth_header_async
@@ -165,23 +165,10 @@ _TOOL_SETTLED_EVENTS = frozenset(
 def tag_run_event(message: dict, run_id: str, conversation_id: str) -> dict:
     """Stamp an outbound event with the run that produced it (issue #884).
 
-    With several conversations executing at once, a bare event is ambiguous:
-    the client cannot tell whether a token, tool row, file, or completion
-    belongs to the conversation on screen or to one running in the background.
-    Every event a tracked run emits carries both ids so the client can route it
-    -- and, crucially, so it can *drop* events for a conversation it is not
-    displaying instead of splicing them into the visible transcript.
-
-    Existing ids are never overwritten: a producer deeper in the pipeline that
-    already knows its own conversation is more authoritative than the run
-    envelope.
+    Delegates to the single tagging authority (issue #915); copies because the
+    event belongs to the caller. See :func:`tag_event` for the rule itself.
     """
-    if not isinstance(message, dict):
-        return message
-    tagged = dict(message)
-    tagged.setdefault("run_id", run_id)
-    tagged.setdefault("conversation_id", conversation_id)
-    return tagged
+    return tag_event(message, run_id, conversation_id, copy=True)
 
 
 async def _release_finished_run(

--- a/atlas/main.py
+++ b/atlas/main.py
@@ -30,7 +30,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 from dotenv import load_dotenv
@@ -162,11 +162,12 @@ _TOOL_SETTLED_EVENTS = frozenset(
 )
 
 
-def tag_run_event(message: dict, run_id: str, conversation_id: str) -> dict:
+def tag_run_event(message: Any, run_id: str, conversation_id: str) -> Any:
     """Stamp an outbound event with the run that produced it (issue #884).
 
     Delegates to the single tagging authority (issue #915); copies because the
-    event belongs to the caller. See :func:`tag_event` for the rule itself.
+    event belongs to the caller. Inherits that authority's non-dict
+    passthrough, hence ``Any``. See :func:`tag_event` for the rule itself.
     """
     return tag_event(message, run_id, conversation_id, copy=True)
 

--- a/atlas/tests/test_parallel_run_transport.py
+++ b/atlas/tests/test_parallel_run_transport.py
@@ -228,23 +228,48 @@ def test_publisher_hot_path_stamps_in_place_without_copying():
 
 
 @pytest.mark.parametrize(
-    "event",
+    "event,expected",
     [
-        {"type": "token_stream", "token": "hi"},
-        # A producer that already named its own conversation, and one that
-        # named both ids: existing values must survive either entry point.
-        {"type": "canvas_content", "conversation_id": "conv-real"},
-        {"type": "chat_response", "run_id": "run-real", "conversation_id": "conv-real"},
+        # A bare event gets both ids.
+        (
+            {"type": "token_stream", "token": "hi"},
+            {
+                "type": "token_stream",
+                "token": "hi",
+                "run_id": "run-1",
+                "conversation_id": "conv-1",
+            },
+        ),
+        # A producer that already named its own conversation keeps it, and
+        # still picks up the run id.
+        (
+            {"type": "canvas_content", "conversation_id": "conv-real"},
+            {
+                "type": "canvas_content",
+                "conversation_id": "conv-real",
+                "run_id": "run-1",
+            },
+        ),
+        # Both ids pre-set: nothing is touched.
+        (
+            {"type": "chat_response", "run_id": "run-real", "conversation_id": "conv-real"},
+            {"type": "chat_response", "run_id": "run-real", "conversation_id": "conv-real"},
+        ),
         # Not a dict: nowhere to put the ids, so it passes straight through.
-        "not-a-dict",
-        None,
+        ("not-a-dict", "not-a-dict"),
+        (None, None),
     ],
 )
-def test_both_tagging_entry_points_share_one_rule(event):
+def test_both_tagging_entry_points_share_one_rule(event, expected):
     """One function implements the stamping rule; the other delegates.
 
+    The expected values are written out literally rather than derived from
+    ``tag_event``: an oracle computed by the very function under test would
+    move in lockstep with a regression inside it (``setdefault`` quietly
+    becoming assignment, say) and the two entry points would still agree.
+
     Parametrised across the shapes the rule actually distinguishes, so a
-    divergence between the two entry points cannot hide in an input the single
+    divergence between the entry points cannot hide in an input a single
     happy-path case never reaches.
     """
     from atlas.application.chat.runs.context import (
@@ -254,8 +279,7 @@ def test_both_tagging_entry_points_share_one_rule(event):
         tag_event,
     )
 
-    expected = tag_event(copy.deepcopy(event), "run-1", "conv-1")
-
+    assert tag_event(copy.deepcopy(event), "run-1", "conv-1") == expected
     assert tag_run_event(copy.deepcopy(event), "run-1", "conv-1") == expected
 
     set_current_run("run-1", "conv-1")

--- a/atlas/tests/test_parallel_run_transport.py
+++ b/atlas/tests/test_parallel_run_transport.py
@@ -204,6 +204,36 @@ def test_frames_are_stamped_with_the_running_run():
         clear_current_run()
 
 
+def test_publisher_hot_path_stamps_in_place_without_copying():
+    """The two tagging call sites were collapsed into one rule (issue #915),
+    but the publisher path must keep stamping in place: it builds each frame
+    fresh per send, and copying every token event would be pure waste."""
+    from atlas.application.chat.runs.context import (
+        clear_current_run,
+        set_current_run,
+        stamp_with_current_run,
+    )
+
+    set_current_run("run-1", "conv-1")
+    try:
+        frame = {"type": "token_stream", "token": "hi"}
+        stamped = stamp_with_current_run(frame)
+        assert stamped is frame
+        assert frame["run_id"] == "run-1"
+        assert frame["conversation_id"] == "conv-1"
+    finally:
+        clear_current_run()
+
+
+def test_both_tagging_entry_points_share_one_rule():
+    """One function implements the stamping rule; the other delegates."""
+    from atlas.application.chat.runs.context import tag_event
+
+    assert tag_run_event({"type": "x"}, "run-1", "conv-1") == tag_event(
+        {"type": "x"}, "run-1", "conv-1"
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_identity_does_not_leak_between_tasks():
     """Each run's task gets its own context, which is the whole reason a

--- a/atlas/tests/test_parallel_run_transport.py
+++ b/atlas/tests/test_parallel_run_transport.py
@@ -5,6 +5,8 @@ an event is stamped with the run that produced it, and how a stop / approval
 frame is resolved to exactly one run.
 """
 
+import copy
+
 import pytest
 from main import (
     _cancel_addressed_run,
@@ -225,13 +227,42 @@ def test_publisher_hot_path_stamps_in_place_without_copying():
         clear_current_run()
 
 
-def test_both_tagging_entry_points_share_one_rule():
-    """One function implements the stamping rule; the other delegates."""
-    from atlas.application.chat.runs.context import tag_event
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "token_stream", "token": "hi"},
+        # A producer that already named its own conversation, and one that
+        # named both ids: existing values must survive either entry point.
+        {"type": "canvas_content", "conversation_id": "conv-real"},
+        {"type": "chat_response", "run_id": "run-real", "conversation_id": "conv-real"},
+        # Not a dict: nowhere to put the ids, so it passes straight through.
+        "not-a-dict",
+        None,
+    ],
+)
+def test_both_tagging_entry_points_share_one_rule(event):
+    """One function implements the stamping rule; the other delegates.
 
-    assert tag_run_event({"type": "x"}, "run-1", "conv-1") == tag_event(
-        {"type": "x"}, "run-1", "conv-1"
+    Parametrised across the shapes the rule actually distinguishes, so a
+    divergence between the two entry points cannot hide in an input the single
+    happy-path case never reaches.
+    """
+    from atlas.application.chat.runs.context import (
+        clear_current_run,
+        set_current_run,
+        stamp_with_current_run,
+        tag_event,
     )
+
+    expected = tag_event(copy.deepcopy(event), "run-1", "conv-1")
+
+    assert tag_run_event(copy.deepcopy(event), "run-1", "conv-1") == expected
+
+    set_current_run("run-1", "conv-1")
+    try:
+        assert stamp_with_current_run(copy.deepcopy(event)) == expected
+    finally:
+        clear_current_run()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #915.

## Problem

Two functions stamped `run_id`/`conversation_id` onto outbound frames, each with its own copy of the "existing ids win" rule:

- `tag_run_event` (`atlas/main.py`) — copies, ids passed explicitly, used by the turn callback.
- `stamp_with_current_run` (`atlas/application/chat/runs/context.py`) — mutates in place, ids read from the `_current_run` contextvar, used by the shared `WebSocketEventPublisher`.

The rule being written twice is the risk: a change to one (overwriting a stale `conversation_id`, normalising a field) does not reach the other, and the two are reached by different paths — so a drift surfaces as events routed correctly from one path and not the other. That failure mode is "messages in the wrong chat", the exact bug the run ids exist to prevent.

The copy/mutate split is load-bearing, though: the publisher builds each frame fresh per send, so copying every token event would be pure waste. "Make both copy" is not the fix.

## Change

`tag_event(data, run_id, conversation_id, *, copy=True)` in `runs/context.py` is now the single authority for the stamping rule. The copy/in-place choice is an explicit argument rather than an implicit difference between two functions.

- `tag_run_event` delegates with `copy=True` (it is handed an event it does not own).
- `stamp_with_current_run` resolves the contextvar and delegates with `copy=False` (hot path, unchanged allocation behaviour).

No behaviour change on either path.

## Tests

- The existing tagging tests in `atlas/tests/test_parallel_run_transport.py` pass unchanged (existing-ids-win, non-dict passthrough, no-mutation-of-the-original).
- Added `test_publisher_hot_path_stamps_in_place_without_copying` — asserts `stamp_with_current_run` returns the *same object*, so the reason for the split cannot be quietly lost in a future cleanup.
- Added `test_both_tagging_entry_points_share_one_rule`.

Full backend suite: 3251 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVmeURf3k3pEUQXiqfrjkM